### PR TITLE
feat: add ClawSweeper-reviewed automerge loop

### DIFF
--- a/.github/workflows/comment-router.yml
+++ b/.github/workflows/comment-router.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Route Clownfish comments
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token || secrets.CLOWNFISH_GH_TOKEN || github.token }}
+          CLOWNFISH_ALLOW_AUTOMERGE: ${{ vars.CLOWNFISH_ALLOW_AUTOMERGE || '0' }}
+          CLOWNFISH_ALLOW_MERGE: ${{ vars.CLOWNFISH_ALLOW_MERGE || '0' }}
         run: |
           set -euo pipefail
           target_repo="${{ github.event_name == 'workflow_dispatch' && inputs.target_repo || vars.CLOWNFISH_TARGET_REPO || 'openclaw/openclaw' }}"

--- a/README.md
+++ b/README.md
@@ -226,9 +226,16 @@ For the ClawSweeper feedback loop that updates existing generated PRs, see
 
 That loop is marker-driven. ClawSweeper comments use hidden
 `clawsweeper-verdict:*` markers, and only actionable PR feedback includes
-`clawsweeper-action:fix-required`. Clownfish ignores pass/human-only verdicts,
-skips stale head SHAs, and caps automatic repairs at five per PR and one per PR
-head SHA.
+`clawsweeper-action:fix-required`. Clownfish skips stale head SHAs and caps
+automatic repairs at five per PR and one per PR head SHA.
+
+Maintainers can opt an existing Clownfish PR into the bounded merge loop with
+`/clownfish automerge`. That adds `clownfish:automerge`, dispatches
+ClawSweeper for the current head, lets Clownfish repair trusted
+`needs-changes` findings for up to five rounds, and merges only after a trusted
+pass verdict for the exact current head plus green checks, clean mergeability,
+and explicit `CLOWNFISH_ALLOW_MERGE=1` and `CLOWNFISH_ALLOW_AUTOMERGE=1`
+gates.
 
 ClawSweeper commit findings have a separate intake lane. A
 `clawsweeper_commit_finding` dispatch fetches the latest markdown commit report,
@@ -421,7 +428,7 @@ The workflow needs:
 - a read-only GitHub token for worker inspection
 - a separate write-scoped GitHub token for the deterministic applicator
 - execution gates that default closed: set `CLOWNFISH_ALLOW_EXECUTE=1` and `CLOWNFISH_ALLOW_FIX_PR=1` only for an intentional execution window; otherwise execute/autonomous dispatches render plan-only output and skip mutation steps
-- merge is separately gated by `CLOWNFISH_ALLOW_MERGE`; it defaults to `0`, and merge-ready PRs are labeled `clownfish:human-review` and `clownfish:merge-ready` for a maintainer to merge manually
+- merge is separately gated by `CLOWNFISH_ALLOW_MERGE`; automerge additionally requires `CLOWNFISH_ALLOW_AUTOMERGE`; both default to `0`, and merge-ready PRs are labeled `clownfish:human-review` and `clownfish:merge-ready` for a maintainer to merge manually
 - optional `CLOWNFISH_CODEX_CLI_VERSION` variable to pin and refresh the cached Codex CLI
 - optional `CLOWNFISH_MODEL` override for dispatch scripts; default Codex model is `gpt-5.5`
 - optional `CLOWNFISH_MAX_LIVE_WORKERS` variable for dispatch/requeue/self-heal worker fan-out; default is `50`

--- a/docs/INTERNAL_FEATURES.md
+++ b/docs/INTERNAL_FEATURES.md
@@ -354,6 +354,8 @@ Behavior:
 - `fix ci`: dispatch the existing Clownfish PR's job for repair.
 - `address review`: dispatch the existing Clownfish PR's job for repair.
 - `rebase`: dispatch the existing Clownfish PR's job for repair.
+- `automerge`: label an existing Clownfish PR with `clownfish:automerge`
+  and dispatch a ClawSweeper review for the current head.
 - `stop`: label the item for human review.
 
 Repair commands currently apply only to existing Clownfish PRs. The router
@@ -368,6 +370,13 @@ default caps are five automatic repair iterations per PR and one dispatch per
 PR head SHA. The per-PR cap is total across head SHA changes, so repeated
 findings on the same commit do not stampede the branch and a single PR cannot
 loop forever.
+
+For PRs labeled `clownfish:automerge`, trusted ClawSweeper `pass`, `approved`,
+or `no-changes` verdict markers become `clawsweeper_auto_merge`. The router
+merges only when the marker SHA matches the current PR head, checks are green,
+GitHub mergeability is clean, no human-review label is present, and both
+`CLOWNFISH_ALLOW_MERGE=1` and `CLOWNFISH_ALLOW_AUTOMERGE=1` are set. Otherwise
+it leaves the PR open and labels it `clownfish:merge-ready` when appropriate.
 
 The scheduled workflow is dry by default. Set
 `CLOWNFISH_COMMENT_ROUTER_EXECUTE=1` to let scheduled runs post replies and
@@ -431,6 +440,9 @@ Important gates:
   Workflows treat any value except literal `1` as closed.
 - `CLOWNFISH_ALLOW_MERGE`: allows Clownfish to merge. Keep this `0` unless a
   maintainer explicitly opens it.
+- `CLOWNFISH_ALLOW_AUTOMERGE`: allows the comment router to merge a
+  `clownfish:automerge` PR after ClawSweeper passes the exact current head.
+  Keep this `0` unless a maintainer explicitly opens an automerge window.
 - `CLOWNFISH_COMMENT_ROUTER_EXECUTE`: lets scheduled comment routing post
   replies and dispatch workers.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -204,6 +204,16 @@ one auto-repair per PR head SHA by default, controlled by
 head SHA changes, so the automatic loop stops after five ClawSweeper-triggered
 repair passes.
 
+Maintainers can start the bounded review/fix/merge loop on an existing
+Clownfish PR with `/clownfish automerge`. The router adds
+`clownfish:automerge`, dispatches ClawSweeper for the current head, and then
+reacts to trusted ClawSweeper markers. `needs-changes` repairs the same branch;
+`pass`, `approved`, or `no-changes` may merge only when the marker SHA matches
+the current head, checks and mergeability are clean, no human-review label is
+present, and both `CLOWNFISH_ALLOW_MERGE=1` and
+`CLOWNFISH_ALLOW_AUTOMERGE=1` are set. `/clownfish stop` or a
+`needs-human` verdict adds `clownfish:human-review` and pauses the loop.
+
 The scheduled workflow is dry by default. Set
 `CLOWNFISH_COMMENT_ROUTER_EXECUTE=1` in repo variables to let scheduled runs
 post replies and dispatch workers. Manual workflow dispatch can also pass
@@ -218,7 +228,7 @@ Minimum useful permissions depend on action tier:
 
 - `CLOWNFISH_READ_GH_TOKEN`: metadata, issues read, pull requests read, contents read; do not use a broad PAT here
 - `CLOWNFISH_GH_TOKEN`: issues write, pull requests write
-- merge: contents write and pull requests write
+- merge/automerge: contents write, pull requests write, issues write
 - fix PRs: contents write, pull requests write, issues write
 
 Do not put tokens in job files. Codex receives no GitHub token; the read token is scoped to preflight, and the write token is scoped to the deterministic apply step.

--- a/docs/auto-update-prs.md
+++ b/docs/auto-update-prs.md
@@ -30,8 +30,8 @@ Maintainer commands:
 
 - author association must be `OWNER`, `MEMBER`, or `COLLABORATOR` by default;
 - supported commands are `/clownfish fix ci`, `/clownfish address review`,
-  `/clownfish rebase`, `/clownfish status`, `/clownfish explain`, and
-  `/clownfish stop`;
+  `/clownfish rebase`, `/clownfish automerge`, `/clownfish status`,
+  `/clownfish explain`, and `/clownfish stop`;
 - commands from contributors are ignored without a reply.
 
 Trusted automation:
@@ -69,6 +69,31 @@ The branch prefix is the durable identity because it maps directly back to the
 cluster id and job path. The label and author checks are compatibility markers
 for already-open PRs and dashboard tools.
 
+## Automerge Opt-In
+
+Maintainers can opt an existing Clownfish PR into the bounded merge loop with:
+
+```text
+/clownfish automerge
+```
+
+The command adds `clownfish:automerge`, asks ClawSweeper to review the current
+PR head, and leaves an idempotent comment. It currently applies only to
+existing Clownfish PRs because the repair loop must map the PR branch back to
+one cluster job. `/clownfish stop` pauses the loop by adding
+`clownfish:human-review`.
+
+Automerge has two explicit gates:
+
+```bash
+CLOWNFISH_ALLOW_MERGE=1
+CLOWNFISH_ALLOW_AUTOMERGE=1
+```
+
+If ClawSweeper passes the exact current head while either gate is closed,
+Clownfish labels the PR `clownfish:merge-ready` and comments instead of
+merging.
+
 ## ClawSweeper Trigger
 
 Preferred ClawSweeper comments should include hidden verdict and action
@@ -101,8 +126,11 @@ Accepted repair verdicts:
 - `fix-required`
 - `repair-required`
 
-Non-repair verdicts such as `pass`, `approved`, `no-changes`, and
-`needs-human` never dispatch Clownfish.
+`pass`, `approved`, and `no-changes` verdicts never repair. On a PR opted into
+`clownfish:automerge`, a pass verdict for the exact current head can merge only
+after required checks, mergeability, review state, and both merge gates are
+green. `needs-human` and `human-review` pause automerge by adding
+`clownfish:human-review`.
 
 The router also has a conservative fallback for current ClawSweeper review
 comments. It only applies to trusted bot authors and looks for phrases like
@@ -154,6 +182,15 @@ The router does not dispatch when:
 - the same PR already reached the total auto-repair cap;
 - the same PR head SHA already reached the per-head auto-repair cap;
 - the ClawSweeper marker names a stale PR head SHA.
+
+Automerge also refuses to merge when:
+
+- `clownfish:automerge` is missing;
+- `clownfish:human-review` is present;
+- the pass marker does not name the reviewed head SHA;
+- the PR is draft, not based on `main`, not mergeable, or has non-green checks;
+- GitHub reports requested changes or required review;
+- `CLOWNFISH_ALLOW_MERGE` or `CLOWNFISH_ALLOW_AUTOMERGE` is not `1`.
 
 For trusted automation comments, these blocked cases are silent skips. That
 keeps Clownfish from replying to every ordinary contributor PR that

--- a/scripts/comment-router-core.mjs
+++ b/scripts/comment-router-core.mjs
@@ -1,4 +1,5 @@
 export const REPAIR_INTENTS = new Set(["fix_ci", "address_review", "rebase", "clawsweeper_auto_repair"]);
+export const MERGE_INTENTS = new Set(["clawsweeper_auto_merge"]);
 
 export function parseCommand(body) {
   for (const line of String(body ?? "").split(/\r?\n/)) {
@@ -17,8 +18,19 @@ export function parseTrustedAutomation(comment, { trustedAuthors = new Set() } =
   const body = String(comment?.body ?? "");
   const verdict = clawsweeperMarker(body, "verdict");
   const actionMarker = clawsweeperMarker(body, "action");
-  if (verdict && ["pass", "approved", "no-changes", "needs-human"].includes(verdict.action)) {
-    return null;
+  if (verdict && ["pass", "approved", "no-changes"].includes(verdict.action)) {
+    return trustedMerge({
+      author,
+      reason: `structured ClawSweeper verdict: ${verdict.action}${markerReasonSuffix(verdict.attrs)}`,
+      marker: verdict,
+    });
+  }
+  if (verdict && ["needs-human", "human-review"].includes(verdict.action)) {
+    return trustedHumanReview({
+      author,
+      reason: `structured ClawSweeper verdict: ${verdict.action}${markerReasonSuffix(verdict.attrs)}`,
+      marker: verdict,
+    });
   }
   if (actionMarker && ["fix-required", "repair-required", "address-review", "fix-ci"].includes(actionMarker.action)) {
     return trustedRepair({
@@ -65,6 +77,20 @@ export function renderResponse(command, dispatched) {
       "I added `clownfish:human-review` when permissions allowed it. Future automation should treat this as a maintainer handoff signal, so this stays out of the repair lane until someone asks again.",
     ].join("\n");
   }
+  if (command.intent === "automerge") {
+    return [
+      marker,
+      dispatched?.clawsweeper
+        ? "Clownfish automerge is enabled for this PR."
+        : "Clownfish could not enable automerge for this PR.",
+      "",
+      dispatched?.clawsweeper
+        ? `I added \`clownfish:automerge\` and asked ClawSweeper to review this head. If ClawSweeper requests changes, I will repair the branch and ask for another review, up to the configured round limit.`
+        : `Reason: ${command.reason ?? "automerge requires an existing Clownfish PR"}.`,
+      "",
+      "A maintainer can pause this with `/clownfish stop`.",
+    ].join("\n");
+  }
   if (!dispatched) {
     return [
       marker,
@@ -87,6 +113,34 @@ export function renderResponse(command, dispatched) {
       `Model: \`${dispatched.model}\``,
       "",
       "I will update this Clownfish PR branch if the repair worker finds a safe, narrow fix.",
+    ].join("\n");
+  }
+  if (command.intent === "clawsweeper_auto_merge") {
+    return [
+      marker,
+      dispatched?.merge?.status === "executed"
+        ? "Thanks, ClawSweeper. Clownfish merged this PR after the passing review."
+        : "Thanks, ClawSweeper. Clownfish saw the passing review, but did not merge yet.",
+      "",
+      `Source: \`${command.trusted_bot_author ?? command.author ?? "trusted automation"}\``,
+      `Feedback: ${command.repair_reason ?? "ClawSweeper reported a passing review."}`,
+      ...(dispatched?.merge?.reason ? [`Merge status: ${dispatched.merge.reason}`] : []),
+      ...(dispatched?.merge?.merged_at ? [`Merged at: ${dispatched.merge.merged_at}`] : []),
+      "",
+      dispatched?.merge?.status === "executed"
+        ? "The automerge loop is complete."
+        : "I left the PR open for the remaining gate instead of bypassing it.",
+    ].join("\n");
+  }
+  if (command.intent === "clawsweeper_needs_human") {
+    return [
+      marker,
+      "Clownfish is pausing automerge for human review.",
+      "",
+      `Source: \`${command.trusted_bot_author ?? command.author ?? "trusted automation"}\``,
+      `Reason: ${command.repair_reason ?? "ClawSweeper requested human review."}`,
+      "",
+      "I added `clownfish:human-review` when permissions allowed it.",
     ].join("\n");
   }
   return [
@@ -114,6 +168,9 @@ function normalizeIntent(command) {
   if (["fix ci", "fix-ci", "ci", "repair ci", "repair checks", "fix checks"].includes(command)) return "fix_ci";
   if (["address review", "address-review", "fix review", "review"].includes(command)) return "address_review";
   if (["rebase", "update branch", "sync"].includes(command)) return "rebase";
+  if (["automerge", "auto merge", "merge when clean", "merge when ready", "automerge on"].includes(command)) {
+    return "automerge";
+  }
   if (["stop", "pause", "human review", "handoff"].includes(command)) return "stop";
   return "help";
 }
@@ -123,6 +180,34 @@ function trustedRepair({ author, reason, marker = null }) {
     trigger: "trusted_bot",
     command: "clawsweeper auto repair",
     intent: "clawsweeper_auto_repair",
+    trusted_bot: true,
+    trusted_bot_author: author,
+    automation_source: "clawsweeper",
+    repair_reason: reason,
+    expected_head_sha: marker?.attrs?.sha ?? null,
+    finding_id: marker?.attrs?.finding ?? null,
+  };
+}
+
+function trustedMerge({ author, reason, marker = null }) {
+  return {
+    trigger: "trusted_bot",
+    command: "clawsweeper auto merge",
+    intent: "clawsweeper_auto_merge",
+    trusted_bot: true,
+    trusted_bot_author: author,
+    automation_source: "clawsweeper",
+    repair_reason: reason,
+    expected_head_sha: marker?.attrs?.sha ?? null,
+    finding_id: marker?.attrs?.finding ?? null,
+  };
+}
+
+function trustedHumanReview({ author, reason, marker = null }) {
+  return {
+    trigger: "trusted_bot",
+    command: "clawsweeper needs human",
+    intent: "clawsweeper_needs_human",
     trusted_bot: true,
     trusted_bot_author: author,
     automation_source: "clawsweeper",

--- a/scripts/comment-router-core.mjs
+++ b/scripts/comment-router-core.mjs
@@ -1,6 +1,20 @@
 export const REPAIR_INTENTS = new Set(["fix_ci", "address_review", "rebase", "clawsweeper_auto_repair"]);
 export const MERGE_INTENTS = new Set(["clawsweeper_auto_merge"]);
 
+export function automergeGateBlockReason(env = process.env) {
+  if (env.CLOWNFISH_ALLOW_MERGE !== "1") return "merge requires CLOWNFISH_ALLOW_MERGE=1";
+  if (env.CLOWNFISH_ALLOW_AUTOMERGE !== "1") return "automerge requires CLOWNFISH_ALLOW_AUTOMERGE=1";
+  return "";
+}
+
+export function buildAutomergeMergeArgs({ issueNumber, repo, expectedHeadSha }) {
+  const args = ["pr", "merge", String(issueNumber), "--repo", repo, "--squash"];
+  if (expectedHeadSha && expectedHeadSha !== "unknown") {
+    args.push("--match-head-commit", expectedHeadSha);
+  }
+  return args;
+}
+
 export function parseCommand(body) {
   for (const line of String(body ?? "").split(/\r?\n/)) {
     const slash = line.match(/^\s*\/clownfish(?:\s+(.+))?\s*$/i);

--- a/scripts/comment-router.mjs
+++ b/scripts/comment-router.mjs
@@ -12,7 +12,7 @@ import {
   validateJob,
   waitForLiveWorkerCapacity,
 } from "./lib.mjs";
-import { parseCommand, parseTrustedAutomation, renderResponse, REPAIR_INTENTS } from "./comment-router-core.mjs";
+import { MERGE_INTENTS, REPAIR_INTENTS, parseCommand, parseTrustedAutomation, renderResponse } from "./comment-router-core.mjs";
 import {
   appendLedger,
   assertRepo,
@@ -30,6 +30,9 @@ import {
 const DEFAULT_TARGET_REPO = "openclaw/openclaw";
 const DEFAULT_HEAD_PREFIX = "clownfish/";
 const DEFAULT_LABEL = "clownfish";
+const AUTOMERGE_LABEL = "clownfish:automerge";
+const HUMAN_REVIEW_LABEL = "clownfish:human-review";
+const MERGE_READY_LABEL = "clownfish:merge-ready";
 const DEFAULT_ALLOWED_ASSOCIATIONS = ["OWNER", "MEMBER", "COLLABORATOR"];
 const DEFAULT_TRUSTED_BOTS = ["clawsweeper[bot]", "openclaw-clawsweeper[bot]"];
 const DEFAULT_CLOWNFISH_AUTHORS = ["openclaw-clownfish", "openclaw-clownfish[bot]"];
@@ -38,6 +41,8 @@ const args = parseArgs(process.argv.slice(2));
 const targetRepo = String(args.repo ?? process.env.CLOWNFISH_TARGET_REPO ?? DEFAULT_TARGET_REPO);
 const clownfishRepo = String(args["clownfish-repo"] ?? process.env.CLOWNFISH_REPO ?? currentProjectRepo());
 const workflow = String(args.workflow ?? process.env.CLOWNFISH_COMMENT_WORKFLOW ?? "cluster-worker.yml");
+const clawsweeperRepo = String(args["clawsweeper-repo"] ?? process.env.CLOWNFISH_CLAWSWEEPER_REPO ?? "openclaw/clawsweeper");
+const clawsweeperWorkflow = String(args["clawsweeper-workflow"] ?? process.env.CLOWNFISH_CLAWSWEEPER_WORKFLOW ?? "sweep.yml");
 const runner = String(args.runner ?? process.env.CLOWNFISH_WORKER_RUNNER ?? "blacksmith-4vcpu-ubuntu-2404");
 const executionRunner = String(
   args["execution-runner"] ?? args.execution_runner ?? process.env.CLOWNFISH_EXECUTION_RUNNER ?? "blacksmith-16vcpu-ubuntu-2404",
@@ -76,6 +81,7 @@ const clownfishAuthors = commaSet(
 
 assertRepo(targetRepo, "repo");
 assertRepo(clownfishRepo, "clownfish-repo");
+assertRepo(clawsweeperRepo, "clawsweeper-repo");
 
 const ledger = readLedger(ledgerPath());
 const processedCommentIds = new Set((ledger.commands ?? []).map((entry) => String(entry.comment_id)));
@@ -118,6 +124,7 @@ const report = {
   generated_at: new Date().toISOString(),
   repo: targetRepo,
   clownfish_repo: clownfishRepo,
+  clawsweeper_repo: clawsweeperRepo,
   since,
   execute,
   max_comments: maxComments,
@@ -175,17 +182,42 @@ function classifyCommand(command) {
   if (["status", "explain", "help"].includes(command.intent)) {
     return { ...next, status: "ready", actions: [{ action: "comment", status: execute ? "pending" : "planned" }] };
   }
+  if (command.intent === "automerge") {
+    if (String(issue.state ?? "").toLowerCase() !== "open") {
+      return automergeBlocked(next, "automerge requires an open PR");
+    }
+    if (!pull) {
+      return automergeBlocked(next, "automerge requires a pull request");
+    }
+    if (!target.is_clownfish_pr) {
+      return automergeBlocked(next, "automerge currently requires an existing Clownfish PR");
+    }
+    if (!target.job_path) {
+      return automergeBlocked(next, "could not find the Clownfish job for this PR branch");
+    }
+    return {
+      ...next,
+      status: "ready",
+      actions: [
+        { action: "label", label: AUTOMERGE_LABEL, status: execute ? "pending" : "planned" },
+        { action: "dispatch_clawsweeper", workflow: clawsweeperWorkflow, status: execute ? "pending" : "planned" },
+        { action: "comment", status: execute ? "pending" : "planned" },
+      ],
+    };
+  }
   if (command.intent === "stop") {
     return {
       ...next,
       status: "ready",
       actions: [
-        { action: "label", label: "clownfish:human-review", status: execute ? "pending" : "planned" },
+        { action: "label", label: HUMAN_REVIEW_LABEL, status: execute ? "pending" : "planned" },
         { action: "comment", status: execute ? "pending" : "planned" },
       ],
     };
   }
   if (!REPAIR_INTENTS.has(command.intent)) {
+    if (MERGE_INTENTS.has(command.intent)) return classifyAutomergePass(next, issue, pull);
+    if (command.intent === "clawsweeper_needs_human") return classifyNeedsHuman(next, issue, pull);
     return { ...next, status: "ready", actions: [{ action: "comment", status: execute ? "pending" : "planned" }] };
   }
   if (String(issue.state ?? "").toLowerCase() !== "open") {
@@ -220,6 +252,56 @@ function classifyCommand(command) {
       { action: "dispatch_repair", workflow, job_path: target.job_path, mode: target.mode, status: execute ? "pending" : "planned" },
       { action: "comment", status: execute ? "pending" : "planned" },
     ],
+  };
+}
+
+function classifyAutomergePass(command, issue, pull) {
+  if (String(issue.state ?? "").toLowerCase() !== "open") return { ...command, status: "skipped", reason: "PR is not open" };
+  if (!pull) return { ...command, status: "skipped", reason: "ClawSweeper pass marker is not on a PR" };
+  if (!hasLabel(command.target, AUTOMERGE_LABEL)) return { ...command, status: "skipped", reason: "PR is not opted into Clownfish automerge" };
+  if (hasLabel(command.target, HUMAN_REVIEW_LABEL)) return { ...command, status: "skipped", reason: "PR is paused for human review" };
+  if (!command.target?.is_clownfish_pr) return { ...command, status: "skipped", reason: "automerge currently requires a Clownfish PR" };
+  if (!command.expected_head_sha || command.expected_head_sha === "unknown") {
+    return { ...command, status: "skipped", reason: "ClawSweeper pass marker must include the reviewed PR head SHA" };
+  }
+  if (
+    command.expected_head_sha &&
+    command.expected_head_sha !== "unknown" &&
+    command.target?.head_sha &&
+    command.expected_head_sha !== command.target.head_sha
+  ) {
+    return { ...command, status: "skipped", reason: "ClawSweeper pass marker targets a stale PR head SHA" };
+  }
+  return {
+    ...command,
+    status: "ready",
+    actions: [
+      { action: "merge", status: execute ? "pending" : "planned" },
+      { action: "comment", status: execute ? "pending" : "planned" },
+    ],
+  };
+}
+
+function classifyNeedsHuman(command, issue, pull) {
+  if (String(issue.state ?? "").toLowerCase() !== "open") return { ...command, status: "skipped", reason: "target is not open" };
+  if (!pull) return { ...command, status: "skipped", reason: "needs-human marker is not on a PR" };
+  if (!hasLabel(command.target, AUTOMERGE_LABEL)) return { ...command, status: "skipped", reason: "PR is not opted into Clownfish automerge" };
+  return {
+    ...command,
+    status: "ready",
+    actions: [
+      { action: "label", label: HUMAN_REVIEW_LABEL, status: execute ? "pending" : "planned" },
+      { action: "comment", status: execute ? "pending" : "planned" },
+    ],
+  };
+}
+
+function automergeBlocked(command, reason) {
+  return {
+    ...command,
+    status: "ready",
+    actions: [{ action: "comment", status: execute ? "pending" : "planned" }],
+    reason,
   };
 }
 
@@ -282,11 +364,42 @@ function executeCommand(command) {
       action.action === "dispatch_repair" ? { ...action, status: "executed", dispatched_at: new Date().toISOString() } : action,
     );
   }
+  if (command.intent === "automerge" && command.issue_number) {
+    ensureAutomergeLabel(command.repo);
+    ghBestEffort(["issue", "edit", String(command.issue_number), "--repo", command.repo, "--add-label", AUTOMERGE_LABEL]);
+    const clawsweeper = dispatchClawSweeperReview(command);
+    dispatched = { ...(dispatched ?? {}), clawsweeper };
+    command.actions = command.actions.map((action) => {
+      if (action.action === "label") return { ...action, status: "executed", label: AUTOMERGE_LABEL };
+      if (action.action === "dispatch_clawsweeper") {
+        return { ...action, status: "executed", dispatched_at: new Date().toISOString(), ...clawsweeper };
+      }
+      return action;
+    });
+  }
+  if (MERGE_INTENTS.has(command.intent) && command.issue_number) {
+    const merge = executeAutomerge(command);
+    dispatched = { ...(dispatched ?? {}), merge };
+    command.actions = command.actions.map((action) =>
+      action.action === "merge" ? { ...action, ...merge, completed_at: new Date().toISOString() } : action,
+    );
+    if (merge.status === "waiting") {
+      command.status = "waiting";
+      return;
+    }
+  }
+  if (command.intent === "clawsweeper_needs_human" && command.issue_number) {
+    ensureHumanReviewLabel(command.repo);
+    ghBestEffort(["issue", "edit", String(command.issue_number), "--repo", command.repo, "--add-label", HUMAN_REVIEW_LABEL]);
+    command.actions = command.actions.map((action) =>
+      action.action === "label" ? { ...action, status: "executed", label: HUMAN_REVIEW_LABEL } : action,
+    );
+  }
   if (command.intent === "stop" && command.issue_number) {
     ensureHumanReviewLabel(command.repo);
-    ghBestEffort(["issue", "edit", String(command.issue_number), "--repo", command.repo, "--add-label", "clownfish:human-review"]);
+    ghBestEffort(["issue", "edit", String(command.issue_number), "--repo", command.repo, "--add-label", HUMAN_REVIEW_LABEL]);
     command.actions = command.actions.map((action) =>
-      action.action === "label" ? { ...action, status: "executed", label: "clownfish:human-review" } : action,
+      action.action === "label" ? { ...action, status: "executed", label: HUMAN_REVIEW_LABEL } : action,
     );
   }
 
@@ -295,6 +408,32 @@ function executeCommand(command) {
     action.action === "comment" ? { ...action, status: "executed", commented_at: new Date().toISOString() } : action,
   );
   command.status = "executed";
+}
+
+function dispatchClawSweeperReview(command) {
+  const result = spawnSync(
+    "gh",
+    [
+      "workflow",
+      "run",
+      clawsweeperWorkflow,
+      "--repo",
+      clawsweeperRepo,
+      "-f",
+      `target_repo=${command.repo}`,
+      "-f",
+      `item_number=${command.issue_number}`,
+    ],
+    { cwd: repoRoot(), encoding: "utf8", env: ghEnv(), stdio: "pipe" },
+  );
+  if (result.status !== 0) {
+    throw new Error(`failed to dispatch ClawSweeper review for #${command.issue_number}: ${result.stderr || result.stdout}`);
+  }
+  return {
+    workflow: clawsweeperWorkflow,
+    repo: clawsweeperRepo,
+    item_number: command.issue_number,
+  };
 }
 
 function dispatchRepair(command) {
@@ -331,6 +470,106 @@ function dispatchRepair(command) {
     execution_runner: executionRunner,
     model,
   };
+}
+
+function executeAutomerge(command) {
+  const view = fetchPullRequestView(command.issue_number);
+  const labels = (view.labels ?? []).map((item) => item.name ?? item);
+  const latestTarget = { ...command.target, ...view, labels, head_sha: view.headRefOid ?? command.target?.head_sha ?? null };
+  const block = validateAutomergeReadiness({ command, view, target: latestTarget });
+  if (block) {
+    if (isTransientAutomergeBlock(block, view)) {
+      return { action: "merge", status: "waiting", reason: block, merge_method: "squash" };
+    }
+    if (process.env.CLOWNFISH_ALLOW_MERGE !== "1" || process.env.CLOWNFISH_ALLOW_AUTOMERGE !== "1") {
+      ensureMergeReadyLabel(command.repo);
+      ghBestEffort(["issue", "edit", String(command.issue_number), "--repo", command.repo, "--add-label", MERGE_READY_LABEL]);
+    }
+    return { action: "merge", status: "blocked", reason: block, merge_method: "squash" };
+  }
+  if (process.env.CLOWNFISH_ALLOW_MERGE !== "1") {
+    ensureMergeReadyLabel(command.repo);
+    ghBestEffort(["issue", "edit", String(command.issue_number), "--repo", command.repo, "--add-label", MERGE_READY_LABEL]);
+    return { action: "merge", status: "blocked", reason: "merge requires CLOWNFISH_ALLOW_MERGE=1", merge_method: "squash" };
+  }
+  if (process.env.CLOWNFISH_ALLOW_AUTOMERGE !== "1") {
+    ensureMergeReadyLabel(command.repo);
+    ghBestEffort(["issue", "edit", String(command.issue_number), "--repo", command.repo, "--add-label", MERGE_READY_LABEL]);
+    return { action: "merge", status: "blocked", reason: "automerge requires CLOWNFISH_ALLOW_AUTOMERGE=1", merge_method: "squash" };
+  }
+  const result = spawnSync("gh", ["pr", "merge", String(command.issue_number), "--repo", command.repo, "--squash"], {
+    cwd: repoRoot(),
+    encoding: "utf8",
+    env: ghEnv(),
+    stdio: "pipe",
+  });
+  if (result.status !== 0) {
+    return {
+      action: "merge",
+      status: "blocked",
+      reason: `merge command failed: ${stripAnsi(result.stderr || result.stdout).trim()}`,
+      merge_method: "squash",
+    };
+  }
+  const merged = fetchPullRequestView(command.issue_number);
+  return {
+    action: "merge",
+    status: "executed",
+    reason: "merged by Clownfish automerge",
+    merged_at: merged.mergedAt ?? new Date().toISOString(),
+    merge_commit_sha: merged.mergeCommit?.oid ?? null,
+    merge_method: "squash",
+  };
+}
+
+function validateAutomergeReadiness({ command, view, target }) {
+  if (!hasLabel(target, AUTOMERGE_LABEL)) return "PR is not opted into Clownfish automerge";
+  if (hasLabel(target, HUMAN_REVIEW_LABEL)) return "PR is paused for human review";
+  if (view.state && view.state !== "OPEN") return `pull request is ${String(view.state).toLowerCase()}`;
+  if (view.isDraft) return "pull request is draft";
+  if (String(view.baseRefName ?? "") !== "main") return "pull request base is not main";
+  if (!command.expected_head_sha || command.expected_head_sha === "unknown") {
+    return "ClawSweeper pass marker must include the reviewed PR head SHA";
+  }
+  if (
+    command.expected_head_sha &&
+    command.expected_head_sha !== "unknown" &&
+    view.headRefOid &&
+    command.expected_head_sha !== view.headRefOid
+  ) {
+    return "ClawSweeper pass marker targets a stale PR head SHA";
+  }
+  if (view.mergeable !== "MERGEABLE") return `mergeable state is ${view.mergeable || "unknown"}`;
+  if (!["CLEAN", "HAS_HOOKS"].includes(String(view.mergeStateStatus ?? ""))) {
+    return `merge state status is ${view.mergeStateStatus || "unknown"}`;
+  }
+  if (["CHANGES_REQUESTED", "REVIEW_REQUIRED"].includes(String(view.reviewDecision ?? ""))) {
+    return `review decision is ${view.reviewDecision}`;
+  }
+  const checks = summarizeChecks(view.statusCheckRollup ?? []);
+  if (checks.blockers.length > 0) return `checks are not green: ${checks.blockers.slice(0, 8).join(", ")}`;
+  if (checks.total === 0) return "no PR checks found";
+  return "";
+}
+
+function isTransientAutomergeBlock(reason, view) {
+  const text = String(reason ?? "").toLowerCase();
+  if (text.includes("checks are not green")) return hasPendingChecks(view.statusCheckRollup ?? []);
+  return (
+    text.includes("mergeable state is unknown") ||
+    text.includes("merge state status is unknown") ||
+    text.includes("merge state status is unstable") ||
+    text.includes("review decision is review_required") ||
+    text.includes("no pr checks found")
+  );
+}
+
+function hasPendingChecks(checks) {
+  return (checks ?? []).some((check) => {
+    const status = String(check.status ?? check.state ?? "").toUpperCase();
+    const conclusion = String(check.conclusion ?? "").toUpperCase();
+    return status && !["COMPLETED", "SUCCESS"].includes(status) && !conclusion;
+  });
 }
 
 function classifyIssueTarget(issue) {
@@ -405,9 +644,15 @@ function fetchPullRequestView(number) {
       "headRefName",
       "headRefOid",
       "author",
+      "baseRefName",
+      "isDraft",
       "labels",
+      "mergeable",
+      "mergeCommit",
       "mergeStateStatus",
+      "mergedAt",
       "reviewDecision",
+      "state",
       "statusCheckRollup",
       "title",
     ].join(","),
@@ -428,7 +673,7 @@ function ensureHumanReviewLabel(repo) {
   ghBestEffort([
     "label",
     "create",
-    "clownfish:human-review",
+    HUMAN_REVIEW_LABEL,
     "--repo",
     repo,
     "--color",
@@ -436,6 +681,38 @@ function ensureHumanReviewLabel(repo) {
     "--description",
     "Needs maintainer review before Clownfish can continue",
   ]);
+}
+
+function ensureAutomergeLabel(repo) {
+  ghBestEffort([
+    "label",
+    "create",
+    AUTOMERGE_LABEL,
+    "--repo",
+    repo,
+    "--color",
+    "0E8A16",
+    "--description",
+    "Maintainer opted this Clownfish PR into bounded ClawSweeper-reviewed automerge",
+  ]);
+}
+
+function ensureMergeReadyLabel(repo) {
+  ghBestEffort([
+    "label",
+    "create",
+    MERGE_READY_LABEL,
+    "--repo",
+    repo,
+    "--color",
+    "0E8A16",
+    "--description",
+    "Clownfish found a merge-ready candidate; human owns the final merge",
+  ]);
+}
+
+function hasLabel(target, name) {
+  return (target?.labels ?? []).some((labelName) => String(labelName).toLowerCase() === String(name).toLowerCase());
 }
 
 function ledgerPath() {

--- a/scripts/comment-router.mjs
+++ b/scripts/comment-router.mjs
@@ -12,7 +12,15 @@ import {
   validateJob,
   waitForLiveWorkerCapacity,
 } from "./lib.mjs";
-import { MERGE_INTENTS, REPAIR_INTENTS, parseCommand, parseTrustedAutomation, renderResponse } from "./comment-router-core.mjs";
+import {
+  MERGE_INTENTS,
+  REPAIR_INTENTS,
+  automergeGateBlockReason,
+  buildAutomergeMergeArgs,
+  parseCommand,
+  parseTrustedAutomation,
+  renderResponse,
+} from "./comment-router-core.mjs";
 import {
   appendLedger,
   assertRepo,
@@ -481,28 +489,28 @@ function executeAutomerge(command) {
     if (isTransientAutomergeBlock(block, view)) {
       return { action: "merge", status: "waiting", reason: block, merge_method: "squash" };
     }
-    if (process.env.CLOWNFISH_ALLOW_MERGE !== "1" || process.env.CLOWNFISH_ALLOW_AUTOMERGE !== "1") {
-      ensureMergeReadyLabel(command.repo);
-      ghBestEffort(["issue", "edit", String(command.issue_number), "--repo", command.repo, "--add-label", MERGE_READY_LABEL]);
-    }
     return { action: "merge", status: "blocked", reason: block, merge_method: "squash" };
   }
-  if (process.env.CLOWNFISH_ALLOW_MERGE !== "1") {
+  const gateBlock = automergeGateBlockReason(process.env);
+  if (gateBlock) {
     ensureMergeReadyLabel(command.repo);
     ghBestEffort(["issue", "edit", String(command.issue_number), "--repo", command.repo, "--add-label", MERGE_READY_LABEL]);
-    return { action: "merge", status: "blocked", reason: "merge requires CLOWNFISH_ALLOW_MERGE=1", merge_method: "squash" };
+    return { action: "merge", status: "blocked", reason: gateBlock, merge_method: "squash" };
   }
-  if (process.env.CLOWNFISH_ALLOW_AUTOMERGE !== "1") {
-    ensureMergeReadyLabel(command.repo);
-    ghBestEffort(["issue", "edit", String(command.issue_number), "--repo", command.repo, "--add-label", MERGE_READY_LABEL]);
-    return { action: "merge", status: "blocked", reason: "automerge requires CLOWNFISH_ALLOW_AUTOMERGE=1", merge_method: "squash" };
-  }
-  const result = spawnSync("gh", ["pr", "merge", String(command.issue_number), "--repo", command.repo, "--squash"], {
-    cwd: repoRoot(),
-    encoding: "utf8",
-    env: ghEnv(),
-    stdio: "pipe",
-  });
+  const result = spawnSync(
+    "gh",
+    buildAutomergeMergeArgs({
+      issueNumber: command.issue_number,
+      repo: command.repo,
+      expectedHeadSha: command.expected_head_sha,
+    }),
+    {
+      cwd: repoRoot(),
+      encoding: "utf8",
+      env: ghEnv(),
+      stdio: "pipe",
+    },
+  );
   if (result.status !== 0) {
     return {
       action: "merge",

--- a/test/comment-router-core.test.mjs
+++ b/test/comment-router-core.test.mjs
@@ -4,6 +4,8 @@ import test from "node:test";
 import {
   MERGE_INTENTS,
   REPAIR_INTENTS,
+  automergeGateBlockReason,
+  buildAutomergeMergeArgs,
   parseCommand,
   parseTrustedAutomation,
   renderResponse,
@@ -188,4 +190,23 @@ test("repair intent set documents executable repair commands", () => {
 
 test("merge intent set documents ClawSweeper pass automerge", () => {
   assert.deepEqual([...MERGE_INTENTS], ["clawsweeper_auto_merge"]);
+});
+
+test("automerge merge args pin the reviewed head SHA", () => {
+  assert.deepEqual(
+    buildAutomergeMergeArgs({ issueNumber: 123, repo: "openclaw/openclaw", expectedHeadSha: "abc123" }),
+    ["pr", "merge", "123", "--repo", "openclaw/openclaw", "--squash", "--match-head-commit", "abc123"],
+  );
+});
+
+test("automerge gate block only reports closed merge policy gates", () => {
+  assert.equal(
+    automergeGateBlockReason({ CLOWNFISH_ALLOW_MERGE: "0", CLOWNFISH_ALLOW_AUTOMERGE: "1" }),
+    "merge requires CLOWNFISH_ALLOW_MERGE=1",
+  );
+  assert.equal(
+    automergeGateBlockReason({ CLOWNFISH_ALLOW_MERGE: "1", CLOWNFISH_ALLOW_AUTOMERGE: "0" }),
+    "automerge requires CLOWNFISH_ALLOW_AUTOMERGE=1",
+  );
+  assert.equal(automergeGateBlockReason({ CLOWNFISH_ALLOW_MERGE: "1", CLOWNFISH_ALLOW_AUTOMERGE: "1" }), "");
 });

--- a/test/comment-router-core.test.mjs
+++ b/test/comment-router-core.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  MERGE_INTENTS,
   REPAIR_INTENTS,
   parseCommand,
   parseTrustedAutomation,
@@ -23,6 +24,11 @@ test("parseCommand recognizes maintainer slash commands", () => {
     trigger: "slash",
     command: "status",
     intent: "status",
+  });
+  assert.deepEqual(parseCommand("/clownfish automerge"), {
+    trigger: "slash",
+    command: "automerge",
+    intent: "automerge",
   });
 });
 
@@ -58,6 +64,35 @@ test("parseTrustedAutomation accepts only trusted ClawSweeper repair signals", (
   assert.match(parsed.repair_reason, /structured ClawSweeper/);
 
   assert.equal(parseTrustedAutomation({ ...comment, user: { login: "random-user" } }, { trustedAuthors }), null);
+});
+
+test("parseTrustedAutomation accepts trusted ClawSweeper pass verdicts for automerge", () => {
+  const trustedAuthors = new Set(["clawsweeper[bot]"]);
+  const parsed = parseTrustedAutomation(
+    {
+      user: { login: "clawsweeper[bot]" },
+      body: "ClawSweeper review passed.\n<!-- clawsweeper-verdict:pass sha=abc123 -->",
+    },
+    { trustedAuthors },
+  );
+
+  assert.equal(parsed.intent, "clawsweeper_auto_merge");
+  assert.equal(parsed.expected_head_sha, "abc123");
+  assert.match(parsed.repair_reason, /verdict: pass/);
+});
+
+test("parseTrustedAutomation accepts trusted ClawSweeper human-review verdicts", () => {
+  const trustedAuthors = new Set(["clawsweeper[bot]"]);
+  const parsed = parseTrustedAutomation(
+    {
+      user: { login: "clawsweeper[bot]" },
+      body: "ClawSweeper needs maintainer judgment.\n<!-- clawsweeper-verdict:needs-human sha=abc123 -->",
+    },
+    { trustedAuthors },
+  );
+
+  assert.equal(parsed.intent, "clawsweeper_needs_human");
+  assert.equal(parsed.expected_head_sha, "abc123");
 });
 
 test("parseTrustedAutomation falls back to actionable ClawSweeper review text", () => {
@@ -119,6 +154,29 @@ test("renderResponse reports trusted repair dispatches without losing guardrails
   assert.doesNotMatch(body, /ProjectClownfish/i);
 });
 
+test("renderResponse reports automerge completion", () => {
+  const body = renderResponse(
+    {
+      comment_id: "789",
+      intent: "clawsweeper_auto_merge",
+      trusted_bot_author: "clawsweeper[bot]",
+      repair_reason: "structured ClawSweeper verdict: pass",
+      target: { head_sha: "abc789" },
+    },
+    {
+      merge: {
+        status: "executed",
+        reason: "merged by Clownfish automerge",
+        merged_at: "2026-04-29T05:00:00Z",
+      },
+    },
+  );
+
+  assert.match(body, /merged this PR/);
+  assert.match(body, /automerge loop is complete/);
+  assert.doesNotMatch(body, /ProjectClownfish/i);
+});
+
 test("repair intent set documents executable repair commands", () => {
   assert.deepEqual([...REPAIR_INTENTS].sort(), [
     "address_review",
@@ -126,4 +184,8 @@ test("repair intent set documents executable repair commands", () => {
     "fix_ci",
     "rebase",
   ]);
+});
+
+test("merge intent set documents ClawSweeper pass automerge", () => {
+  assert.deepEqual([...MERGE_INTENTS], ["clawsweeper_auto_merge"]);
 });


### PR DESCRIPTION
## Summary
- add `/clownfish automerge` for existing Clownfish PRs
- route trusted ClawSweeper pass/needs-human verdict markers into merge or human-review decisions
- require exact head SHA, green checks, mergeability, and both merge/automerge gates before merging
- document the bounded review/fix/merge loop and extend script tests

## Verification
- npm test
- npm run validate
- for f in scripts/*.mjs; do node --check "$f"; done
- node scripts/comment-router.mjs --repo openclaw/openclaw --since 2099-01-01T00:00:00Z --max-comments 1 --clawsweeper-repo openclaw/clawsweeper
