### PR TITLE
fix: strip color from job sweep gh output

### DIFF
--- a/scripts/sweep-openclaw-jobs.mjs
+++ b/scripts/sweep-openclaw-jobs.mjs
@@ -286,14 +286,20 @@ function readJson(filePath) {
 }
 
 function ghJson(ghArgs) {
+  const env = { ...process.env, NO_COLOR: "1", CLICOLOR: "0" };
+  delete env.FORCE_COLOR;
   const text = execFileSync("gh", ghArgs, {
     cwd: repoRoot(),
     encoding: "utf8",
-    env: process.env,
+    env,
     stdio: ["ignore", "pipe", "pipe"],
     maxBuffer: 64 * 1024 * 1024,
   });
-  return JSON.parse(text || "null");
+  return JSON.parse(stripAnsi(text) || "null");
+}
+
+function stripAnsi(text) {
+  return text.replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "");
 }
 
 function writeMarkdownReport(report, filePath) {


### PR DESCRIPTION
## Summary
- strip ANSI escape codes from job sweep gh JSON before parsing
- force no-color env for sweep gh subprocesses

## Verification
- npm run sweep-openclaw-jobs -- --live --report /tmp/openclaw-job-sweep-patched.json
- npm run validate
- git diff --check