### PR TITLE
fix(worker): fail infrastructure-blocked results

### DIFF
--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -99,6 +99,12 @@ function reviewResult(resultPath) {
   if (result.status === "executed") {
     failures.push("worker result status must not be executed; only the applicator records execution");
   }
+  if (result.status === "failed") {
+    failures.push("worker result status is failed");
+  }
+  if (isInfrastructureBlockedResult(result, actions)) {
+    failures.push(`worker infrastructure blocked: ${firstLine(result.summary) || "unknown worker failure"}`);
+  }
 
   const closeActions = [];
   const fixActions = [];
@@ -292,6 +298,19 @@ function isUnavailableNeedsHumanAction(action) {
   if (action.status !== "planned" && action.status !== "blocked") return false;
   const text = [action.reason, action.comment, ...(action.evidence ?? [])].join("\n");
   return /\b(404|not found|unavailable|could not hydrate|missing live|refreshed hydration)\b/i.test(text);
+}
+
+function isInfrastructureBlockedResult(result, actions) {
+  if (result.status !== "blocked") return false;
+  if (actions.length > 0) return false;
+  const text = [result.summary, ...(Array.isArray(result.needs_human) ? result.needs_human : [])].join("\n");
+  return /\b(Codex worker timed out|Codex worker exited|HTTP error:\s*401|401 Unauthorized|Unauthorized|failed to connect to websocket|OPENAI_API_KEY|CODEX_API_KEY|API key|authentication|auth failed|login failed)\b/i.test(
+    text,
+  );
+}
+
+function firstLine(value) {
+  return String(value ?? "").split(/\r?\n/, 1)[0].trim();
 }
 
 function isFixFirstBlockedCloseAction(action, hasClusterFixPath) {

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("review-results fails worker infrastructure auth blocks", () => {
+  const dir = makeResultDir({
+    status: "blocked",
+    summary:
+      "2026-06-09T05:41:01Z ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket: HTTP error: 401 Unauthorized, url: wss://api.openai.com/v1/responses",
+    needs_human: ["HTTP error: 401 Unauthorized"],
+  });
+
+  const result = review(dir);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /worker infrastructure blocked/);
+  assert.match(result.stdout, /401 Unauthorized/);
+});
+
+test("review-results fails explicit worker failed status", () => {
+  const dir = makeResultDir({
+    status: "failed",
+    summary: "worker produced an invalid terminal result",
+  });
+
+  const result = review(dir);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /worker result status is failed/);
+});
+
+test("review-results allows actionless blocked maintainer decisions", () => {
+  const dir = makeResultDir({
+    status: "blocked",
+    summary: "needs maintainer choice between two live canonical issues",
+    needs_human: ["choose canonical issue"],
+  });
+
+  const result = review(dir);
+
+  assert.equal(result.status, 0, result.stdout || result.stderr);
+  assert.match(result.stdout, /"status": "passed"/);
+});
+
+function makeResultDir(overrides) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-review-"));
+  const result = {
+    status: "planned",
+    repo: "openclaw/openclaw",
+    cluster_id: "cluster-test",
+    mode: "plan",
+    summary: "test result",
+    actions: [],
+    needs_human: [],
+    ...overrides,
+  };
+  fs.writeFileSync(path.join(dir, "result.json"), `${JSON.stringify(result, null, 2)}\n`);
+  return dir;
+}
+
+function review(dir) {
+  return spawnSync(process.execPath, ["scripts/review-results.mjs", dir], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}


### PR DESCRIPTION
## Summary
- fail worker result review when Codex/auth/runtime infrastructure blocks produce actionless blocked results
- fail explicit worker failed statuses
- add focused review-results coverage for infra blocks, failed status, and real maintainer-blocked decisions

## Verification
- node --test test/review-results.test.mjs
- npm test
- npm run validate
- git diff --check
- npm run review-results -- /tmp/clownfish-check-27186274666 /tmp/clownfish-check-27186275552 exits 1 on the live 401 canary artifacts