### PR TITLE
fix(worker): expose target checkout to planner

### DIFF
--- a/.github/workflows/cluster-worker.yml
+++ b/.github/workflows/cluster-worker.yml
@@ -157,6 +157,17 @@ jobs:
       - name: Validate job
         run: npm run validate:job -- "${{ inputs.job }}"
 
+      - name: Prepare target checkout
+        if: ${{ (inputs.mode == 'execute' || inputs.mode == 'autonomous') && !inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          target_repo="$(node --input-type=module -e 'import { parseJob } from "./scripts/lib.mjs"; console.log(parseJob(process.argv[1]).frontmatter.repo);' "${{ inputs.job }}")"
+          target_dir=".projectclownfish/target/${target_repo//\//-}"
+          rm -rf "$target_dir"
+          gh repo clone "$target_repo" "$target_dir" -- --depth=1
+          echo "CLOWNFISH_TARGET_CHECKOUT=$target_dir" >> "$GITHUB_ENV"
+          echo "prepared target checkout for $target_repo at $target_dir"
+
       - name: Run worker
         run: |
           worker_mode="${{ inputs.mode }}"

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -427,6 +427,16 @@ export function renderPrompt(job, requestedMode, context = {}) {
     );
   }
 
+  if (context.targetCheckoutPath) {
+    const absolute = path.resolve(String(context.targetCheckoutPath));
+    parts.push(
+      "## Target checkout",
+      `Repository: \`${context.targetCheckoutRepo ?? job.frontmatter.repo}\``,
+      `Path: \`${path.relative(repoRoot(), absolute)}\``,
+      "A read-only checkout of the target repository is available for verifying current main before planning executable fixes. Inspect it directly when the job requires proving current target behavior.",
+    );
+  }
+
   parts.push(
     "## Required final output",
     "Return JSON matching `schemas/codex-result.schema.json` and nothing else.",

--- a/scripts/plan-cluster.mjs
+++ b/scripts/plan-cluster.mjs
@@ -352,7 +352,7 @@ function buildFixArtifact(plan, job) {
     mode: plan.mode,
     generated_at: plan.generated_at,
     source_job: plan.source_job,
-    target_checkout: job.frontmatter.target_checkout ?? null,
+    target_checkout: job.frontmatter.target_checkout ?? process.env.CLOWNFISH_TARGET_CHECKOUT ?? null,
     permissions: {
       allow_instant_close: job.frontmatter.allow_instant_close === true,
       allow_low_signal_pr_close: job.frontmatter.allow_low_signal_pr_close === true,

--- a/scripts/run-worker.mjs
+++ b/scripts/run-worker.mjs
@@ -55,6 +55,10 @@ const promptPath = path.join(runDir, "prompt.md");
 const resultPath = path.join(runDir, "result.json");
 const transcriptPath = path.join(runDir, "codex.jsonl");
 const promptContext = {};
+if (process.env.CLOWNFISH_TARGET_CHECKOUT) {
+  promptContext.targetCheckoutPath = process.env.CLOWNFISH_TARGET_CHECKOUT;
+  promptContext.targetCheckoutRepo = job.frontmatter.repo;
+}
 
 if (!dryRun) {
   const plannerArgs = ["scripts/plan-cluster.mjs", jobPath, "--run-dir", runDir];


### PR DESCRIPTION
## Summary
- prepare a read-only target repository checkout before autonomous/execute planning
- pass that checkout path into the worker prompt and generated fix artifact
- keep executor behavior unchanged; it still performs its own writable target clone

## Validation
- npm test
- npm run validate
- branch canary: https://github.com/openclaw/clownfish/actions/runs/27187735401
- branch canary opened OpenClaw fix PR: https://github.com/openclaw/openclaw/pull/91637

## Notes
This fixes commit-sourced ClawSweeper jobs blocking with no target checkout and no GitHub content access during planning.