### PR TITLE
fix: record missing worker results

### DIFF
--- a/scripts/run-worker.mjs
+++ b/scripts/run-worker.mjs
@@ -129,6 +129,22 @@ if (child.status !== 0) {
 }
 
 repairResultIfNeeded();
+const finalReview = reviewResult();
+if (finalReview.status !== 0) {
+  fs.writeFileSync(path.join(runDir, "review-results-final.json"), finalReview.stdout || finalReview.stderr || "");
+  if (!fs.existsSync(resultPath)) {
+    writeBlockedResult("Codex worker completed without writing result.json; see codex.jsonl for the transcript");
+    const blockedReview = reviewResult();
+    if (blockedReview.status !== 0) {
+      fs.writeFileSync(path.join(runDir, "review-results-blocked.json"), blockedReview.stdout || blockedReview.stderr || "");
+      console.error(blockedReview.stdout || blockedReview.stderr || "blocked worker result failed validation");
+      process.exit(1);
+    }
+  } else {
+    console.error(finalReview.stdout || finalReview.stderr || "worker result failed validation");
+    process.exit(1);
+  }
+}
 
 console.log(`result: ${path.relative(repoRoot(), resultPath)}`);
 
@@ -251,6 +267,7 @@ function writeBlockedResult(summary) {
     canonical: null,
     canonical_issue: null,
     canonical_pr: null,
+    merge_preflight: [],
     fix_artifact: null,
   };
   fs.writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`);


### PR DESCRIPTION
## Summary
- Write a valid blocked result when Codex exits successfully but does not produce result.json.
- Fail the worker job immediately when a produced result remains invalid after repair attempts.
- Include merge_preflight in generated blocked results so they match the worker schema.

## Evidence
- Canary run 27191078727 failed in execute/apply because execute-fix-artifact --latest could not find result.json after the worker step.

## Verification
- node --check scripts/run-worker.mjs
- git diff --check
- npm run test
- npm run validate
- fake codex harness: Codex exits 0 without writing output; run-worker emits a valid blocked result and review-results passes.