### PR TITLE
fix: report Codex review failures

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -1157,7 +1157,16 @@ function runCodexReview({ fixArtifact, targetDir, mode, attempt, baseBranch = DE
   fs.writeFileSync(path.join(workRoot, `${mode}-codex-review-${attempt}.jsonl`), child.stdout ?? "");
   if (child.stderr) fs.writeFileSync(path.join(workRoot, `${mode}-codex-review-${attempt}.stderr.log`), child.stderr);
   if (child.error?.code === "ETIMEDOUT") throw new Error(`Codex /review timed out after ${codexTimeoutMs}ms`);
-  if (child.status !== 0) throw new Error(child.stderr || child.stdout || "Codex /review failed");
+  if (child.status !== 0) {
+    const fallbackReview = extractCodexReviewFromJsonl(child.stdout);
+    if (fallbackReview) {
+      fs.writeFileSync(outputPath, `${JSON.stringify(fallbackReview, null, 2)}\n`);
+      throw new Error(`Codex /review failed: ${fallbackReview.summary || "structured review did not pass"}`);
+    }
+    const stdout = compactText(child.stdout, 800);
+    const stderr = compactText(child.stderr, 800);
+    throw new Error(`Codex /review failed: stdout=${stdout || "empty"}; stderr=${stderr || "empty"}`);
+  }
   if (!fs.existsSync(outputPath)) {
     const fallbackReview = extractCodexReviewFromJsonl(child.stdout);
     if (fallbackReview) {


### PR DESCRIPTION
## Summary
- Preserve structured Codex /review output when the review subprocess exits nonzero.
- Convert nonzero /review exits into a blockable executor error instead of an unclassified workflow crash.

## Evidence
- Canary run 27191080344 built a valid fix artifact, then crashed in execute/apply when Codex /review returned a structured blocked review on stdout with nonzero exit.

## Verification
- node --check scripts/execute-fix-artifact.mjs
- git diff --check
- npm run test
- npm run validate