### PR TITLE
fix: preserve recoverable fix branch metadata

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -65,6 +65,7 @@ const codexWriteNetworkAccess = parseBooleanEnv(
 const codexReviewNetworkAccess = parseBooleanEnv(process.env.CLOWNFISH_CODEX_REVIEW_NETWORK_ACCESS, false);
 let workRoot = "";
 let targetDir = "";
+let activeFixProgress = null;
 
 if (!jobPath) {
   console.error("usage: node scripts/execute-fix-artifact.mjs <job.md> [result.json] [--latest] [--dry-run]");
@@ -261,12 +262,7 @@ try {
     };
   } else {
     if (!isBlockedFixError(error)) throw error;
-    outcome = {
-      action: "execute_fix",
-      status: "blocked",
-      repair_strategy: fixArtifact.repair_strategy,
-      reason: error.message,
-    };
+    outcome = blockedFixOutcome(error, fixArtifact);
   }
 }
 
@@ -279,6 +275,33 @@ function isBlockedFixError(error) {
   return /fix execution deadline exceeded|timed out after \d+ms before fix execution deadline|Codex produced no target repo changes|Codex \/review did not pass|Codex (?:fix worker|review-fix worker|rebase-fix worker|\/review) timed out|Codex (?:fix worker|review-fix worker|rebase-fix worker|\/review) failed|could not repair rebase conflicts|validation command failed|base branch advanced after validation/i.test(
     String(error?.message ?? error),
   );
+}
+
+function noteFixProgress(progress) {
+  activeFixProgress = {
+    ...(activeFixProgress ?? {}),
+    ...progress,
+  };
+}
+
+function blockedFixOutcome(error, fixArtifact) {
+  const reason = String(error?.message ?? error);
+  if (activeFixProgress?.recoverable_branch_pushed === true) {
+    return {
+      ...activeFixProgress,
+      status: "blocked",
+      repair_strategy: activeFixProgress.repair_strategy ?? fixArtifact.repair_strategy,
+      reason,
+      retry_recommended: true,
+      recovery_note: "recoverable branch was pushed before fix execution blocked; requeue can resume it",
+    };
+  }
+  return {
+    action: "execute_fix",
+    status: "blocked",
+    repair_strategy: fixArtifact.repair_strategy,
+    reason,
+  };
 }
 
 function remainingFixExecutionMs(label, { reserveMs = fixReportReserveMs, minMs = 10 * 1000 } = {}) {
@@ -403,6 +426,17 @@ function executeRepairBranch({ fixArtifact, targetDir }) {
   ghAuthSetupGit(targetDir);
   const pushArgs = repairBranchPushArgs({ pull, rebased });
   run("git", pushArgs, { cwd: targetDir });
+  noteFixProgress({
+    action: "repair_contributor_branch",
+    repair_strategy: fixArtifact.repair_strategy,
+    target: sourcePr.url,
+    head_repo: pull.head.repo.full_name,
+    head_ref: pull.head.ref,
+    rebased,
+    commit: prep.commit,
+    recoverable_branch_pushed: true,
+    merge_preflight: prep.merge_preflight,
+  });
   const threadResolution = prepareReviewThreadsForMerge({ repo: result.repo, number: sourcePr.number, targetDir });
   const comment = repairContributorBranchComment({
     sourcePrUrl: sourcePr.url,
@@ -465,10 +499,20 @@ function executeReplacementBranch({ fixArtifact, targetDir, supersedeSources, fa
   }
   run("git", ["fetch", "origin", baseBranch], { cwd: targetDir });
   const branchState = checkoutRecoverableReplacementBranch({ targetDir, branch, baseBranch });
+  const branchProgress = {
+    action: "open_fix_pr",
+    repair_strategy: fixArtifact.repair_strategy,
+    branch,
+    resumed_branch: branchState.resumed,
+    supersede_sources: supersedeSources ? fixArtifact.source_prs ?? [] : [],
+    contributor_credit: contributorCredits.map(publicContributorCredit),
+  };
+  noteFixProgress(branchProgress);
   if (branchState.resumed) rebaseRecoverableReplacementBranch({ targetDir, branch, baseBranch, fixArtifact });
   prepareTargetToolchain(targetDir);
 
   if (!dryRun) ghAuthSetupGit(targetDir);
+  const pushedCheckpointCommits = [];
   const prep = editValidatePrepareMerge({
     fixArtifact,
     targetDir,
@@ -478,7 +522,19 @@ function executeReplacementBranch({ fixArtifact, targetDir, supersedeSources, fa
     baseBranch,
     contributorCredits,
     allowExistingChanges: branchState.resumed && branchHasBaseDiff({ targetDir, baseBranch }),
-    pushCheckpoint: dryRun ? null : () => pushRecoverableBranch({ targetDir, branch }),
+    pushCheckpoint: dryRun
+      ? null
+      : () => {
+          pushRecoverableBranch({ targetDir, branch });
+          const commit = currentHead(targetDir);
+          pushedCheckpointCommits.push(commit);
+          noteFixProgress({
+            ...branchProgress,
+            commit,
+            checkpoint_commits: uniqueStrings(pushedCheckpointCommits),
+            recoverable_branch_pushed: true,
+          });
+        },
   });
   if (refreshValidatedBranchBase({ targetDir, branch, baseBranch })) {
     prep.commit = currentHead(targetDir);

--- a/scripts/publish-result.mjs
+++ b/scripts/publish-result.mjs
@@ -590,6 +590,10 @@ function sanitizeFixAction(action) {
     source_status: action.source_status ?? null,
     repair_strategy: action.repair_strategy ?? null,
     reason: action.reason ?? null,
+    commit: action.commit ?? null,
+    checkpoint_commits: action.checkpoint_commits ?? null,
+    retry_recommended: action.retry_recommended ?? null,
+    recoverable_branch_pushed: action.recoverable_branch_pushed ?? null,
     title: action.title ?? null,
     url: action.url ?? action.pr_url ?? null,
   };

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("execute-fix-artifact preserves recoverable replacement branch when review deadline blocks", () => {
+  const fixture = makeFixture();
+  const resultPath = path.join(fixture.runDir, "result.json");
+  const reportPath = path.join(fixture.runDir, "fix-execution-report.json");
+
+  fs.writeFileSync(fixture.jobPath, jobFile("deadline-cluster"));
+  fs.writeFileSync(resultPath, `${JSON.stringify(resultFile("deadline-cluster"), null, 2)}\n`);
+
+  const child = spawnSync(
+    process.execPath,
+    [
+      "scripts/execute-fix-artifact.mjs",
+      fixture.jobPath,
+      resultPath,
+      "--target-dir",
+      fixture.targetDir,
+      "--work-dir",
+      fixture.workDir,
+      "--report",
+      reportPath,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+        CLOWNFISH_ALLOW_EXECUTE: "1",
+        CLOWNFISH_ALLOW_FIX_PR: "1",
+        CLOWNFISH_FIX_STEP_TIMEOUT_MS: "61000",
+        CLOWNFISH_FIX_TIMEOUT_RESERVE_MS: "0",
+        CLOWNFISH_FIX_REPORT_RESERVE_MS: "0",
+        CLOWNFISH_INSTALL_TARGET_DEPS: "0",
+        CLOWNFISH_SKIP_CODEX_WRITE_PREFLIGHT: "1",
+        CLOWNFISH_CODEX_REVIEW_ATTEMPTS: "1",
+      },
+    },
+  );
+
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.equal(report.actions.length, 1);
+  assert.equal(report.actions[0].action, "open_fix_pr");
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(report.actions[0].branch, "clownfish/deadline-cluster");
+  assert.equal(report.actions[0].repair_strategy, "new_fix_pr");
+  assert.equal(report.actions[0].recoverable_branch_pushed, true);
+  assert.equal(report.actions[0].retry_recommended, true);
+  assert.match(report.actions[0].reason, /fix execution deadline exceeded before Codex \/review/);
+  assert.match(report.actions[0].commit, /^[0-9a-f]{40}$/);
+  assert.deepEqual(report.actions[0].checkpoint_commits, [report.actions[0].commit]);
+
+  const remoteBranch = git(["ls-remote", "--heads", fixture.originDir, "clownfish/deadline-cluster"], {
+    cwd: fixture.root,
+  });
+  assert.match(remoteBranch, new RegExp(`^${report.actions[0].commit}\\s+refs/heads/clownfish/deadline-cluster`));
+});
+
+function makeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-fix-exec-"));
+  const binDir = path.join(root, "bin");
+  const runDir = path.join(root, "run");
+  const workDir = path.join(root, "work");
+  const seedDir = path.join(root, "seed");
+  const originDir = path.join(root, "origin.git");
+  const targetDir = path.join(root, "target");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(runDir, { recursive: true });
+  fs.mkdirSync(workDir, { recursive: true });
+  writeStubs(binDir);
+
+  git(["init", "--bare", originDir], { cwd: root });
+  git(["init", "-b", "main", seedDir], { cwd: root });
+  git(["config", "user.name", "Test User"], { cwd: seedDir });
+  git(["config", "user.email", "test@example.com"], { cwd: seedDir });
+  fs.mkdirSync(path.join(seedDir, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(seedDir, "package.json"),
+    `${JSON.stringify({ scripts: { "check:changed": "node scripts/check-changed.mjs" } }, null, 2)}\n`,
+  );
+  fs.writeFileSync(path.join(seedDir, "src", "app.js"), "export const value = 1;\n");
+  git(["add", "."], { cwd: seedDir });
+  git(["commit", "-m", "initial"], { cwd: seedDir });
+  git(["remote", "add", "origin", originDir], { cwd: seedDir });
+  git(["push", "-u", "origin", "main"], { cwd: seedDir });
+  git(["clone", originDir, targetDir], { cwd: root });
+  git(["checkout", "main"], { cwd: targetDir });
+
+  return {
+    root,
+    binDir,
+    runDir,
+    workDir,
+    originDir,
+    targetDir,
+    jobPath: path.join(root, "job.md"),
+  };
+}
+
+function writeStubs(binDir) {
+  writeExecutable(
+    path.join(binDir, "codex"),
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+if (args.includes("--output-schema")) {
+  console.error("review should not run after the deadline check");
+  process.exit(42);
+}
+const cd = args[args.indexOf("--cd") + 1];
+const output = args.includes("--output-last-message") ? args[args.indexOf("--output-last-message") + 1] : "";
+Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2500);
+fs.appendFileSync(path.join(cd, "src", "app.js"), "\\n// ProjectClownfish test edit\\n");
+if (output) fs.writeFileSync(output, "edited\\n");
+`,
+  );
+  writeExecutable(
+    path.join(binDir, "gh"),
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "setup-git") process.exit(0);
+if (args[0] === "pr" && args[1] === "list") {
+  console.log("[]");
+  process.exit(0);
+}
+console.error("unexpected gh call: " + args.join(" "));
+process.exit(2);
+`,
+  );
+  writeExecutable(
+    path.join(binDir, "pnpm"),
+    `#!/usr/bin/env node
+process.exit(0);
+`,
+  );
+}
+
+function writeExecutable(filePath, content) {
+  fs.writeFileSync(filePath, content);
+  fs.chmodSync(filePath, 0o755);
+}
+
+function jobFile(clusterId) {
+  return `---
+repo: openclaw/openclaw
+cluster_id: ${clusterId}
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - fix
+  - raise_pr
+blocked_actions:
+  - close
+  - merge
+require_human_for:
+  - close
+  - merge
+canonical: []
+candidates:
+  - "#1"
+cluster_refs:
+  - "#1"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: false
+security_policy: central_security_only
+security_sensitive: false
+---
+
+# Deadline test job
+`;
+}
+
+function resultFile(clusterId) {
+  return {
+    status: "planned",
+    repo: "openclaw/openclaw",
+    cluster_id: clusterId,
+    mode: "autonomous",
+    summary: "open a replacement fix PR",
+    actions: [{ action: "open_fix_pr", status: "planned", target: `cluster:${clusterId}` }],
+    needs_human: [],
+    fix_artifact: {
+      summary: "Make a narrow test edit.",
+      pr_title: "fix: preserve recoverable branch metadata",
+      pr_body: "Test replacement PR body.",
+      affected_surfaces: ["src"],
+      likely_files: ["src/app.js"],
+      linked_refs: ["#1"],
+      validation_commands: ["pnpm check:changed"],
+      credit_notes: ["No external contributor credit for this test."],
+      changelog_required: false,
+      repair_strategy: "new_fix_pr",
+    },
+  };
+}
+
+function git(args, options) {
+  const child = spawnSync("git", args, { encoding: "utf8", ...options });
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  return child.stdout.trim();
+}


### PR DESCRIPTION
## Summary

- preserve `open_fix_pr` / `repair_contributor_branch` action metadata when fix execution blocks after a recoverable branch has already been pushed
- publish recovery fields (`branch`, `commit`, checkpoint commits, retry flag) into run records
- add a regression that simulates a pushed replacement branch followed by a Codex `/review` deadline block without hitting GitHub or real Codex

## Why

A previous run pushed `clownfish/<cluster>` successfully, then timed out before `/review`. The executor collapsed that into `execute_fix: blocked` with no branch/PR metadata, so post-flight had no fix-PR action to finalize and operators had to rediscover the branch manually.

This keeps the safety contract intact: no PR is opened before validation and `/review` pass. The failed run now carries a durable recovery handle so requeue/manual salvage can resume the pushed branch instead of starting blind.

## Validation

- `node --test test/execute-fix-artifact.test.mjs`
- `node --check scripts/execute-fix-artifact.mjs scripts/post-flight.mjs scripts/publish-result.mjs`
- `node --check scripts/plan-cluster.mjs scripts/import-gitcrawl-clusters.mjs scripts/run-worker.mjs scripts/post-flight.mjs`
- `npm test`
- `npm run validate`
- `git diff --check`

Note: `scripts/import-ghcrawl-clusters.mjs` from the skill notes does not exist in this repo; the matching repo script is `scripts/import-gitcrawl-clusters.mjs`.
