### PR TITLE
chore(jobs): allow TTS migration fix artifact

### DIFF
--- a/jobs/openclaw/inbox/clawsweeper-commit-openclaw-openclaw-1d0e9a907e6d.md
+++ b/jobs/openclaw/inbox/clawsweeper-commit-openclaw-openclaw-1d0e9a907e6d.md
@@ -21,6 +21,7 @@ allow_fix_pr: true
 allow_merge: false
 allow_unmerged_fix_close: false
 allow_post_merge_close: false
+allow_broad_fix_artifacts: true
 require_fix_before_close: false
 security_policy: central_security_only
 security_sensitive: false


### PR DESCRIPTION
## Summary

- allow the `clawsweeper-commit-openclaw-openclaw-1d0e9a907e6d` job to execute its broad-but-bounded TTS migration fix artifact
- keep the override scoped to this one job instead of enabling `CLOWNFISH_ALLOW_BROAD_FIX_ARTIFACTS` globally

## Evidence

- run `27242270327` produced a valid terminal result for this job
- executor blocked only because the artifact spans the expected core migration, Discord contract, tests, and changelog surfaces
- `npm run validate`
- `git diff --check`

Merge and close actions remain blocked by the job; this only permits opening the implementation PR.
