### PR TITLE
fix(worker): raise Codex stdout buffer

### DIFF
--- a/scripts/run-worker.mjs
+++ b/scripts/run-worker.mjs
@@ -23,6 +23,10 @@ const resultRepairAttempts = Math.max(0, Number(process.env.CLOWNFISH_RESULT_REP
 const resultRepairTimeoutMs = Number(process.env.CLOWNFISH_RESULT_REPAIR_TIMEOUT_MS ?? 10 * 60 * 1000);
 const codexReasoningEffort = String(process.env.CLOWNFISH_CODEX_REASONING_EFFORT ?? "medium");
 const codexServiceTier = String(process.env.CLOWNFISH_CODEX_SERVICE_TIER ?? "fast").trim();
+const codexStdoutMaxBufferBytes = parsePositiveIntegerEnv(
+  process.env.CLOWNFISH_CODEX_STDOUT_MAX_BUFFER_BYTES,
+  64 * 1024 * 1024,
+);
 
 if (!jobPath) {
   console.error("usage: node scripts/run-worker.mjs <job.md> --mode plan|execute|autonomous [--dry-run]");
@@ -121,6 +125,11 @@ if (child.error?.code === "ETIMEDOUT") {
   console.error(`Codex worker timed out after ${codexTimeoutMs}ms`);
   process.exit(0);
 }
+if (child.error?.code === "ENOBUFS") {
+  writeBlockedResult(`Codex worker stdout exceeded ${codexStdoutMaxBufferBytes} bytes before writing result.json`);
+  console.error(`Codex worker stdout exceeded ${codexStdoutMaxBufferBytes} bytes`);
+  process.exit(0);
+}
 
 if (child.status !== 0) {
   if (recoverResultFromTranscriptIfMissing()) {
@@ -184,6 +193,7 @@ function runCodex({ input, outputPath, transcriptPath: codexTranscriptPath, stde
     encoding: "utf8",
     env: codexEnv(),
     timeout: timeoutMs,
+    maxBuffer: codexStdoutMaxBufferBytes,
   });
 
   fs.writeFileSync(codexTranscriptPath, child.stdout ?? "");
@@ -283,6 +293,13 @@ function codexEnv() {
   delete env.CLOWNFISH_READ_GH_TOKEN;
   delete env.CLOWNFISH_CODEX_GH_TOKEN;
   return env;
+}
+
+function parsePositiveIntegerEnv(value, fallback) {
+  if (value === undefined || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return fallback;
+  return parsed;
 }
 
 function writeBlockedResult(summary) {

--- a/test/run-worker-source.test.mjs
+++ b/test/run-worker-source.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("run-worker gives Codex JSON transcripts an explicit stdout buffer", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "run-worker.mjs"), "utf8");
+
+  assert.match(source, /CLOWNFISH_CODEX_STDOUT_MAX_BUFFER_BYTES/);
+  assert.match(source, /maxBuffer:\s*codexStdoutMaxBufferBytes/);
+  assert.match(source, /child\.error\?\.code === "ENOBUFS"/);
+});


### PR DESCRIPTION
## Summary
- give Codex JSON transcript capture an explicit 64 MiB stdout buffer
- write a blocked result if stdout still exceeds that buffer instead of falling through to an opaque missing-result failure
- add a regression check for the worker buffer wiring

## Validation
- node --test test/run-worker-source.test.mjs
- node --check scripts/run-worker.mjs
- node --check scripts/plan-cluster.mjs
- node --check scripts/post-flight.mjs
- npm test
- npm run validate
- git diff --check