### PR TITLE
fix(executor): parse quoted validation commands

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2024,13 +2024,56 @@ function uniqueStrings(values) {
 function parseAllowedValidationCommand(command) {
   const text = String(command ?? "").trim();
   if (!text) throw new Error("empty validation command");
-  if (/[`$;&|<>()[\]{}*?~]/.test(text)) {
-    throw new Error(`unsafe validation command: ${text}`);
-  }
-  const parts = text.split(/\s+/);
+  const parts = splitValidationCommand(text);
   if (!["pnpm", "npm", "node", "git"].includes(parts[0])) {
     throw new Error(`unsupported validation command: ${text}`);
   }
+  return parts;
+}
+
+function splitValidationCommand(text) {
+  const parts = [];
+  let current = "";
+  let quote = "";
+  let escaped = false;
+
+  for (const ch of text) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (quote) {
+      if (ch === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (ch === quote) {
+        quote = "";
+        continue;
+      }
+      current += ch;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) {
+        parts.push(current);
+        current = "";
+      }
+      continue;
+    }
+    if (/[`$;&|<>()[\]{}*?~\\]/.test(ch)) {
+      throw new Error(`unsafe validation command: ${text}`);
+    }
+    current += ch;
+  }
+
+  if (escaped || quote) throw new Error(`unsafe validation command: ${text}`);
+  if (current) parts.push(current);
   return parts;
 }
 

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -215,7 +215,10 @@ function resultFile(clusterId) {
       affected_surfaces: ["src"],
       likely_files: ["src/app.js"],
       linked_refs: ["#1"],
-      validation_commands: ["pnpm check:changed"],
+      validation_commands: [
+        'pnpm test:serial src/app.js -t "previewRemHarness|skips REM short-term candidates whose source file disappeared"',
+        "pnpm check:changed",
+      ],
       credit_notes: ["No external contributor credit for this test."],
       changelog_required: false,
       repair_strategy: "new_fix_pr",


### PR DESCRIPTION
## Summary
- parse validation command strings into argv with single/double quote support
- keep unquoted shell-control characters blocked
- cover the REM harness replay failure shape with a quoted pnpm test filter containing a pipe

## Validation
- node --test test/execute-fix-artifact.test.mjs
- node --check scripts/execute-fix-artifact.mjs
- npm test
- npm run validate
- git diff --check