### PR TITLE
fix(post-flight): wait for PR checks before merge

### DIFF
--- a/scripts/dispatch-jobs.mjs
+++ b/scripts/dispatch-jobs.mjs
@@ -127,6 +127,10 @@ if (files.length === 0) {
   );
   process.exit(2);
 }
+if (repositoryWorkerDispatch && !headSha) {
+  console.error("repository-worker dispatch requires a resolved main ancestor SHA");
+  process.exit(1);
+}
 
 if (!Number.isInteger(publishBacklogThreshold) || publishBacklogThreshold < 0) {
   console.error("--publish-backlog-threshold must be a non-negative integer");
@@ -639,8 +643,29 @@ function readDispatchLedger() {
 }
 
 function currentHeadSha() {
+  const direct = gitRevision(ref || "origin/main");
+  if (direct) return direct;
+  if (!isMainRef(ref)) return "";
+
   try {
-    return execFileSync("git", ["rev-parse", ref || "origin/main"], {
+    execFileSync("git", ["fetch", "origin", "main", "--depth=1"], {
+      cwd: repoRoot(),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return "";
+  }
+  return gitRevision("FETCH_HEAD");
+}
+
+function isMainRef(value) {
+  return !value || value === "main" || value === "origin/main" || value === "refs/heads/main";
+}
+
+function gitRevision(revision) {
+  try {
+    return execFileSync("git", ["rev-parse", revision], {
       cwd: repoRoot(),
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],

--- a/scripts/post-flight-checks.mjs
+++ b/scripts/post-flight-checks.mjs
@@ -1,0 +1,60 @@
+const PASSING_CHECK_CONCLUSIONS = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"]);
+const DEFAULT_IGNORED_CHECKS = ["auto-response", "Labeler", "Stale"];
+
+export function shouldRequirePrChecks(value = process.env.CLOWNFISH_POST_FLIGHT_REQUIRE_PR_CHECKS) {
+  return value !== "0";
+}
+
+export function validateStatusChecks(checks, ignored = ignoredCheckNames()) {
+  if (!Array.isArray(checks) || checks.length === 0) return "no PR checks found";
+  const blockers = [];
+  let relevantChecks = 0;
+  for (const check of checks) {
+    const name = String(check.name ?? check.context ?? "unknown check");
+    if (ignored.has(name)) continue;
+    relevantChecks += 1;
+    const status = String(check.status ?? check.state ?? "").toUpperCase();
+    const conclusion = String(check.conclusion ?? "").toUpperCase();
+    if (status && !["COMPLETED", "SUCCESS"].includes(status)) {
+      blockers.push(`${name}: ${status}`);
+      continue;
+    }
+    if (conclusion && !PASSING_CHECK_CONCLUSIONS.has(conclusion)) {
+      blockers.push(`${name}: ${conclusion}`);
+    }
+  }
+  if (relevantChecks === 0) return "no PR checks found";
+  if (blockers.length > 0) return `checks are not clean: ${blockers.slice(0, 5).join(", ")}`;
+  return "";
+}
+
+export function shouldWaitForMergeReadiness({ mergeBlock, view, ignored = ignoredCheckNames() }) {
+  const message = String(mergeBlock ?? "").toLowerCase();
+  if (message.includes("no pr checks found")) return true;
+  if (message.includes("mergeable state is unknown")) return true;
+  if (message.includes("merge state status is unknown")) return true;
+  if (message.includes("merge state status is unstable")) return hasPendingChecks(view.statusCheckRollup ?? [], ignored);
+  if (message.includes("checks are not clean")) return hasPendingChecks(view.statusCheckRollup ?? [], ignored);
+  return false;
+}
+
+export function ignoredCheckNames(value = process.env.CLOWNFISH_POST_FLIGHT_IGNORE_CHECKS) {
+  const configured = value ?? DEFAULT_IGNORED_CHECKS.join(",");
+  return new Set(
+    String(configured)
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean),
+  );
+}
+
+function hasPendingChecks(checks, ignored) {
+  return (checks ?? []).some((check) => {
+    const name = String(check.name ?? check.context ?? "unknown check");
+    if (ignored.has(name)) return false;
+    const status = String(check.status ?? check.state ?? "").toUpperCase();
+    const conclusion = String(check.conclusion ?? "").toUpperCase();
+    if (conclusion) return false;
+    return Boolean(status) && !["COMPLETED", "SUCCESS"].includes(status);
+  });
+}

--- a/scripts/post-flight.mjs
+++ b/scripts/post-flight.mjs
@@ -4,14 +4,13 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { assertAllowedOwner, hasDeterministicSecuritySignal, parseArgs, parseJob, repoRoot, validateJob } from "./lib.mjs";
 import { externalMessageProvenance, postMergeCloseoutComment } from "./external-messages.mjs";
+import { shouldRequirePrChecks, shouldWaitForMergeReadiness, validateStatusChecks } from "./post-flight-checks.mjs";
 
-const PASSING_CHECK_CONCLUSIONS = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"]);
 const CLEAN_MERGE_STATES = new Set(["CLEAN", "HAS_HOOKS"]);
 const FIX_PR_MERGE_STATES = new Set(["CLEAN", "HAS_HOOKS", "UNSTABLE"]);
 const FIX_PR_ACTIONS = new Set(["open_fix_pr", "repair_contributor_branch"]);
 const FIX_PR_READY_STATUSES = new Set(["opened", "pushed"]);
 const POST_MERGE_CLOSE_ACTIONS = new Set(["close_duplicate", "close_superseded", "close_fixed_by_candidate", "post_merge_close"]);
-const DEFAULT_IGNORED_CHECKS = ["auto-response", "Labeler", "Stale"];
 const CLOWNFISH_LABEL = "clownfish";
 const CLOWNFISH_LABEL_COLOR = "F97316";
 const CLOWNFISH_LABEL_DESCRIPTION = "Tracked by Clownfish automation";
@@ -364,62 +363,6 @@ function validateMergePreflight(preflight) {
     return "Codex /review evidence is missing";
   }
   return "";
-}
-
-function validateStatusChecks(checks) {
-  if (!Array.isArray(checks) || checks.length === 0) return "no PR checks found";
-  const ignored = ignoredCheckNames();
-  const blockers = [];
-  for (const check of checks) {
-    const name = String(check.name ?? check.context ?? "unknown check");
-    if (ignored.has(name)) continue;
-    const status = String(check.status ?? check.state ?? "").toUpperCase();
-    const conclusion = String(check.conclusion ?? "").toUpperCase();
-    if (status && !["COMPLETED", "SUCCESS"].includes(status)) {
-      blockers.push(`${name}: ${status}`);
-      continue;
-    }
-    if (conclusion && !PASSING_CHECK_CONCLUSIONS.has(conclusion)) {
-      blockers.push(`${name}: ${conclusion}`);
-    }
-  }
-  if (blockers.length > 0) return `checks are not clean: ${blockers.slice(0, 5).join(", ")}`;
-  return "";
-}
-
-function shouldWaitForMergeReadiness({ mergeBlock, view }) {
-  const message = String(mergeBlock ?? "").toLowerCase();
-  if (message.includes("mergeable state is unknown")) return true;
-  if (message.includes("merge state status is unknown")) return true;
-  if (message.includes("merge state status is unstable")) return hasPendingChecks(view.statusCheckRollup ?? []);
-  if (message.includes("checks are not clean")) return hasPendingChecks(view.statusCheckRollup ?? []);
-  return false;
-}
-
-function hasPendingChecks(checks) {
-  const ignored = ignoredCheckNames();
-  return (checks ?? []).some((check) => {
-    const name = String(check.name ?? check.context ?? "unknown check");
-    if (ignored.has(name)) return false;
-    const status = String(check.status ?? check.state ?? "").toUpperCase();
-    const conclusion = String(check.conclusion ?? "").toUpperCase();
-    if (conclusion) return false;
-    return Boolean(status) && !["COMPLETED", "SUCCESS"].includes(status);
-  });
-}
-
-function ignoredCheckNames() {
-  const configured = String(process.env.CLOWNFISH_POST_FLIGHT_IGNORE_CHECKS ?? DEFAULT_IGNORED_CHECKS.join(","));
-  return new Set(
-    configured
-      .split(",")
-      .map((item) => item.trim())
-      .filter(Boolean),
-  );
-}
-
-function shouldRequirePrChecks() {
-  return process.env.CLOWNFISH_POST_FLIGHT_REQUIRE_PR_CHECKS === "1";
 }
 
 function validateResolvedReviewThreads(repo, number) {

--- a/test/app-token-auth.test.mjs
+++ b/test/app-token-auth.test.mjs
@@ -189,6 +189,55 @@ test("dispatch supports repository-worker canary dispatch", () => {
   assert.match(result.stdout, /dispatched 1\/1/);
 });
 
+test("repository-worker dispatch fetches main when a shallow checkout lacks origin/main", () => {
+  const fixture = makeFixture();
+  writeFailingGh(fixture.bin, "gh");
+  const fakeGhx = writeFakeGh(fixture.bin, "ghx");
+  writeShallowCheckoutGit(fixture.bin);
+  const env = {
+    ...process.env,
+    PATH: `${fixture.bin}${path.delimiter}${process.env.PATH}`,
+    EXPECT_REPOSITORY_WORKER_FIELDS: "1",
+  };
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "scripts/dispatch-jobs.mjs",
+      "jobs/openclaw/inbox/cluster-example.md",
+      "--repo",
+      "openclaw/clownfish",
+      "--mode",
+      "autonomous",
+      "--dispatch-event",
+      "repository-worker",
+      "--ref",
+      "main",
+      "--gh-bin",
+      fakeGhx,
+      "--allow-app-token-auth",
+      "--skip-publish-backlog-check",
+      "--max-live-workers",
+      "1",
+      "--hydrate-comments",
+      "1",
+      "--max-linked-refs",
+      "20",
+      "--max-comments-per-item",
+      "30",
+      "--max-review-comments-per-pr",
+      "50",
+      "--dry-run",
+      "1",
+      "--no-dispatch-ledger",
+    ],
+    { cwd: repoRoot, encoding: "utf8", env },
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /dispatched 1\/1/);
+});
+
 test("cluster-worker repository dispatch guard accepts descendants", () => {
   const workflow = fs.readFileSync(path.join(repoRoot, ".github/workflows/cluster-worker.yml"), "utf8");
 
@@ -302,6 +351,26 @@ function writeFailingGh(binDir, name) {
     filePath,
     `#!/usr/bin/env node
 console.error("plain gh should not be used by this test");
+process.exit(1);
+`,
+  );
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
+function writeShallowCheckoutGit(binDir) {
+  const filePath = path.join(binDir, "git");
+  fs.writeFileSync(
+    filePath,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "rev-parse" && args[1] === "origin/main") process.exit(1);
+if (args[0] === "fetch" && args[1] === "origin" && args[2] === "main") process.exit(0);
+if (args[0] === "rev-parse" && args[1] === "FETCH_HEAD") {
+  console.log("${"a".repeat(40)}");
+  process.exit(0);
+}
+console.error("unexpected fake git call", args.join(" "));
 process.exit(1);
 `,
   );

--- a/test/post-flight-checks.test.mjs
+++ b/test/post-flight-checks.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  shouldRequirePrChecks,
+  shouldWaitForMergeReadiness,
+  validateStatusChecks,
+} from "../scripts/post-flight-checks.mjs";
+
+test("post-flight requires PR checks unless explicitly disabled", () => {
+  assert.equal(shouldRequirePrChecks(undefined), true);
+  assert.equal(shouldRequirePrChecks("1"), true);
+  assert.equal(shouldRequirePrChecks("0"), false);
+});
+
+test("post-flight waits for checks to register instead of merging through an empty rollup", () => {
+  const mergeBlock = validateStatusChecks([]);
+
+  assert.equal(mergeBlock, "no PR checks found");
+  assert.equal(shouldWaitForMergeReadiness({ mergeBlock, view: { statusCheckRollup: [] } }), true);
+});
+
+test("post-flight does not treat ignored checks as readiness proof", () => {
+  const checks = [{ name: "auto-response", status: "COMPLETED", conclusion: "SUCCESS" }];
+  const mergeBlock = validateStatusChecks(checks);
+
+  assert.equal(mergeBlock, "no PR checks found");
+  assert.equal(shouldWaitForMergeReadiness({ mergeBlock, view: { statusCheckRollup: checks } }), true);
+});
+
+test("post-flight waits for pending checks and blocks terminal failures", () => {
+  const pending = [{ name: "CI", status: "IN_PROGRESS", conclusion: null }];
+  const pendingBlock = validateStatusChecks(pending);
+  assert.equal(pendingBlock, "checks are not clean: CI: IN_PROGRESS");
+  assert.equal(shouldWaitForMergeReadiness({ mergeBlock: pendingBlock, view: { statusCheckRollup: pending } }), true);
+
+  const failed = [{ name: "CI", status: "COMPLETED", conclusion: "FAILURE" }];
+  const failedBlock = validateStatusChecks(failed);
+  assert.equal(failedBlock, "checks are not clean: CI: FAILURE");
+  assert.equal(shouldWaitForMergeReadiness({ mergeBlock: failedBlock, view: { statusCheckRollup: failed } }), false);
+});
+
+test("post-flight accepts completed passing checks", () => {
+  const passing = [{ name: "CI", status: "COMPLETED", conclusion: "SUCCESS" }];
+  assert.equal(validateStatusChecks(passing), "");
+});


### PR DESCRIPTION
## Summary
- require at least one non-ignored PR check before post-flight merge readiness
- wait for checks to register instead of merging through an empty rollup
- preserve an explicit CLOWNFISH_POST_FLIGHT_REQUIRE_PR_CHECKS=0 emergency override

## Verification
- node --test test/post-flight-checks.test.mjs
- node --test --test-concurrency=1 test/*.test.mjs
- npm run validate