### PR TITLE
chore: finalize gitcrawl 451 job

### DIFF
--- a/jobs/openclaw/outbox/finalized/gitcrawl-451-autonomous-terminal-gap.md
+++ b/jobs/openclaw/outbox/finalized/gitcrawl-451-autonomous-terminal-gap.md
@@ -74,3 +74,8 @@ Open candidates:
 Existing-overlap context refs:
 
 - #86898 fix(context-engine): resolve turn-maintenance livelock on Telegram DM sessions (#77340)
+
+## Finalization
+
+- Replacement PR #93727 merged as `c1df7aa08be26d3df1773613cf53e155d871822b`.
+- Canonical issue #77340 was closed after the merge.


### PR DESCRIPTION
Finalizes the verified gitcrawl-451 queue entry after https://github.com/openclaw/openclaw/pull/93727 merged and https://github.com/openclaw/openclaw/issues/77340 closed.