### PR TITLE
fix(queue): recover publisher backlogs

### DIFF
--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -1,6 +1,8 @@
 name: publish cluster results
 
 on:
+  schedule:
+    - cron: "*/10 * * * *"
   workflow_dispatch:
     inputs:
       run_id:

--- a/scripts/dispatch-jobs.mjs
+++ b/scripts/dispatch-jobs.mjs
@@ -91,6 +91,14 @@ const publishBacklogThreshold = Number(
 const publishBacklogLookback = Number(
   args["publish-backlog-lookback"] ?? process.env.CLOWNFISH_PUBLISH_BACKLOG_LOOKBACK ?? 500,
 );
+const publishBacklogWaitMs = numberArg(
+  args["publish-backlog-wait-ms"] ?? process.env.CLOWNFISH_PUBLISH_BACKLOG_WAIT_MS ?? 600_000,
+  "publish-backlog-wait-ms",
+);
+const publishBacklogPollMs = positiveNumberArg(
+  args["publish-backlog-poll-ms"] ?? process.env.CLOWNFISH_PUBLISH_BACKLOG_POLL_MS ?? 30_000,
+  "publish-backlog-poll-ms",
+);
 const skipPublishBacklogCheck = Boolean(args["skip-publish-backlog-check"]);
 const skipTokenSecretCheck = Boolean(args["skip-token-secret-check"] ?? args.skip_token_secret_check);
 const allowAppTokenAuth = Boolean(
@@ -123,7 +131,7 @@ const headSha = currentHeadSha();
 
 if (files.length === 0) {
   console.error(
-    "usage: node scripts/dispatch-jobs.mjs <job.md> [...] [--jobs-file path] [--mode plan|execute|autonomous] [--runner label] [--execution-runner label] [--model model] [--gh-bin ghx] [--max-live-workers 50] [--wait-for-capacity] [--batch-size N] [--batch-delay-ms N] [--dispatch-limit N] [--dispatch-concurrency N] [--dispatch-event workflow|repository-worker|repository-batch] [--batch-max-parallel N] [--publish-backlog-threshold 25] [--hydrate-comments 0|1] [--max-linked-refs N] [--dry-run 0|1] [--allow-app-token-auth] [--skip-token-secret-check]",
+    "usage: node scripts/dispatch-jobs.mjs <job.md> [...] [--jobs-file path] [--mode plan|execute|autonomous] [--runner label] [--execution-runner label] [--model model] [--gh-bin ghx] [--max-live-workers 50] [--wait-for-capacity] [--batch-size N] [--batch-delay-ms N] [--dispatch-limit N] [--dispatch-concurrency N] [--dispatch-event workflow|repository-worker|repository-batch] [--batch-max-parallel N] [--publish-backlog-threshold 25] [--publish-backlog-wait-ms 600000] [--publish-backlog-poll-ms 30000] [--hydrate-comments 0|1] [--max-linked-refs N] [--dry-run 0|1] [--allow-app-token-auth] [--skip-token-secret-check]",
   );
   process.exit(2);
 }
@@ -226,7 +234,38 @@ if (!failed) {
 }
 
 function assertPublishBacklog() {
-  const result = spawnSync(
+  let result = readPublishBacklog();
+  if (result.status === 0) {
+    writePublishBacklogOutput(result);
+    return;
+  }
+  if (!waitForCapacity || publishBacklogWaitMs === 0) {
+    writePublishBacklogOutput(result);
+    failed = true;
+    return;
+  }
+
+  const startedAt = Date.now();
+  const deadline = startedAt + publishBacklogWaitMs;
+  const initial = publishBacklogSummary(result);
+  console.log(
+    `publish backlog ${initial?.missing_count ?? "unknown"} exceeds threshold ${publishBacklogThreshold}; waiting up to ${publishBacklogWaitMs}ms for publisher reconciliation`,
+  );
+  while (Date.now() < deadline) {
+    sleepMs(Math.min(publishBacklogPollMs, deadline - Date.now()));
+    result = readPublishBacklog();
+    if (result.status === 0) {
+      writePublishBacklogOutput(result);
+      console.log(`publish backlog drained after ${Date.now() - startedAt}ms`);
+      return;
+    }
+  }
+  writePublishBacklogOutput(result);
+  failed = true;
+}
+
+function readPublishBacklog() {
+  return spawnSync(
     process.execPath,
     [
       path.join(repoRoot(), "scripts", "publish-backlog.mjs"),
@@ -246,11 +285,19 @@ function assertPublishBacklog() {
     ],
     { cwd: repoRoot(), encoding: "utf8", stdio: "pipe" },
   );
+}
+
+function publishBacklogSummary(result) {
+  try {
+    return JSON.parse(String(result.stdout ?? ""));
+  } catch {
+    return null;
+  }
+}
+
+function writePublishBacklogOutput(result) {
   if (result.stdout) process.stdout.write(result.stdout);
   if (result.stderr) process.stderr.write(result.stderr);
-  if (result.status !== 0) {
-    failed = true;
-  }
 }
 
 let dispatched = 0;

--- a/test/dispatch-jobs-publish-backlog.test.mjs
+++ b/test/dispatch-jobs-publish-backlog.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("throttled dispatch waits for a transient publisher backlog", () => {
+  const fixture = makeFixture();
+  writeFakeGhx(fixture);
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "scripts/dispatch-jobs.mjs",
+      "jobs/openclaw/inbox/cluster-example.md",
+      "--mode",
+      "plan",
+      "--gh-bin",
+      fixture.gh,
+      "--skip-token-secret-check",
+      "--no-dispatch-ledger",
+      "--wait-for-capacity",
+      "--batch-size",
+      "1",
+      "--batch-delay-ms",
+      "1",
+      "--publish-backlog-threshold",
+      "0",
+      "--publish-backlog-wait-ms",
+      "100",
+      "--publish-backlog-poll-ms",
+      "1",
+    ],
+    { cwd: repoRoot, encoding: "utf8", env: { ...process.env, FAKE_GHX_STATE: fixture.state } },
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /waiting up to 100ms for publisher reconciliation/);
+  assert.match(result.stdout, /publish backlog drained after/);
+  assert.match(result.stdout, /dispatched 1\/1 jobs\/openclaw\/inbox\/cluster-example\.md/);
+});
+
+function makeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-dispatch-publish-backlog-"));
+  return {
+    gh: path.join(root, "fake-ghx.mjs"),
+    state: path.join(root, "state"),
+  };
+}
+
+function writeFakeGhx(fixture) {
+  fs.writeFileSync(
+    fixture.gh,
+    `#!/usr/bin/env node
+import fs from "node:fs";
+
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  console.log("fake-ghx 1.0");
+  process.exit(0);
+}
+if (args[0] === "run" && args[1] === "list") {
+  const state = process.env.FAKE_GHX_STATE;
+  const count = fs.existsSync(state) ? Number(fs.readFileSync(state, "utf8")) : 0;
+  fs.writeFileSync(state, String(count + 1));
+  if (count === 0) {
+    console.log(JSON.stringify([{ databaseId: 999991, status: "completed", conclusion: "success" }]));
+  } else {
+    console.log("[]");
+  }
+  process.exit(0);
+}
+if (args[0] === "api") {
+  console.log("[]");
+  process.exit(0);
+}
+if (args[0] === "workflow" && args[1] === "run") process.exit(0);
+console.error("unexpected fake ghx args: " + args.join(" "));
+process.exit(1);
+`,
+    { mode: 0o755 },
+  );
+}


### PR DESCRIPTION
## Summary
- reconcile worker result publishing every 10 minutes
- let throttled dispatches wait through a bounded transient publish backlog
- cover backlog drain behavior with a focused dispatcher test

## Validation
- npm test
- npm run validate