### PR TITLE
chore(queue): add fresh PR inventory shards

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260616T224810-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260616T224810-001.md
@@ -1,0 +1,104 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260616T224810-001
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - maintainer_signal
+  - active_author_followup
+  - green_checks
+  - focused_bug_fix
+  - technical_correctness_judgment
+canonical: []
+candidates:
+  - "#93701"
+  - "#93702"
+  - "#93699"
+  - "#93703"
+  - "#93700"
+cluster_refs:
+  - "#93701"
+  - "#93702"
+  - "#93699"
+  - "#93703"
+  - "#93700"
+security_policy: central_security_only
+security_sensitive: false
+canonical_hint: "This is a live PR inventory shard over currently untracked open PRs, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-16T22:48:10.806Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 1
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #93701 fix: graceful fallback when schtasks /Run fails on Windows
+
+- bucket: needs_proof
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-16T16:29:08Z
+- live url: https://github.com/openclaw/openclaw/pull/93701
+
+### #93702 fix(process-respawn): rewrite pnpm-versioned entrypoint to stable openclaw.mjs on detached respawn
+
+- bucket: needs_proof
+- author: 1052326311
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-16T16:29:56Z
+- live url: https://github.com/openclaw/openclaw/pull/93702
+
+### #93699 fix(control-ui): apply seamColor bootstrap config
+
+- bucket: recent_active
+- author: goutamadwant
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: S, triage: blank-template, proof: supplied
+- live updated: 2026-06-16T16:32:27Z
+- live url: https://github.com/openclaw/openclaw/pull/93699
+
+### #93703 perf: reuse realpath cache across manifest registry index builds
+
+- bucket: needs_proof
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-16T16:32:38Z
+- live url: https://github.com/openclaw/openclaw/pull/93703
+
+### #93700 fix: report download path in browser click action result
+
+- bucket: needs_proof
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-16T16:55:29Z
+- live url: https://github.com/openclaw/openclaw/pull/93700

--- a/jobs/openclaw/inbox/live-pr-inventory-20260616T224810-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260616T224810-002.md
@@ -1,0 +1,104 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260616T224810-002
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - maintainer_signal
+  - active_author_followup
+  - green_checks
+  - focused_bug_fix
+  - technical_correctness_judgment
+canonical: []
+candidates:
+  - "#93735"
+  - "#93737"
+  - "#93739"
+  - "#93704"
+  - "#93733"
+cluster_refs:
+  - "#93735"
+  - "#93737"
+  - "#93739"
+  - "#93704"
+  - "#93733"
+security_policy: central_security_only
+security_sensitive: false
+canonical_hint: "This is a live PR inventory shard over currently untracked open PRs, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-16T22:48:10.807Z; bucket=maintainer_owned; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 2
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #93735 refactor: add restart recovery lifecycle seam
+
+- bucket: maintainer_owned
+- author: jalehman
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: scripts, agents, maintainer, size: M
+- live updated: 2026-06-16T18:02:46Z
+- live url: https://github.com/openclaw/openclaw/pull/93735
+
+### #93737 refactor: add session maintenance transaction seam
+
+- bucket: maintainer_owned
+- author: jalehman
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: maintainer, size: L
+- live updated: 2026-06-16T18:05:43Z
+- live url: https://github.com/openclaw/openclaw/pull/93737
+
+### #93739 refactor: add session patch projection seam
+
+- bucket: maintainer_owned
+- author: jalehman
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: gateway, scripts, maintainer, size: M
+- live updated: 2026-06-16T18:12:16Z
+- live url: https://github.com/openclaw/openclaw/pull/93739
+
+### #93704 refactor: add session cleanup lifecycle seam
+
+- bucket: maintainer_owned
+- author: jalehman
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: scripts, maintainer, size: L
+- live updated: 2026-06-16T18:14:42Z
+- live url: https://github.com/openclaw/openclaw/pull/93704
+
+### #93733 fix: add plugin host session cleanup seam
+
+- bucket: maintainer_owned
+- author: jalehman
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: scripts, maintainer, size: L
+- live updated: 2026-06-16T18:28:43Z
+- live url: https://github.com/openclaw/openclaw/pull/93733

--- a/jobs/openclaw/inbox/live-pr-inventory-20260616T224810-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260616T224810-003.md
@@ -1,0 +1,104 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260616T224810-003
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - maintainer_signal
+  - active_author_followup
+  - green_checks
+  - focused_bug_fix
+  - technical_correctness_judgment
+canonical: []
+candidates:
+  - "#93734"
+  - "#93713"
+  - "#93706"
+  - "#93779"
+  - "#93780"
+cluster_refs:
+  - "#93734"
+  - "#93713"
+  - "#93706"
+  - "#93779"
+  - "#93780"
+security_policy: central_security_only
+security_sensitive: false
+canonical_hint: "This is a live PR inventory shard over currently untracked open PRs, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-16T22:48:10.807Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 3
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #93734 refactor: add task session registry maintenance seam
+
+- bucket: maintainer_owned
+- author: jalehman
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: scripts, commands, maintainer, size: M
+- live updated: 2026-06-16T18:33:33Z
+- live url: https://github.com/openclaw/openclaw/pull/93734
+
+### #93713 fix: route deleted-agent session purge through lifecycle seam
+
+- bucket: maintainer_owned
+- author: jalehman
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: scripts, maintainer, size: S, P2, rating: silver shellfish, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-16T18:58:26Z
+- live url: https://github.com/openclaw/openclaw/pull/93713
+
+### #93706 fix(feishu): detect card JSON in plain message param for proactive sends (fixes #53486)
+
+- bucket: maintainer_owned
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: channel: feishu, size: S, proof: supplied, P2, rating: silver shellfish, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-16T19:01:58Z
+- live url: https://github.com/openclaw/openclaw/pull/93706
+
+### #93779 fix(webchat): skip textarea resize during IME composition to eliminate typing lag
+
+- bucket: recent_active
+- author: joelnishanth
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, proof: supplied
+- live updated: 2026-06-16T21:04:49Z
+- live url: https://github.com/openclaw/openclaw/pull/93779
+
+### #93780 fix(google): keep parallel Gemini tool responses in the turn after the model
+
+- bucket: needs_proof
+- author: yetval
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: mock-only-proof, P1, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-16T21:36:54Z
+- live url: https://github.com/openclaw/openclaw/pull/93780

--- a/jobs/openclaw/inbox/live-pr-inventory-20260616T224810-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260616T224810-004.md
@@ -1,0 +1,104 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260616T224810-004
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - maintainer_signal
+  - active_author_followup
+  - green_checks
+  - focused_bug_fix
+  - technical_correctness_judgment
+canonical: []
+candidates:
+  - "#93785"
+  - "#93772"
+  - "#93786"
+  - "#93783"
+  - "#93790"
+cluster_refs:
+  - "#93785"
+  - "#93772"
+  - "#93786"
+  - "#93783"
+  - "#93790"
+security_policy: central_security_only
+security_sensitive: false
+canonical_hint: "This is a live PR inventory shard over currently untracked open PRs, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-16T22:48:10.807Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 4
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #93785 fix(reasoning-tags): strip MiniMax `mm:` namespaced reasoning tags
+
+- bucket: needs_proof
+- author: manus-use
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-16T21:39:19Z
+- live url: https://github.com/openclaw/openclaw/pull/93785
+
+### #93772 fix(feishu): recover CJK filenames from JSON file_name field (fixes #81103)
+
+- bucket: maintainer_owned
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: channel: feishu, size: XS, proof: supplied
+- live updated: 2026-06-16T21:41:58Z
+- live url: https://github.com/openclaw/openclaw/pull/93772
+
+### #93786 fix(plugins): treat refreshable catalogs as requiring runtime discovery (fixes #93775)
+
+- bucket: recent_active
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-16T21:45:04Z
+- live url: https://github.com/openclaw/openclaw/pull/93786
+
+### #93783 fix(qmd): strip mcporter daemon startup logs from stdout before JSON.parse (fixes #59808)
+
+- bucket: recent_active
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: XS, proof: supplied
+- live updated: 2026-06-16T21:58:04Z
+- live url: https://github.com/openclaw/openclaw/pull/93783
+
+### #93790 fix(slack): forward identity (username/icon) to chat.update for edited messages (fixes #58737)
+
+- bucket: recent_active
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: slack, size: XS, proof: supplied
+- live updated: 2026-06-16T22:12:54Z
+- live url: https://github.com/openclaw/openclaw/pull/93790

--- a/jobs/openclaw/inbox/live-pr-inventory-20260616T224810-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260616T224810-005.md
@@ -1,0 +1,104 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260616T224810-005
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - maintainer_signal
+  - active_author_followup
+  - green_checks
+  - focused_bug_fix
+  - technical_correctness_judgment
+canonical: []
+candidates:
+  - "#93791"
+  - "#93788"
+  - "#93787"
+  - "#93789"
+  - "#93792"
+cluster_refs:
+  - "#93791"
+  - "#93788"
+  - "#93787"
+  - "#93789"
+  - "#93792"
+security_policy: central_security_only
+security_sensitive: false
+canonical_hint: "This is a live PR inventory shard over currently untracked open PRs, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-16T22:48:10.807Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 5
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #93791 fix(memory): await search-sync before returning results to prevent stale index (fixes #52115)
+
+- bucket: recent_active
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: XS, proof: supplied
+- live updated: 2026-06-16T22:19:39Z
+- live url: https://github.com/openclaw/openclaw/pull/93791
+
+### #93788 docs: add ClawHub trust pages to sidebar
+
+- bucket: ready_for_maintainer
+- author: vyctorbrzezowski
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, triage: docs-discoverability, triage: needs-real-behavior-proof, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-16T22:20:29Z
+- live url: https://github.com/openclaw/openclaw/pull/93788
+
+### #93787 refactor(whatsapp): migrate admission object callers
+
+- bucket: maintainer_owned
+- author: mcaxtr
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: channel: whatsapp-web, maintainer, size: XL, P2, rating: silver shellfish, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-16T22:20:57Z
+- live url: https://github.com/openclaw/openclaw/pull/93787
+
+### #93789 fix(agents): make lane suspension consistent across cooldown-precheck and embedded-runner paths
+
+- bucket: needs_proof
+- author: joelnishanth
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: availability, status: needs proof
+- live updated: 2026-06-16T22:28:53Z
+- live url: https://github.com/openclaw/openclaw/pull/93789
+
+### #93792 [codex] Fix Android node approval wait state
+
+- bucket: recent_active
+- author: Solvely-Colin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: android, gateway, size: L, proof: supplied
+- live updated: 2026-06-16T22:41:17Z
+- live url: https://github.com/openclaw/openclaw/pull/93792

--- a/jobs/openclaw/inbox/live-pr-inventory-20260616T224810-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260616T224810-006.md
@@ -1,0 +1,78 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260616T224810-006
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - maintainer_signal
+  - active_author_followup
+  - green_checks
+  - focused_bug_fix
+  - technical_correctness_judgment
+canonical: []
+candidates:
+  - "#93784"
+  - "#93763"
+  - "#93773"
+cluster_refs:
+  - "#93784"
+  - "#93763"
+  - "#93773"
+security_policy: central_security_only
+security_sensitive: false
+canonical_hint: "This is a live PR inventory shard over currently untracked open PRs, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-16T22:48:10.807Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 6
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #93784 fix(status): show 0/1.0m instead of ?/1.0m on fresh session
+
+- bucket: needs_proof
+- author: manus-use
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-16T22:47:01Z
+- live url: https://github.com/openclaw/openclaw/pull/93784
+
+### #93763 fix(agents): neutral billing-error copy for OAuth/subscription auth instead of "top up API key" [AI-assisted]
+
+- bucket: maintainer_owned
+- author: eldar702
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: agents, size: M, proof: supplied
+- live updated: 2026-06-16T22:47:37Z
+- live url: https://github.com/openclaw/openclaw/pull/93763
+
+### #93773 fix(ui): scope Skill Workshop proposals to selected agent
+
+- bucket: maintainer_owned
+- author: TurboTheTurtle
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: app: web-ui, size: M, proof: supplied
+- live updated: 2026-06-16T22:48:08Z
+- live url: https://github.com/openclaw/openclaw/pull/93773


### PR DESCRIPTION
## Summary
- add six plan-only inventory shards for 28 newly tracked open OpenClaw PRs
- retain conservative close/comment/label-only action boundaries

## Validation
- npm run validate