### PR TITLE
fix(queue): prioritize fresh close candidates

### DIFF
--- a/jobs/openclaw/inbox/pr-close-canary-93785-fresh-inventory-close-20260617-a.md
+++ b/jobs/openclaw/inbox/pr-close-canary-93785-fresh-inventory-close-20260617-a.md
@@ -1,0 +1,59 @@
+---
+repo: openclaw/openclaw
+cluster_id: pr-close-canary-93785-fresh-inventory-close-20260617-a
+mode: execute
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#93767"
+candidates:
+  - "#93785"
+  - "#93767"
+cluster_refs:
+  - "#93785"
+  - "#93767"
+overlap_policy: "skip-any"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Close-only canary: #93785 was planned as fixed by merged #93767 in run 27653348272. Re-fetch live state and only close if #93785 remains open and #93767 is still merged. Because #93767 is already merged/closed, use candidate_fix rather than canonical for the close action."
+notes: "Generated from ProjectClownfish result live-pr-inventory-20260616T224810-004 after live refetch on 2026-06-16."
+---
+
+# PR Close Canary #93785
+
+## Goal
+
+Run one live close-only cleanup pass. Hydrate #93785 and #93767, then emit at most one planned close action for #93785. Do not merge, fix, raise a PR, or close the merged candidate.
+
+## Live Refetch Baseline
+
+- target: #93785 fix(reasoning-tags): strip MiniMax `mm:` namespaced reasoning tags
+- target live state at generation: OPEN
+- target updatedAt at generation: 2026-06-16T21:39:19Z
+- canonical/candidate: #93767 fix(reasoning-tags): strip MiniMax `mm:` namespaced reasoning tags
+- canonical/candidate live state at generation: MERGED
+- canonical/candidate mergedAt at generation: 2026-06-16T22:46:38Z
+- source result: results/runs/27653348272.json
+
+## Instructions
+
+If #93785 is still open and #93767 is still merged, prefer `close_fixed_by_candidate` with `candidate_fix: "#93767"` for #93785. Do not emit `close_superseded` with closed/merged #93767 in `canonical`; merged PRs are candidate fixes, not surviving open canonicals. Mention both PR/issue URLs in the close comment and preserve contributor/user context. If either live state changed, keep the target open or mark the exact blocker with `needs_human`.

--- a/scripts/import-close-canaries-from-results.mjs
+++ b/scripts/import-close-canaries-from-results.mjs
@@ -85,9 +85,18 @@ if (jsonOutput) {
 
 function collectPlannedCloseActions() {
   const items = [];
-  for (const file of fs.readdirSync(resultsDir).filter((entry) => entry.endsWith(".json")).sort()) {
-    const absolute = path.join(resultsDir, file);
-    const result = safeJsonFile(absolute);
+  const results = fs
+    .readdirSync(resultsDir)
+    .filter((entry) => entry.endsWith(".json"))
+    .map((file) => {
+      const absolute = path.join(resultsDir, file);
+      return { file, absolute, result: safeJsonFile(absolute) };
+    })
+    .sort((left, right) => {
+      const newest = Date.parse(right.result.published_at ?? "") - Date.parse(left.result.published_at ?? "");
+      return Number.isNaN(newest) || newest === 0 ? right.file.localeCompare(left.file) : newest;
+    });
+  for (const { file, absolute, result } of results) {
     const clusterId = String(result.cluster_id ?? result.clusterId ?? path.basename(file, ".json"));
     const actions = Array.isArray(result.actions) ? result.actions : [];
     for (const action of actions) {

--- a/test/import-close-canaries-from-results.test.mjs
+++ b/test/import-close-canaries-from-results.test.mjs
@@ -112,6 +112,51 @@ test("import-close-canaries writes open canonical duplicate closeouts", () => {
   assert.match(job, /Do not use `candidate_fix` for open canonical refs/);
 });
 
+test("import-close-canaries prioritizes newly published results before stale lexical run ids", () => {
+  const fixture = makeFixture();
+  for (let index = 1; index <= 5; index += 1) {
+    fs.writeFileSync(
+      path.join(fixture.results, `10000000000000${index}.json`),
+      JSON.stringify({
+        published_at: "2026-06-15T00:00:00.000Z",
+        actions: [{ target: `#9900${index}`, action: "close_superseded", status: "planned", canonical: "#74273" }],
+      }),
+    );
+  }
+  fs.writeFileSync(
+    path.join(fixture.results, "999.json"),
+    JSON.stringify({
+      published_at: "2026-06-16T23:07:18.007Z",
+      actions: [{ target: "#84902", action: "close_superseded", status: "planned", canonical: "#74273" }],
+    }),
+  );
+  writeFakeGhx(fixture.bin);
+
+  const run = spawnSync(
+    process.execPath,
+    [
+      "scripts/import-close-canaries-from-results.mjs",
+      "--results-dir",
+      fixture.results,
+      "--out",
+      fixture.inbox,
+      "--existing-dir",
+      fixture.existing,
+      "--limit",
+      "1",
+      "--live-fetch-limit",
+      "5",
+      "--suffix",
+      "newest",
+      "--json",
+    ],
+    { cwd: repoRoot, env: { ...process.env, PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}` }, encoding: "utf8" },
+  );
+
+  assert.equal(run.status, 0, run.stderr || run.stdout);
+  assert.deepEqual(JSON.parse(run.stdout).candidates.map((candidate) => candidate.target), ["#84902"]);
+});
+
 test("import-close-canaries quarantines security-shaped candidates before generation", () => {
   const fixture = makeFixture();
   fs.writeFileSync(


### PR DESCRIPTION
## Summary
- prioritize latest published result records when promoting close canaries
- add the verified `#93785` close-only canary against merged `#93767`

## Validation
- npm test
- npm run validate