### PR TITLE
chore(queue): add fresh PR intake shards

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260616T232308-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260616T232308-001.md
@@ -1,0 +1,78 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260616T232308-001
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - maintainer_signal
+  - active_author_followup
+  - green_checks
+  - focused_bug_fix
+  - technical_correctness_judgment
+canonical: []
+candidates:
+  - "#93802"
+  - "#93798"
+  - "#93795"
+cluster_refs:
+  - "#93802"
+  - "#93798"
+  - "#93795"
+security_policy: central_security_only
+security_sensitive: false
+canonical_hint: "These three fresh-session status PRs overlap around #93771. Compare their live behavior, diff scope, and proof before selecting any canonical path; do not invent one without current evidence."
+notes: "Generated from live GitHub open PR inventory on 2026-06-16T23:23:08.585Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 1
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #93802 fix(usage): show 0 instead of ? for fresh-session context tokens in /status
+
+- bucket: recent_active
+- author: lzyyzznl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-16T23:11:50Z
+- live url: https://github.com/openclaw/openclaw/pull/93802
+
+### #93798 fix(status): show 0 (not ?) for fresh-session context tokens
+
+- bucket: needs_proof
+- author: Alix-007
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-16T23:05:48Z
+- live url: https://github.com/openclaw/openclaw/pull/93798
+
+### #93795 fix(status): show 0/1.0m instead of ?/1.0m on fresh session (fixes #93771)
+
+- bucket: recent_active
+- author: zenglingbiao
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-16T23:04:49Z
+- live url: https://github.com/openclaw/openclaw/pull/93795

--- a/jobs/openclaw/inbox/live-pr-inventory-20260616T232308-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260616T232308-002.md
@@ -1,0 +1,78 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260616T232308-002
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - maintainer_signal
+  - active_author_followup
+  - green_checks
+  - focused_bug_fix
+  - technical_correctness_judgment
+canonical: []
+candidates:
+  - "#93797"
+  - "#93796"
+  - "#93800"
+cluster_refs:
+  - "#93797"
+  - "#93796"
+  - "#93800"
+security_policy: central_security_only
+security_sensitive: false
+canonical_hint: "This is a live PR inventory shard over currently untracked open PRs, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-16T23:23:08.586Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 2
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #93797 fix(browser): use openTab return value to prevent wsUrl race in ensureTabAvailable (fixes #63343)
+
+- bucket: recent_active
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-16T23:04:44Z
+- live url: https://github.com/openclaw/openclaw/pull/93797
+
+### #93796 fix(feishu): paginate wiki node and space listing (#37626)
+
+- bucket: draft
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: channel: feishu, size: M, triage: needs-real-behavior-proof
+- live updated: 2026-06-16T23:02:41Z
+- live url: https://github.com/openclaw/openclaw/pull/93796
+
+### #93800 fix(agents): serialize Claude live-session turns per key
+
+- bucket: needs_proof
+- author: NathanDai5287
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: refactor-only, triage: needs-real-behavior-proof
+- live updated: 2026-06-16T23:09:51Z
+- live url: https://github.com/openclaw/openclaw/pull/93800


### PR DESCRIPTION
## Summary
- add two plan-only live PR inventory shards for six newly opened OpenClaw PRs
- keep merge, fix, and replacement-PR actions blocked
- group the three overlapping fresh-session `/status` PRs for shared live comparison

## Validation
- live state refreshed for all six PRs
- `npm run validate` (5,356 jobs)
- `git diff --check`