### PR TITLE
fix(publish): skip empty worker artifacts

### DIFF
--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -24,7 +24,7 @@ on:
       conclusion:
         description: GitHub Actions conclusion to include, or any
         required: false
-        default: "any"
+        default: "success"
       order:
         description: newest or oldest missing runs first
         required: false
@@ -73,7 +73,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt || github.event.inputs.run_attempt || '1' }}
           BACKFILL_LIMIT: ${{ github.event.inputs.limit || vars.CLOWNFISH_PUBLISH_BACKFILL_LIMIT || '250' }}
           BACKFILL_LOOKBACK: ${{ github.event.inputs.lookback || vars.CLOWNFISH_PUBLISH_BACKFILL_LOOKBACK || '1200' }}
-          BACKFILL_CONCLUSION: ${{ github.event.inputs.conclusion || 'any' }}
+          BACKFILL_CONCLUSION: ${{ github.event.inputs.conclusion || 'success' }}
           BACKFILL_ORDER: ${{ github.event.inputs.order || 'newest' }}
           BACKFILL_WORKFLOW: ${{ github.event.workflow_run.name == 'cluster batch' && 'cluster-batch.yml' || 'cluster-worker.yml' }}
         run: |
@@ -109,6 +109,11 @@ jobs:
             npm run filter-reviewed-artifacts -- artifacts \
               --review-report artifacts/review-results.json \
               --runs-json artifacts/runs.json
+            if node -e 'const fs=require("node:fs"); const rows=JSON.parse(fs.readFileSync("artifacts/runs.json","utf8")); process.exit(rows.length === 0 ? 0 : 1)'; then
+              echo "has_results=false" >> "$GITHUB_OUTPUT"
+              echo "No review-passing cluster results to publish"
+              exit 0
+            fi
             set +e
             node scripts/review-results.mjs artifacts > artifacts/review-results.filtered.json
             review_status=$?

--- a/scripts/backfill-cluster-results.mjs
+++ b/scripts/backfill-cluster-results.mjs
@@ -56,6 +56,8 @@ for (const run of candidates) {
       artifact_name: downloaded.artifact_name,
       artifact_count: downloaded.artifact_count ?? null,
     });
+  } else if (downloaded.skipped) {
+    manifest.skipped.push({ ...summarizeRun(run), reason: downloaded.reason });
   } else {
     manifest.failed.push({ ...summarizeRun(run), reason: downloaded.reason });
   }
@@ -89,6 +91,7 @@ console.log(
       workflow,
       selected: candidates.length,
       downloaded: manifest.downloaded.length,
+      skipped: manifest.skipped.length,
       failed: manifest.failed.length,
       allow_partial: allowPartial,
       dry_run: dryRun,
@@ -168,7 +171,7 @@ function downloadRunArtifacts(run) {
   const artifactNames = listRunArtifactNames(runId);
   if (artifactNames.includes(artifactName)) {
     const specific = spawnGh(["run", "download", runId, "--repo", repo, "--name", artifactName, "--dir", destination]);
-    if (specific.status === 0) return { ok: true, dir: destination, artifact_name: artifactName };
+    if (specific.status === 0) return acceptResultArtifact(destination, { artifact_name: artifactName });
   }
 
   const matrixNames = artifactNames.filter((name) => name.startsWith(`${artifactName}-`));
@@ -184,7 +187,10 @@ function downloadRunArtifacts(run) {
       ...matrixNames.flatMap((name) => ["--name", name]),
     ]);
     if (matrix.status === 0) {
-      return { ok: true, dir: destination, artifact_name: `${artifactName}-*`, artifact_count: matrixNames.length };
+      return acceptResultArtifact(destination, {
+        artifact_name: `${artifactName}-*`,
+        artifact_count: matrixNames.length,
+      });
     }
     fs.rmSync(destination, { recursive: true, force: true });
     return {
@@ -203,7 +209,25 @@ function downloadRunArtifacts(run) {
   }
 
   removeWorkerArtifacts(destination);
-  return { ok: true, dir: destination, artifact_name: null };
+  return acceptResultArtifact(destination, { artifact_name: null });
+}
+
+function acceptResultArtifact(destination, details) {
+  if (containsResultArtifact(destination)) return { ok: true, dir: destination, ...details };
+  fs.rmSync(destination, { recursive: true, force: true });
+  return {
+    ok: false,
+    skipped: true,
+    reason: "downloaded artifacts did not contain result.json",
+  };
+}
+
+function containsResultArtifact(directory) {
+  for (const entry of fs.readdirSync(directory, { recursive: true })) {
+    const candidate = path.join(directory, String(entry));
+    if (path.basename(candidate) === "result.json" && fs.statSync(candidate).isFile()) return true;
+  }
+  return false;
 }
 
 function listRunArtifactNames(runId) {

--- a/scripts/filter-reviewed-artifacts.mjs
+++ b/scripts/filter-reviewed-artifacts.mjs
@@ -40,7 +40,7 @@ if (!Array.isArray(rows)) throw new Error(`runs json must be an array: ${runsJso
 const remainingRunIds = remainingResultRunIds(artifactDir);
 const filteredRows = rows.filter((row) => {
   const runId = String(row.run_id ?? row.databaseId ?? row.id ?? "");
-  return !failedRunIds.has(runId) || remainingRunIds.has(runId);
+  return remainingRunIds.has(runId);
 });
 fs.writeFileSync(runsJsonPath, `${JSON.stringify(filteredRows, null, 2)}\n`, "utf8");
 fs.writeFileSync(

--- a/test/publisher-artifact-recovery.test.mjs
+++ b/test/publisher-artifact-recovery.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("backfill skips worker-only downloads without result artifacts", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.bin);
+
+  const run = spawnSync(
+    process.execPath,
+    [
+      "scripts/backfill-cluster-results.mjs",
+      "--repo",
+      "openclaw/clownfish",
+      "--workflow",
+      "cluster-worker.yml",
+      "--limit",
+      "1",
+      "--lookback",
+      "1",
+      "--out",
+      fixture.artifacts,
+      "--runs-json",
+      fixture.runsJson,
+    ],
+    {
+      cwd: repoRoot,
+      env: { ...process.env, PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}` },
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(run.status, 0, run.stderr || run.stdout);
+  assert.deepEqual(JSON.parse(fs.readFileSync(fixture.runsJson, "utf8")), []);
+
+  const manifest = JSON.parse(fs.readFileSync(path.join(fixture.artifacts, "backfill-manifest.json"), "utf8"));
+  assert.equal(manifest.downloaded.length, 0);
+  assert.equal(manifest.skipped.length, 1);
+  assert.match(manifest.skipped[0].reason, /did not contain result\.json/);
+  assert.equal(fs.existsSync(path.join(fixture.artifacts, "projectclownfish-100-1")), false);
+});
+
+test("filter retains only runs with a surviving result artifact", () => {
+  const fixture = makeFixture();
+  const validResult = path.join(fixture.artifacts, "projectclownfish-100-1", "result.json");
+  const failedResult = path.join(fixture.artifacts, "projectclownfish-200-1", "result.json");
+  fs.mkdirSync(path.dirname(validResult), { recursive: true });
+  fs.mkdirSync(path.dirname(failedResult), { recursive: true });
+  fs.writeFileSync(validResult, "{}\n");
+  fs.writeFileSync(failedResult, "{}\n");
+  fs.writeFileSync(
+    fixture.runsJson,
+    `${JSON.stringify([{ run_id: "100" }, { run_id: "200" }, { run_id: "300" }], null, 2)}\n`,
+  );
+  fs.writeFileSync(
+    fixture.reviewReport,
+    `${JSON.stringify(
+      {
+        reports: [{ status: "failed", result: failedResult }],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const run = spawnSync(
+    process.execPath,
+    [
+      "scripts/filter-reviewed-artifacts.mjs",
+      fixture.artifacts,
+      "--review-report",
+      fixture.reviewReport,
+      "--runs-json",
+      fixture.runsJson,
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+
+  assert.equal(run.status, 0, run.stderr || run.stdout);
+  assert.deepEqual(JSON.parse(fs.readFileSync(fixture.runsJson, "utf8")), [{ run_id: "100" }]);
+  assert.equal(fs.existsSync(`${failedResult}.failed`), true);
+});
+
+test("publisher defaults to successful runs and exits before reviewing an empty filtered set", () => {
+  const workflow = fs.readFileSync(path.join(repoRoot, ".github/workflows/publish-results.yml"), "utf8");
+
+  assert.match(workflow, /default: "success"/);
+  assert.match(workflow, /BACKFILL_CONCLUSION: \${{ github\.event\.inputs\.conclusion \|\| 'success' }}/);
+  assert.match(
+    workflow,
+    /filter-reviewed-artifacts[\s\S]*No review-passing cluster results to publish[\s\S]*review-results\.filtered\.json/,
+  );
+});
+
+function makeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-publisher-"));
+  const artifacts = path.join(root, "artifacts");
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(artifacts, { recursive: true });
+  fs.mkdirSync(bin, { recursive: true });
+  return {
+    artifacts,
+    bin,
+    reviewReport: path.join(artifacts, "review-results.json"),
+    runsJson: path.join(artifacts, "runs.json"),
+  };
+}
+
+function writeFakeGh(bin) {
+  const script = `#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+if (args[0] === "run" && args[1] === "list") {
+  process.stdout.write(JSON.stringify([{
+    databaseId: 100,
+    status: "completed",
+    conclusion: "success",
+    createdAt: "2026-06-16T00:00:00Z",
+    updatedAt: "2026-06-16T00:01:00Z",
+    headSha: "abc",
+    url: "https://example.invalid/runs/100"
+  }]));
+  process.exit(0);
+}
+if (args[0] === "api") {
+  process.stdout.write(JSON.stringify([{ artifacts: [{ name: "projectclownfish-worker-100-1", expired: false }] }]));
+  process.exit(0);
+}
+if (args[0] === "run" && args[1] === "download") {
+  const destination = args[args.indexOf("--dir") + 1];
+  fs.mkdirSync(path.join(destination, "projectclownfish-worker-100-1"), { recursive: true });
+  fs.writeFileSync(path.join(destination, "projectclownfish-worker-100-1", "worker.json"), "{}\\n");
+  process.exit(0);
+}
+process.stderr.write(\`unexpected gh invocation: \${args.join(" ")}\\n\`);
+process.exit(1);
+`;
+  const file = path.join(bin, "gh");
+  fs.writeFileSync(file, script, { mode: 0o755 });
+}


### PR DESCRIPTION
## Summary
- accept backfilled artifacts only when they contain `result.json`
- keep the publish ledger aligned with surviving review artifacts
- default publisher backfills to successful workers and exit cleanly after an empty filter

## Verification
- `npm test`
- `npm run validate`
- `node --test test/publisher-artifact-recovery.test.mjs`