### PR TITLE
fix(publisher): account for batch child results

### DIFF
--- a/scripts/backfill-cluster-results.mjs
+++ b/scripts/backfill-cluster-results.mjs
@@ -19,6 +19,9 @@ const requestedRunId = args["run-id"] ? String(args["run-id"]) : "";
 const requestedRunAttempt = args["run-attempt"] ? String(args["run-attempt"]) : "1";
 const dryRun = Boolean(args["dry-run"]);
 const allowPartial = Boolean(args["allow-partial"]) || process.env.CLOWNFISH_BACKFILL_ALLOW_PARTIAL === "1";
+const batchChildRunIds = new Map();
+const runAttempts = new Map();
+const artifactNamesByRunId = new Map();
 
 if (since !== null && Number.isNaN(since)) throw new Error("--since must be an ISO-compatible timestamp");
 if (!["success", "failure", "cancelled", "timed_out", "action_required", "neutral", "skipped", "any"].includes(conclusion)) {
@@ -112,7 +115,7 @@ function selectCandidates(runs, requested) {
   if (requested) byId.set(String(requested.databaseId), requested);
   for (const run of runs) {
     const id = String(run.databaseId);
-    if (!id || publishedRunIds.has(id)) continue;
+    if (!id || isPublishedRun(run, publishedRunIds)) continue;
     if (since !== null && Date.parse(run.createdAt ?? "") < since) continue;
     if (run.status !== "completed") continue;
     if (conclusion !== "any" && run.conclusion !== conclusion) continue;
@@ -162,7 +165,7 @@ function sortRuns(runs) {
 
 function downloadRunArtifacts(run) {
   const runId = String(run.databaseId);
-  const runAttempt = String(run.runAttempt ?? "1");
+  const runAttempt = selectedRunAttempt(run);
   const artifactName = `projectclownfish-${runId}-${runAttempt}`;
   const destination = path.join(outDir, artifactName);
   fs.rmSync(destination, { recursive: true, force: true });
@@ -231,13 +234,15 @@ function containsResultArtifact(directory) {
 }
 
 function listRunArtifactNames(runId) {
+  const cached = artifactNamesByRunId.get(runId);
+  if (cached) return cached;
   const pages = ghJson([
     "api",
     `repos/${repo}/actions/runs/${runId}/artifacts?per_page=100`,
     "--paginate",
     "--slurp",
   ]);
-  return [
+  const names = [
     ...new Set(
       (Array.isArray(pages) ? pages : [])
         .flatMap((page) => (Array.isArray(page?.artifacts) ? page.artifacts : []))
@@ -246,6 +251,8 @@ function listRunArtifactNames(runId) {
         .filter(Boolean),
     ),
   ];
+  artifactNamesByRunId.set(runId, names);
+  return names;
 }
 
 function removeWorkerArtifacts(directory) {
@@ -255,6 +262,53 @@ function removeWorkerArtifacts(directory) {
       fs.rmSync(candidate, { recursive: true, force: true });
     }
   }
+}
+
+function isPublishedRun(run, publishedRunIds) {
+  if (workflow !== "cluster-batch.yml") return publishedRunIds.has(String(run.databaseId));
+
+  const expected = expectedBatchChildRunIds(run);
+  return expected.length > 0 && expected.every((runId) => publishedRunIds.has(runId));
+}
+
+function expectedBatchChildRunIds(run) {
+  const runId = String(run.databaseId);
+  const runAttempt = selectedRunAttempt(run);
+  const cacheKey = `${runId}-${runAttempt}`;
+  const cached = batchChildRunIds.get(cacheKey);
+  if (cached) return cached;
+
+  const prefix = `projectclownfish-${runId}-${runAttempt}-`;
+  const expected = [
+    ...new Set(
+      listRunArtifactNames(runId)
+        .filter((name) => name.startsWith(prefix))
+        .map((name) => name.slice(prefix.length))
+        .filter((matrixIndex) => /^\d+$/.test(matrixIndex))
+        .map((matrixIndex) => `${runId}-${runAttempt}-${matrixIndex}`),
+    ),
+  ];
+  batchChildRunIds.set(cacheKey, expected);
+  return expected;
+}
+
+function selectedRunAttempt(run) {
+  if (workflow !== "cluster-batch.yml") return String(run.runAttempt ?? run.run_attempt ?? run.attempt ?? "1");
+
+  const listed = run.runAttempt ?? run.run_attempt ?? run.attempt;
+  if (/^\d+$/.test(String(listed ?? ""))) return String(listed);
+
+  const runId = String(run.databaseId);
+  const cached = runAttempts.get(runId);
+  if (cached) return cached;
+
+  const details = ghJson(["api", `repos/${repo}/actions/runs/${runId}`]);
+  const runAttempt = String(details?.run_attempt ?? details?.runAttempt ?? "");
+  if (!/^\d+$/.test(runAttempt)) {
+    throw new Error(`could not determine run attempt for cluster-batch wrapper ${runId}`);
+  }
+  runAttempts.set(runId, runAttempt);
+  return runAttempt;
 }
 
 function readPublishedRunIds() {
@@ -271,7 +325,7 @@ function readPublishedRunIds() {
 function summarizeRun(run) {
   return {
     databaseId: String(run.databaseId),
-    runAttempt: String(run.runAttempt ?? "1"),
+    runAttempt: workflow === "cluster-batch.yml" ? selectedRunAttempt(run) : String(run.runAttempt ?? "1"),
     status: run.status ?? null,
     conclusion: run.conclusion ?? null,
     createdAt: run.createdAt ?? null,

--- a/scripts/publish-backlog.mjs
+++ b/scripts/publish-backlog.mjs
@@ -15,6 +15,8 @@ const fetch = args.fetch !== false && args.fetch !== "false";
 const ghCommand = String(args["gh-bin"] ?? args.gh_bin ?? process.env.CLOWNFISH_GH_BIN ?? firstAvailableCommand(["ghx", "gh"]));
 const ghRetries = numberArg("gh-retries", Number(process.env.CLOWNFISH_GH_RETRIES ?? 4));
 const ghRetryBaseMs = numberArg("gh-retry-base-ms", Number(process.env.CLOWNFISH_GH_RETRY_BASE_MS ?? 1500));
+const batchChildRunIds = new Map();
+const runAttempts = new Map();
 
 if (!["success", "failure", "cancelled", "timed_out", "action_required", "neutral", "skipped", "any"].includes(conclusion)) {
   throw new Error("--conclusion must be a GitHub Actions conclusion or any");
@@ -28,7 +30,7 @@ const publishedRunIds = readPublishedRunIds();
 const runs = listWorkflowRuns();
 const completed = runs.filter((run) => run.status === "completed");
 const selected = completed.filter((run) => conclusion === "any" || run.conclusion === conclusion);
-const missing = selected.filter((run) => !publishedRunIds.has(String(run.databaseId)));
+const missing = selected.filter((run) => !isPublishedRun(run, publishedRunIds));
 const summary = {
   repo,
   workflow,
@@ -103,6 +105,69 @@ function readPublishedRunIds() {
       .filter((name) => name.endsWith(".json"))
       .map((name) => path.basename(name, ".json")),
   );
+}
+
+function isPublishedRun(run, publishedRunIds) {
+  if (workflow !== "cluster-batch.yml") return publishedRunIds.has(String(run.databaseId));
+
+  const expected = expectedBatchChildRunIds(run);
+  return expected.length > 0 && expected.every((runId) => publishedRunIds.has(runId));
+}
+
+function expectedBatchChildRunIds(run) {
+  const runId = String(run.databaseId);
+  const runAttempt = selectedRunAttempt(run);
+  const cacheKey = `${runId}-${runAttempt}`;
+  const cached = batchChildRunIds.get(cacheKey);
+  if (cached) return cached;
+
+  const prefix = `projectclownfish-${runId}-${runAttempt}-`;
+  const expected = [
+    ...new Set(
+      listRunArtifactNames(runId)
+        .filter((name) => name.startsWith(prefix))
+        .map((name) => name.slice(prefix.length))
+        .filter((matrixIndex) => /^\d+$/.test(matrixIndex))
+        .map((matrixIndex) => `${runId}-${runAttempt}-${matrixIndex}`),
+    ),
+  ];
+  batchChildRunIds.set(cacheKey, expected);
+  return expected;
+}
+
+function selectedRunAttempt(run) {
+  const listed = run.runAttempt ?? run.run_attempt ?? run.attempt;
+  if (/^\d+$/.test(String(listed ?? ""))) return String(listed);
+
+  const runId = String(run.databaseId);
+  const cached = runAttempts.get(runId);
+  if (cached) return cached;
+
+  const details = ghJson(["api", `repos/${repo}/actions/runs/${runId}`]);
+  const runAttempt = String(details?.run_attempt ?? details?.runAttempt ?? "");
+  if (!/^\d+$/.test(runAttempt)) {
+    throw new Error(`could not determine run attempt for cluster-batch wrapper ${runId}`);
+  }
+  runAttempts.set(runId, runAttempt);
+  return runAttempt;
+}
+
+function listRunArtifactNames(runId) {
+  const pages = ghJson([
+    "api",
+    `repos/${repo}/actions/runs/${runId}/artifacts?per_page=100`,
+    "--paginate",
+    "--slurp",
+  ]);
+  return [
+    ...new Set(
+      (Array.isArray(pages) ? pages : [])
+        .flatMap((page) => (Array.isArray(page?.artifacts) ? page.artifacts : []))
+        .filter((artifact) => artifact && !artifact.expired)
+        .map((artifact) => String(artifact.name ?? ""))
+        .filter(Boolean),
+    ),
+  ];
 }
 
 function ghJson(ghArgs) {

--- a/test/dispatch-jobs-publish-backlog.test.mjs
+++ b/test/dispatch-jobs-publish-backlog.test.mjs
@@ -43,11 +43,112 @@ test("throttled dispatch waits for a transient publisher backlog", () => {
   assert.match(result.stdout, /dispatched 1\/1 jobs\/openclaw\/inbox\/cluster-example\.md/);
 });
 
+test("publish backlog accepts a complete cluster batch", () => {
+  const result = runPublishBacklog({
+    workflow: "cluster-batch.yml",
+    runs: [completedRun(200)],
+    runAttemptsByRunId: { 200: 3 },
+    artifactsByRunId: {
+      200: [
+        "projectclownfish-200-3-0",
+        "projectclownfish-200-3-1",
+        "projectclownfish-200-3-2",
+      ],
+    },
+    publishedRunIds: ["200-3-0", "200-3-1", "200-3-2"],
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(JSON.parse(result.stdout).missing_count, 0);
+});
+
+test("publish backlog keeps a partial cluster batch missing", () => {
+  const result = runPublishBacklog({
+    workflow: "cluster-batch.yml",
+    runs: [completedRun(200, 3)],
+    artifactsByRunId: {
+      200: [
+        "projectclownfish-200-3-0",
+        "projectclownfish-200-3-1",
+        "projectclownfish-200-3-2",
+      ],
+    },
+    publishedRunIds: ["200-3-0", "200-3-2"],
+  });
+
+  assert.notEqual(result.status, 0);
+  const summary = JSON.parse(result.stdout);
+  assert.equal(summary.missing_count, 1);
+  assert.deepEqual(summary.missing_run_ids, ["200"]);
+});
+
+test("publish backlog keeps exact IDs for single cluster workers", () => {
+  const result = runPublishBacklog({
+    workflow: "cluster-worker.yml",
+    runs: [completedRun(300, 1)],
+    publishedRunIds: ["300-1-0"],
+  });
+
+  assert.notEqual(result.status, 0);
+  const summary = JSON.parse(result.stdout);
+  assert.equal(summary.missing_count, 1);
+  assert.deepEqual(summary.missing_run_ids, ["300"]);
+});
+
 function makeFixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-dispatch-publish-backlog-"));
   return {
     gh: path.join(root, "fake-ghx.mjs"),
     state: path.join(root, "state"),
+  };
+}
+
+function runPublishBacklog({ workflow, runs, artifactsByRunId = {}, runAttemptsByRunId = {}, publishedRunIds }) {
+  const fixture = makeFixture();
+  writeFakeGhx(fixture);
+  writeFakeGit(fixture);
+
+  return spawnSync(
+    process.execPath,
+    [
+      "scripts/publish-backlog.mjs",
+      "--repo",
+      "openclaw/clownfish",
+      "--workflow",
+      workflow,
+      "--lookback",
+      "10",
+      "--conclusion",
+      "success",
+      "--threshold",
+      "0",
+      "--fetch",
+      "false",
+      "--gh-bin",
+      fixture.gh,
+      "--json",
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+        FAKE_GHX_RUNS: JSON.stringify(runs),
+        FAKE_GHX_ARTIFACTS: JSON.stringify(artifactsByRunId),
+        FAKE_GHX_RUN_ATTEMPTS: JSON.stringify(runAttemptsByRunId),
+        FAKE_GIT_PUBLISHED_RUN_IDS: JSON.stringify(publishedRunIds),
+      },
+    },
+  );
+}
+
+function completedRun(databaseId, runAttempt = undefined) {
+  return {
+    databaseId,
+    ...(runAttempt === undefined ? {} : { runAttempt }),
+    status: "completed",
+    conclusion: "success",
   };
 }
 
@@ -63,6 +164,10 @@ if (args[0] === "--version") {
   process.exit(0);
 }
 if (args[0] === "run" && args[1] === "list") {
+  if (process.env.FAKE_GHX_RUNS) {
+    console.log(process.env.FAKE_GHX_RUNS);
+    process.exit(0);
+  }
   const state = process.env.FAKE_GHX_STATE;
   const count = fs.existsSync(state) ? Number(fs.readFileSync(state, "utf8")) : 0;
   fs.writeFileSync(state, String(count + 1));
@@ -74,11 +179,41 @@ if (args[0] === "run" && args[1] === "list") {
   process.exit(0);
 }
 if (args[0] === "api") {
+  if (process.env.FAKE_GHX_ARTIFACTS) {
+    const endpoint = args.find((arg) => arg.includes("/actions/runs/"));
+    const runId = endpoint?.match(/\\/actions\\/runs\\/(\\d+)/)?.[1];
+    if (!endpoint?.includes("/artifacts")) {
+      console.log(JSON.stringify({ run_attempt: JSON.parse(process.env.FAKE_GHX_RUN_ATTEMPTS ?? "{}")[runId] ?? 1 }));
+      process.exit(0);
+    }
+    const artifacts = JSON.parse(process.env.FAKE_GHX_ARTIFACTS)[runId] ?? [];
+    console.log(JSON.stringify([{ artifacts: artifacts.map((name) => ({ name, expired: false })) }]));
+    process.exit(0);
+  }
   console.log("[]");
   process.exit(0);
 }
 if (args[0] === "workflow" && args[1] === "run") process.exit(0);
 console.error("unexpected fake ghx args: " + args.join(" "));
+process.exit(1);
+`,
+    { mode: 0o755 },
+  );
+}
+
+function writeFakeGit(fixture) {
+  fixture.bin = path.join(path.dirname(fixture.gh), "bin");
+  fs.mkdirSync(fixture.bin, { recursive: true });
+  fs.writeFileSync(
+    path.join(fixture.bin, "git"),
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "ls-tree") {
+  const runIds = JSON.parse(process.env.FAKE_GIT_PUBLISHED_RUN_IDS ?? "[]");
+  process.stdout.write(runIds.map((runId) => \`results/runs/\${runId}.json\`).join("\\n"));
+  process.exit(0);
+}
+process.stderr.write("unexpected git invocation: " + args.join(" ") + "\\n");
 process.exit(1);
 `,
     { mode: 0o755 },


### PR DESCRIPTION
Treat a cluster-batch wrapper as published only when all child result records exist. This prevents phantom publish backlog and redundant backfills. Tests cover complete and partial batches plus single-worker exact-ID behavior.