### PR TITLE
chore(queue): add bounded repair canaries

### DIFF
--- a/jobs/openclaw/inbox/repair-51868-qr-rendering.md
+++ b/jobs/openclaw/inbox/repair-51868-qr-rendering.md
@@ -1,0 +1,58 @@
+---
+repo: openclaw/openclaw
+cluster_id: repair-51868-qr-rendering
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - close
+  - fix
+  - raise_pr
+blocked_actions:
+  - merge
+require_human_for:
+  - merge
+canonical:
+  - #51868
+candidates:
+  - #51868
+cluster_refs:
+  - #51868
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: true
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: clownfish/repair-51868-qr-rendering
+source: clawsweeper
+---
+
+# ClawSweeper-promoted fix PR candidate
+
+ProjectClownfish should create or update one implementation PR from `clownfish/repair-51868-qr-rendering`.
+
+## Operator Prompt
+
+Repair #51868 only. Rehydrate the live PR and source diff. The source branch is uneditable and contains dirty unrelated drift, so create a narrow credited replacement only if the UTF-8 half-block QR rendering fix is still concrete and independently reproducible. Keep the replacement limited to the rendering defect; do not carry unrelated source changes. Do not merge, close, or mutate unrelated refs. Require focused OpenClaw-native validation and Codex review before opening a replacement PR.
+
+## Related Refs
+
+- #51868
+
+## Likely Files
+
+- unknown
+
+## Validation
+
+- choose the narrowest repo-native validation for the touched surface
+
+## Guardrails
+
+- Do not merge.
+- Do not close issues before a fix PR is opened, landed, or explicitly proven unnecessary.
+- Keep one PR for this cluster; reuse `clownfish/repair-51868-qr-rendering` if it already exists.
+- Preserve contributor credit and add a changelog entry when the target repo expects one.

--- a/jobs/openclaw/inbox/repair-92165-memory-dreaming.md
+++ b/jobs/openclaw/inbox/repair-92165-memory-dreaming.md
@@ -1,0 +1,61 @@
+---
+repo: openclaw/openclaw
+cluster_id: repair-92165-memory-dreaming
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - close
+  - fix
+  - raise_pr
+blocked_actions:
+  - merge
+require_human_for:
+  - merge
+canonical:
+  - #92165
+candidates:
+  - #92165
+  - #87637
+cluster_refs:
+  - #92165
+  - #87637
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: true
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: clownfish/repair-92165-memory-dreaming
+source: clawsweeper
+---
+
+# ClawSweeper-promoted fix PR candidate
+
+ProjectClownfish should create or update one implementation PR from `clownfish/repair-92165-memory-dreaming`.
+
+## Operator Prompt
+
+Repair #92165 for linked issue #87637 only. Rehydrate the live contributor PR and review threads, then make the narrowest safe repair for showing dreaming status without search. Preserve contributor intent and credit; update the contributor branch when safely editable, otherwise use a guarded credited replacement. Do not merge, close, or touch security-linked work. Require focused OpenClaw-native validation and Codex review before opening or updating a repair PR.
+
+## Related Refs
+
+- #92165
+- #87637
+
+## Likely Files
+
+- unknown
+
+## Validation
+
+- choose the narrowest repo-native validation for the touched surface
+
+## Guardrails
+
+- Do not merge.
+- Do not close issues before a fix PR is opened, landed, or explicitly proven unnecessary.
+- Keep one PR for this cluster; reuse `clownfish/repair-92165-memory-dreaming` if it already exists.
+- Preserve contributor credit and add a changelog entry when the target repo expects one.

--- a/jobs/openclaw/inbox/repair-93222-discord-timeout.md
+++ b/jobs/openclaw/inbox/repair-93222-discord-timeout.md
@@ -1,0 +1,58 @@
+---
+repo: openclaw/openclaw
+cluster_id: repair-93222-discord-timeout
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - close
+  - fix
+  - raise_pr
+blocked_actions:
+  - merge
+require_human_for:
+  - merge
+canonical:
+  - #93222
+candidates:
+  - #93222
+cluster_refs:
+  - #93222
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: true
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: clownfish/repair-93222-discord-timeout
+source: clawsweeper
+---
+
+# ClawSweeper-promoted fix PR candidate
+
+ProjectClownfish should create or update one implementation PR from `clownfish/repair-93222-discord-timeout`.
+
+## Operator Prompt
+
+Repair #93222 only. Rehydrate the live PR and review threads, then address the concrete review-bot finding in the configurable Discord REST API timeout change with the narrowest maintainer-editable patch. Preserve contributor credit and existing intent. Do not broaden configuration semantics, merge, close, or mutate any unrelated ref. Run the narrowest OpenClaw-native validation and Codex review before opening or updating a repair PR.
+
+## Related Refs
+
+- #93222
+
+## Likely Files
+
+- unknown
+
+## Validation
+
+- choose the narrowest repo-native validation for the touched surface
+
+## Guardrails
+
+- Do not merge.
+- Do not close issues before a fix PR is opened, landed, or explicitly proven unnecessary.
+- Keep one PR for this cluster; reuse `clownfish/repair-93222-discord-timeout` if it already exists.
+- Preserve contributor credit and add a changelog entry when the target repo expects one.


### PR DESCRIPTION
Add three isolated autonomous repair jobs for concrete current PR leads. Each prohibits merge and close actions, requires rehydration plus focused validation and review, and preserves contributor credit.