### PR TITLE
fix(executor): retain validation diagnostics

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -59,6 +59,10 @@ const closeSupersededSourcePrs = process.env.CLOWNFISH_CLOSE_SUPERSEDED_SOURCE_P
 const maxAutonomousFixFiles = Math.max(1, Number(process.env.CLOWNFISH_MAX_AUTONOMOUS_FIX_FILES ?? 8));
 const maxAutonomousFixSurfaces = Math.max(1, Number(process.env.CLOWNFISH_MAX_AUTONOMOUS_FIX_SURFACES ?? 4));
 const maxActivePrsPerArea = Number(process.env.CLOWNFISH_MAX_ACTIVE_PRS_PER_AREA ?? 50);
+const validationDebugOutputMaxChars = Math.max(
+  16 * 1024,
+  Number(process.env.CLOWNFISH_VALIDATION_DEBUG_OUTPUT_MAX_CHARS ?? 512 * 1024),
+);
 const CLOWNFISH_LABEL = "clownfish";
 const CLOWNFISH_LABEL_COLOR = "F97316";
 const CLOWNFISH_LABEL_DESCRIPTION = "Tracked by Clownfish automation";
@@ -81,6 +85,7 @@ let workRoot = "";
 let targetDir = "";
 let activeFixProgress = null;
 let writePreflight = null;
+let validationDebugSequence = 0;
 
 if (!jobPath) {
   console.error("usage: node scripts/execute-fix-artifact.mjs <job.md> [result.json] [--latest] [--dry-run]");
@@ -2060,7 +2065,7 @@ function runAllowedValidationCommands(commands, cwd, baseBranch = DEFAULT_BASE_B
       if (executed.includes(rendered)) continue;
       try {
         noteFixStage("validation_command_start", { command: rendered });
-        run(parts[0], parts.slice(1), { cwd, env: validationEnv });
+        runValidationCommand(parts, { cwd, env: validationEnv, rendered });
         executed.push(rendered);
         noteFixStage("validation_command_complete", { command: rendered });
       } catch (error) {
@@ -2070,7 +2075,12 @@ function runAllowedValidationCommands(commands, cwd, baseBranch = DEFAULT_BASE_B
             const fallbackRendered = fallbackParts.join(" ");
             if (executed.includes(fallbackRendered)) continue;
             noteFixStage("validation_command_start", { command: fallbackRendered, fallback: true });
-            run(fallbackParts[0], fallbackParts.slice(1), { cwd, env: validationEnv });
+            runValidationCommand(fallbackParts, {
+              cwd,
+              env: validationEnv,
+              rendered: fallbackRendered,
+              fallback: true,
+            });
             executed.push(fallbackRendered);
             noteFixStage("validation_command_complete", { command: fallbackRendered, fallback: true });
           }
@@ -2081,6 +2091,87 @@ function runAllowedValidationCommands(commands, cwd, baseBranch = DEFAULT_BASE_B
     }
   }
   return executed;
+}
+
+function runValidationCommand(parts, { cwd, env, rendered, fallback = false }) {
+  const timeoutMs = remainingFixExecutionMs(rendered, { minMs: 10 * 1000 });
+  const startedAt = new Date().toISOString();
+  const startedAtMs = Date.now();
+  const child = spawnSync(parts[0], parts.slice(1), {
+    cwd,
+    env,
+    encoding: "utf8",
+    timeout: timeoutMs,
+  });
+  const stdout = captureValidationDebugOutput(child.stdout);
+  const stderr = captureValidationDebugOutput(child.stderr);
+  const processError = child.error
+    ? {
+        code: child.error.code ?? null,
+        message: redactValidationDebugText(child.error.message),
+      }
+    : null;
+  writeValidationDebugRecord({
+    command: rendered,
+    argv: parts,
+    fallback,
+    started_at: startedAt,
+    duration_ms: Date.now() - startedAtMs,
+    timeout_ms: timeoutMs,
+    exit_code: child.status ?? null,
+    signal: child.signal ?? null,
+    timed_out: child.error?.code === "ETIMEDOUT",
+    error: processError,
+    stdout: stdout.text,
+    stdout_original_chars: stdout.originalChars,
+    stdout_truncated: stdout.truncated,
+    stderr: stderr.text,
+    stderr_original_chars: stderr.originalChars,
+    stderr_truncated: stderr.truncated,
+  });
+  if (child.error?.code === "ETIMEDOUT") {
+    throw new Error(`${rendered} timed out after ${timeoutMs}ms before fix execution deadline`);
+  }
+  if (child.error) throw child.error;
+  if (child.status !== 0) {
+    const detail = child.stderr || child.stdout || `${rendered} exited ${child.status}`;
+    throw new Error(String(detail).trim());
+  }
+}
+
+function writeValidationDebugRecord(record) {
+  if (!workRoot) return;
+  const sequence = String((validationDebugSequence += 1)).padStart(3, "0");
+  fs.writeFileSync(
+    path.join(workRoot, `validation-command-${sequence}.json`),
+    `${JSON.stringify(record, null, 2)}\n`,
+  );
+}
+
+function captureValidationDebugOutput(value) {
+  const text = redactValidationDebugText(value);
+  if (text.length <= validationDebugOutputMaxChars) {
+    return { text, originalChars: text.length, truncated: false };
+  }
+  const headLength = Math.floor(validationDebugOutputMaxChars * 0.75);
+  const tailLength = validationDebugOutputMaxChars - headLength;
+  return {
+    text: `${text.slice(0, headLength)}\n\n... [truncated ${text.length - validationDebugOutputMaxChars} chars] ...\n\n${text.slice(-tailLength)}`,
+    originalChars: text.length,
+    truncated: true,
+  };
+}
+
+function redactValidationDebugText(value) {
+  return String(value ?? "")
+    .replace(
+      /\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,})\b/g,
+      "[redacted]",
+    )
+    .replace(
+      /\b(authorization|bearer|token|api[_-]?key|password|secret)\b(\s*[:=]\s*)([^\s]+)/gi,
+      "$1$2[redacted]",
+    );
 }
 
 function preflightTargetValidationPlan({ fixArtifact, targetDir, baseBranch = DEFAULT_BASE_BRANCH }) {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -190,6 +190,95 @@ test("execute-fix-artifact rejects review-fix workers that leave no diff", () =>
   assert.match(source, /else if \(reviewFix\.head_changed\)/);
 });
 
+test("execute-fix-artifact preserves failed validation diagnostics in the uploaded debug artifacts", () => {
+  const fixture = makeFixture();
+  const resultPath = path.join(fixture.runDir, "result.json");
+  const reportPath = path.join(fixture.runDir, "fix-execution-report.json");
+
+  fs.writeFileSync(fixture.jobPath, jobFile("validation-debug-cluster"));
+  fs.writeFileSync(
+    resultPath,
+    `${JSON.stringify(
+      {
+        ...resultFile("validation-debug-cluster"),
+        fix_artifact: {
+          ...resultFile("validation-debug-cluster").fix_artifact,
+          validation_commands: ["pnpm check:changed"],
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeExecutable(
+    path.join(fixture.binDir, "codex"),
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+const cd = args[args.indexOf("--cd") + 1];
+const output = args.includes("--output-last-message") ? args[args.indexOf("--output-last-message") + 1] : "";
+fs.appendFileSync(path.join(cd, "src", "app.js"), "\\n// ProjectClownfish validation debug edit\\n");
+if (output) fs.writeFileSync(output, "edited\\n");
+`,
+  );
+  writeExecutable(
+    path.join(fixture.binDir, "pnpm"),
+    `#!/usr/bin/env node
+console.log("validation stdout token=ghp_abcdefghijklmnopqrstuvwxyz123456");
+console.error("validation stderr api_key=should-not-leak");
+process.exit(9);
+`,
+  );
+
+  const child = spawnSync(
+    process.execPath,
+    [
+      "scripts/execute-fix-artifact.mjs",
+      fixture.jobPath,
+      resultPath,
+      "--target-dir",
+      fixture.targetDir,
+      "--work-dir",
+      fixture.workDir,
+      "--report",
+      reportPath,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+        CLOWNFISH_ALLOW_EXECUTE: "1",
+        CLOWNFISH_ALLOW_FIX_PR: "1",
+        CLOWNFISH_FIX_STEP_TIMEOUT_MS: "120000",
+        CLOWNFISH_FIX_TIMEOUT_RESERVE_MS: "0",
+        CLOWNFISH_FIX_REPORT_RESERVE_MS: "0",
+        CLOWNFISH_INSTALL_TARGET_DEPS: "0",
+        CLOWNFISH_SKIP_CODEX_WRITE_PREFLIGHT: "1",
+        CLOWNFISH_CODEX_REVIEW_ATTEMPTS: "1",
+      },
+    },
+  );
+
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.actions[0].reason, /validation command failed/);
+  assert.match(report.debug_artifacts, /fix-executor-debug$/);
+
+  const diagnostics = JSON.parse(
+    fs.readFileSync(path.join(fixture.runDir, "fix-executor-debug", "validation-command-001.json"), "utf8"),
+  );
+  assert.equal(diagnostics.command, "pnpm check:changed");
+  assert.equal(diagnostics.exit_code, 9);
+  assert.equal(diagnostics.timed_out, false);
+  assert.match(diagnostics.stdout, /validation stdout token=\[redacted\]/);
+  assert.match(diagnostics.stderr, /api_key=\[redacted\]/);
+});
+
 function makeFixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-fix-exec-"));
   const binDir = path.join(root, "bin");


### PR DESCRIPTION
## Summary
- capture each validation command result in `fix-executor-debug`
- include redacted stdout/stderr, exit status, duration, and timeout state
- cover failed validation artifact capture end to end

## Validation
- `npm test`
- `git diff --check`