### PR TITLE
chore(queue): tighten 92165 repair retry

### DIFF
--- a/jobs/openclaw/inbox/repair-92165-memory-dreaming.md
+++ b/jobs/openclaw/inbox/repair-92165-memory-dreaming.md
@@ -3,14 +3,15 @@ repo: openclaw/openclaw
 cluster_id: repair-92165-memory-dreaming
 mode: autonomous
 allowed_actions:
-  - comment
-  - label
-  - close
   - fix
   - raise_pr
 blocked_actions:
+  - comment
+  - label
+  - close
   - merge
 require_human_for:
+  - close
   - merge
 canonical:
   - #92165
@@ -38,7 +39,15 @@ ProjectClownfish should create or update one implementation PR from `clownfish/r
 
 ## Operator Prompt
 
-Repair #92165 for linked issue #87637 only. Rehydrate the live contributor PR and review threads, then make the narrowest safe repair for showing dreaming status without search. Preserve contributor intent and credit; update the contributor branch when safely editable, otherwise use a guarded credited replacement. Do not merge, close, or touch security-linked work. Require focused OpenClaw-native validation and Codex review before opening or updating a repair PR.
+Repair #92165 for linked issue #87637 only. Rehydrate the live contributor PR and review threads, then make the narrowest safe repair for showing dreaming status without search. Preserve contributor intent and credit; update the contributor branch when safely editable, otherwise use a guarded credited replacement. Do not merge, close, comment on, label, or touch security-linked work. Require focused OpenClaw-native validation and Codex review before opening or updating a repair PR.
+
+The previous guarded execution reached the final `pnpm check:changed` gate and
+failed only in `src/commands/doctor-memory-search.test.ts`: three
+`DoctorMemoryDreamingPayload` fixture values inferred `storageMode` as `string`
+instead of the `"both" | "inline" | "separate"` union. Preserve the fixture
+literal type with the narrowest TypeScript-safe construction, then run the
+targeted test and `pnpm check:changed`. Do not relax production types or skip
+the changed gate.
 
 ## Related Refs
 
@@ -56,6 +65,7 @@ Repair #92165 for linked issue #87637 only. Rehydrate the live contributor PR an
 ## Guardrails
 
 - Do not merge.
+- Do not comment on, label, or close any issue or PR.
 - Do not close issues before a fix PR is opened, landed, or explicitly proven unnecessary.
 - Keep one PR for this cluster; reuse `clownfish/repair-92165-memory-dreaming` if it already exists.
 - Preserve contributor credit and add a changelog entry when the target repo expects one.


### PR DESCRIPTION
Carries the exact `pnpm check:changed` type failure into the #92165 repair job and narrows the retry to fix/PR actions only.

Validation: `npm run validate:job -- jobs/openclaw/inbox/repair-92165-memory-dreaming.md`; `npm run validate`.