### PR TITLE
fix: retry active PR capacity reads

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -1774,8 +1774,7 @@ function validateActivePrAreaCapacity({ fixArtifact, targetDir, branch }) {
 
 function listOpenClownfishPrAreas({ targetDir }) {
   const pulls = JSON.parse(
-    run(
-      "gh",
+    runGithubReadWithRetry(
       ["pr", "list", "--repo", result.repo, "--state", "open", "--limit", "500", "--json", "number,title,url,headRefName,labels"],
       { cwd: targetDir, env: ghEnv() },
     ),
@@ -1800,7 +1799,7 @@ function listOpenClownfishPrAreas({ targetDir }) {
 
 function fetchPullRequestFilePaths({ targetDir, number }) {
   const view = JSON.parse(
-    run("gh", ["pr", "view", String(number), "--repo", result.repo, "--json", "files"], {
+    runGithubReadWithRetry(["pr", "view", String(number), "--repo", result.repo, "--json", "files"], {
       cwd: targetDir,
       env: ghEnv(),
     }),

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -161,6 +161,8 @@ test("execute-fix-artifact retries transient GitHub reads before branch repair",
 
   assert.match(source, /const maxGithubReadAttempts = .*CLOWNFISH_GITHUB_READ_ATTEMPTS/);
   assert.match(source, /function fetchPullRequest\(number\)[\s\S]*runGithubReadWithRetry/);
+  assert.match(source, /function listOpenClownfishPrAreas\(\{ targetDir \}\)[\s\S]*?runGithubReadWithRetry/);
+  assert.match(source, /function fetchPullRequestFilePaths\(\{ targetDir, number \}\)[\s\S]*?runGithubReadWithRetry/);
   assert.match(source, /function runGithubReadWithRetry\(commandArgs, options = \{\}\)/);
   assert.match(source, /function isRetryableGithubReadError\(error\)/);
   assert.match(source, /HTTP\\s\+\(\?:408\|429\|5\\d\\d\)/);


### PR DESCRIPTION
Retries transient GitHub failures while checking active Clownfish PR capacity before opening a repair PR. Persistent failures remain blocking.