### PR TITLE
fix: record no-diff replacement outcomes

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -333,8 +333,23 @@ try {
       reason: "Codex produced no target repo changes; treating this allow_no_pr artifact as an audited no-PR outcome",
     };
   } else {
-    if (!isBlockedFixError(error)) throw error;
-    outcome = blockedFixOutcome(error, fixArtifact);
+    if (isBlockedFixError(error)) {
+      outcome = blockedFixOutcome(error, fixArtifact);
+    } else {
+      report.status = "failed";
+      report.reason = error.message;
+      if (!report.actions.some((action) => action.status === "failed")) {
+        report.actions.push({
+          ...(activeFixProgress ?? {}),
+          action: activeFixProgress?.action ?? "execute_fix",
+          status: "failed",
+          repair_strategy: activeFixProgress?.repair_strategy ?? fixArtifact.repair_strategy,
+          reason: error.message,
+        });
+      }
+      writeReport(report, resultPath);
+      throw error;
+    }
   }
 }
 
@@ -738,10 +753,26 @@ function executeReplacementBranch({ fixArtifact, targetDir, supersedeSources, fa
   }
 
   pushRecoverableBranch({ targetDir, branch });
+  const existingPrUrl = findOpenPullRequestForBranch(branch, targetDir);
+  if (!existingPrUrl && !branchHasBaseDiff({ targetDir, baseBranch })) {
+    return {
+      action: "open_fix_pr",
+      status: "skipped",
+      code: "no_diff_from_base",
+      reason: `replacement branch has no commits ahead of ${baseBranch}; no PR is needed`,
+      branch,
+      resumed_branch: branchState.resumed,
+      commit: prep.commit,
+      checkpoint_commits: prep.checkpoint_commits,
+      merge_preflight: prep.merge_preflight,
+      supersede_sources: supersedeSources ? fixArtifact.source_prs ?? [] : [],
+      contributor_credit: contributorCredits.map(publicContributorCredit),
+    };
+  }
   const bodyPath = path.join(workRoot, "replacement-pr-body.md");
   fs.writeFileSync(bodyPath, body);
   const prUrl =
-    findOpenPullRequestForBranch(branch, targetDir) ||
+    existingPrUrl ||
     run(
       "gh",
       ["pr", "create", "--repo", result.repo, "--base", baseBranch, "--head", branch, "--title", fixArtifact.pr_title, "--body-file", bodyPath],

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -168,6 +168,24 @@ test("execute-fix-artifact retries transient GitHub reads before branch repair",
   assert.match(source, /HTTP\\s\+\(\?:408\|429\|5\\d\\d\)/);
 });
 
+test("execute-fix-artifact records stale replacement branches as audited no-ops", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "execute-fix-artifact.mjs"), "utf8");
+
+  assert.match(source, /function executeReplacementBranch\([\s\S]*?const existingPrUrl = findOpenPullRequestForBranch\(branch, targetDir\);/);
+  assert.match(source, /if \(!existingPrUrl && !branchHasBaseDiff\(\{ targetDir, baseBranch \}\)\)/);
+  assert.match(source, /status: "skipped",\s*code: "no_diff_from_base"/);
+  assert.match(source, /existingPrUrl \|\|\s*run\(\s*"gh",\s*\["pr", "create"/);
+});
+
+test("execute-fix-artifact writes a report before unknown executor failures escape", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "execute-fix-artifact.mjs"), "utf8");
+
+  assert.match(
+    source,
+    /report\.status = "failed";[\s\S]*?report\.actions\.push\([\s\S]*?status: "failed",[\s\S]*?writeReport\(report, resultPath\);\s*throw error;/,
+  );
+});
+
 test("execute-fix-artifact fetches contributor repair heads through the base PR ref", () => {
   const source = fs.readFileSync(path.join(repoRoot, "scripts", "execute-fix-artifact.mjs"), "utf8");
   const repairFetch = source.match(


### PR DESCRIPTION
Treat a replacement branch that becomes identical to current base as an audited no-op, and persist reports for unexpected executor failures.