### PR TITLE
fix: reject non-plan jobs in batch dispatch

### DIFF
--- a/scripts/dispatch-jobs.mjs
+++ b/scripts/dispatch-jobs.mjs
@@ -195,6 +195,13 @@ for (const file of files) {
     for (const error of errors) console.error(`- ${error}`);
     continue;
   }
+  if (repositoryBatchDispatch && job.frontmatter.mode !== "plan") {
+    failed = true;
+    console.error(
+      `repository-batch only accepts job files with mode: plan; ${file} declares mode: ${job.frontmatter.mode}`,
+    );
+    continue;
+  }
 
   const relative = job.relativePath;
   if (!fs.existsSync(path.join(repoRoot(), relative))) {


### PR DESCRIPTION
Rejects non-plan job manifests before dispatching cluster-batch.yml, matching the workflow invariant and avoiding no-op failed batch runs.