### PR TITLE
fix: refresh repository dispatch base SHA

### DIFF
--- a/.github/workflows/cluster-worker.yml
+++ b/.github/workflows/cluster-worker.yml
@@ -173,17 +173,33 @@ jobs:
               if (!/^[0-9a-f]{40,64}$/i.test(requiredAncestor)) {
                 throw new Error(`invalid repository_dispatch required_ancestor_sha: ${requiredAncestor}`);
               }
-              spawnSync("git", ["fetch", "--no-tags", "--depth=100", "origin", "main"], {
+            const isShallow = execFileSync("git", ["rev-parse", "--is-shallow-repository"], {
+              encoding: "utf8",
+            }).trim() === "true";
+            const fetchMain = (args) => {
+              const result = spawnSync("git", args, {
                 encoding: "utf8",
                 stdio: "pipe",
               });
-              const ancestorCheck = spawnSync("git", ["merge-base", "--is-ancestor", requiredAncestor, "HEAD"], {
+              if (result.status !== 0) {
+                throw new Error(`failed to fetch origin/main: ${String(result.stderr ?? "").trim()}`);
+              }
+            };
+            fetchMain(["fetch", "--no-tags", ...(isShallow ? ["--deepen=250"] : []), "origin", "main"]);
+            let ancestorCheck = spawnSync("git", ["merge-base", "--is-ancestor", requiredAncestor, "HEAD"], {
+              encoding: "utf8",
+              stdio: "pipe",
+            });
+            if (ancestorCheck.status !== 0 && isShallow) {
+              fetchMain(["fetch", "--no-tags", "--unshallow", "origin", "main"]);
+              ancestorCheck = spawnSync("git", ["merge-base", "--is-ancestor", requiredAncestor, "HEAD"], {
                 encoding: "utf8",
                 stdio: "pipe",
               });
-              if (ancestorCheck.status !== 0) {
-                throw new Error(
-                  `stale repository_dispatch required_ancestor_sha ${requiredAncestor}; workflow checked out ${actualHead}`,
+            }
+            if (ancestorCheck.status !== 0) {
+              throw new Error(
+                `stale repository_dispatch required_ancestor_sha ${requiredAncestor}; workflow checked out ${actualHead}`,
                 );
               }
             } else if (expectedHead && expectedHead !== actualHead) {

--- a/scripts/dispatch-jobs.mjs
+++ b/scripts/dispatch-jobs.mjs
@@ -697,9 +697,7 @@ function readDispatchLedger() {
 }
 
 function currentHeadSha() {
-  const direct = gitRevision(ref || "origin/main");
-  if (direct) return direct;
-  if (!isMainRef(ref)) return "";
+  if (!isMainRef(ref)) return gitRevision(ref);
 
   try {
     execFileSync("git", ["fetch", "origin", "main", "--depth=1"], {

--- a/test/app-token-auth.test.mjs
+++ b/test/app-token-auth.test.mjs
@@ -149,6 +149,7 @@ test("dispatch supports repository-worker canary dispatch", () => {
   const fixture = makeFixture();
   writeFailingGh(fixture.bin, "gh");
   const fakeGhx = writeFakeGh(fixture.bin, "ghx");
+  writeShallowCheckoutGit(fixture.bin);
   const env = {
     ...process.env,
     PATH: `${fixture.bin}${path.delimiter}${process.env.PATH}`,
@@ -238,12 +239,64 @@ test("repository-worker dispatch fetches main when a shallow checkout lacks orig
   assert.match(result.stdout, /dispatched 1\/1/);
 });
 
+test("repository-worker dispatch refreshes an existing stale origin/main ref", () => {
+  const fixture = makeFixture();
+  writeFailingGh(fixture.bin, "gh");
+  const fakeGhx = writeFakeGh(fixture.bin, "ghx");
+  writeStaleMainGit(fixture.bin);
+  const env = {
+    ...process.env,
+    PATH: `${fixture.bin}${path.delimiter}${process.env.PATH}`,
+    EXPECT_REPOSITORY_WORKER_FIELDS: "1",
+    EXPECT_REQUIRED_ANCESTOR: "a".repeat(40),
+  };
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "scripts/dispatch-jobs.mjs",
+      "jobs/openclaw/inbox/cluster-example.md",
+      "--repo",
+      "openclaw/clownfish",
+      "--mode",
+      "autonomous",
+      "--dispatch-event",
+      "repository-worker",
+      "--ref",
+      "main",
+      "--gh-bin",
+      fakeGhx,
+      "--allow-app-token-auth",
+      "--skip-publish-backlog-check",
+      "--max-live-workers",
+      "1",
+      "--hydrate-comments",
+      "1",
+      "--max-linked-refs",
+      "20",
+      "--max-comments-per-item",
+      "30",
+      "--max-review-comments-per-pr",
+      "50",
+      "--dry-run",
+      "1",
+      "--no-dispatch-ledger",
+    ],
+    { cwd: repoRoot, encoding: "utf8", env },
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /dispatched 1\/1/);
+});
+
 test("cluster-worker repository dispatch guard accepts descendants", () => {
   const workflow = fs.readFileSync(path.join(repoRoot, ".github/workflows/cluster-worker.yml"), "utf8");
 
   assert.match(workflow, /required_ancestor_sha/);
   assert.match(workflow, /parsedPayload && typeof parsedPayload === "object" \? parsedPayload : {}/);
   assert.match(workflow, /spawnSync\("git", \["merge-base", "--is-ancestor", requiredAncestor, "HEAD"\]/);
+  assert.match(workflow, /--deepen=250/);
+  assert.match(workflow, /--unshallow/);
   assert.match(workflow, /repository_dispatch worker requires required_ancestor_sha or legacy head_sha/);
 });
 
@@ -340,6 +393,10 @@ if (args[0] === "api" && args.includes("repos/openclaw/clownfish/dispatches")) {
       console.error("missing required_ancestor_sha", JSON.stringify(payload));
       process.exit(1);
     }
+    if (process.env.EXPECT_REQUIRED_ANCESTOR && client.required_ancestor_sha !== process.env.EXPECT_REQUIRED_ANCESTOR) {
+      console.error("wrong required_ancestor_sha", client.required_ancestor_sha, "wanted", process.env.EXPECT_REQUIRED_ANCESTOR);
+      process.exit(1);
+    }
   }
   console.log("accepted repository dispatch");
   process.exit(0);
@@ -379,6 +436,29 @@ if (args[0] === "rev-parse" && args[1] === "origin/main") process.exit(1);
 if (args[0] === "fetch" && args[1] === "origin" && args[2] === "main") process.exit(0);
 if (args[0] === "rev-parse" && args[1] === "FETCH_HEAD") {
   console.log("${"a".repeat(40)}");
+  process.exit(0);
+}
+console.error("unexpected fake git call", args.join(" "));
+process.exit(1);
+`,
+  );
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
+function writeStaleMainGit(binDir) {
+  const filePath = path.join(binDir, "git");
+  fs.writeFileSync(
+    filePath,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "fetch" && args[1] === "origin" && args[2] === "main") process.exit(0);
+if (args[0] === "rev-parse" && args[1] === "FETCH_HEAD") {
+  console.log("${"a".repeat(40)}");
+  process.exit(0);
+}
+if (args[0] === "rev-parse" && args[1] === "origin/main") {
+  console.log("${"b".repeat(40)}");
   process.exit(0);
 }
 console.error("unexpected fake git call", args.join(" "));


### PR DESCRIPTION
Refresh `main` before repository-worker dispatches so the required ancestor reflects remote state.

When a shallow worker cannot establish an otherwise-valid ancestor, deepen then unshallow only for that exceptional guard retry.

Validation: `npm run validate`; `npm test`.