### PR TITLE
fix(apply): accept hydrated close evidence

### DIFF
--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -91,6 +91,8 @@ const allowedRefs = new Set(
     .map((ref) => normalizeIssueRef(ref, result.repo))
     .filter(Boolean),
 );
+const hydratedCloseRefs = hydratedPreflightCloseRefs(resultPath, result.repo);
+const allowedCloseRefs = new Set([...allowedRefs, ...hydratedCloseRefs]);
 const maintainerCloseRefs = new Set(
   (job.frontmatter.maintainer_close_refs ?? [])
     .map((ref) => normalizeIssueRef(ref, result.repo))
@@ -123,6 +125,27 @@ function findLatestResultPath() {
   candidates.sort((left, right) => right.mtimeMs - left.mtimeMs);
   if (!candidates[0]) throw new Error("no result.json files found");
   return candidates[0].path;
+}
+
+function hydratedPreflightCloseRefs(resultPath, repo) {
+  const planPath = path.join(path.dirname(resultPath), "cluster-plan.json");
+  if (!fs.existsSync(planPath)) return new Set();
+  const plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
+  return new Set(
+    (plan.items ?? [])
+      .filter(
+        (item) =>
+          item &&
+          !item.hydration_error &&
+          item.security_sensitive !== true &&
+          item.ref &&
+          item.kind &&
+          item.state &&
+          item.updated_at,
+      )
+      .map((item) => normalizeIssueRef(item.ref, repo))
+      .filter(Boolean),
+  );
 }
 
 function readFixExecutionReport() {
@@ -238,14 +261,14 @@ function applyCloseAction({
     return { ...base, status: "blocked", reason: "closure requires canonical or duplicate_of" };
   }
   const isPostMergeFixedClose = actionName === "post_merge_close" && classification === "fixed_by_candidate";
-  if (canonical && !allowedRefs.has(canonical) && !isPostMergeFixedClose) {
-    return { ...base, status: "blocked", reason: "canonical is not listed in job refs" };
+  if (canonical && !allowedCloseRefs.has(canonical) && !isPostMergeFixedClose) {
+    return { ...base, status: "blocked", reason: "canonical is not a hydrated close reference" };
   }
   if (classification === "fixed_by_candidate" && !candidateFix && !allowCurrentMainFixedClose) {
     return { ...base, status: "blocked", reason: "closure requires candidate_fix" };
   }
-  if (candidateFix && !allowedRefs.has(candidateFix) && !isPostMergeFixedClose) {
-    return { ...base, status: "blocked", reason: "candidate fix is not listed in job refs" };
+  if (candidateFix && !allowedCloseRefs.has(candidateFix) && !isPostMergeFixedClose) {
+    return { ...base, status: "blocked", reason: "candidate fix is not a hydrated close reference" };
   }
   if (actionName === "post_merge_close" || explicitSupersededByCandidate) {
     const candidateBlock = validateMergedCandidateFix(result.repo, candidateFix);

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -49,6 +49,84 @@ test("apply-result keeps fixed-by close blocked without explicit unmerged-fix op
   assert.match(report.actions[0].reason, /fixed_by_candidate close requires a merged fix PR/);
 });
 
+test("apply-result allows a candidate fix hydrated in the preflight plan", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeGhStub(binDir);
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, jobMarkdown({ allowUnmergedFixClose: true }));
+  fs.writeFileSync(resultPath, `${JSON.stringify(resultJsonWithHydratedCandidate(), null, 2)}\n`);
+  fs.writeFileSync(
+    path.join(tmp, "cluster-plan.json"),
+    `${JSON.stringify(
+      {
+        items: [
+          {
+            ref: "#60064",
+            kind: "pull_request",
+            state: "closed",
+            updated_at: "2026-06-11T05:07:30Z",
+            hydration_error: null,
+            security_sensitive: false,
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const result = apply(jobPath, resultPath, reportPath, binDir);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "planned");
+  assert.equal(report.actions[0].candidate_fix, "#60064");
+});
+
+test("apply-result blocks a candidate fix with failed preflight hydration", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeGhStub(binDir);
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, jobMarkdown({ allowUnmergedFixClose: true }));
+  fs.writeFileSync(resultPath, `${JSON.stringify(resultJsonWithHydratedCandidate(), null, 2)}\n`);
+  fs.writeFileSync(
+    path.join(tmp, "cluster-plan.json"),
+    `${JSON.stringify(
+      {
+        items: [
+          {
+            ref: "#60064",
+            kind: "pull_request",
+            state: "closed",
+            updated_at: "2026-06-11T05:07:30Z",
+            hydration_error: "pull request details unavailable",
+            security_sensitive: false,
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const result = apply(jobPath, resultPath, reportPath, binDir);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /candidate fix is not a hydrated close reference/);
+});
+
 test("apply-result treats closed target with matching marker as idempotently executed", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");
@@ -293,6 +371,28 @@ function resultJson() {
         target_updated_at: "2026-06-11T05:07:30Z",
         reason: "current main already contains the narrow streaming fix and regression coverage",
         idempotency_key: "openclaw/openclaw#60063:close_fixed_by_current_main:test",
+      },
+    ],
+  };
+}
+
+function resultJsonWithHydratedCandidate() {
+  return {
+    status: "planned",
+    repo: "openclaw/openclaw",
+    cluster_id: "ghcrawl-199237-agentic-merge",
+    mode: "autonomous",
+    summary: "a hydrated pull request contains the fix",
+    actions: [
+      {
+        target: "#60063",
+        action: "close_fixed_by_candidate",
+        status: "planned",
+        classification: "fixed_by_candidate",
+        candidate_fix: "#60064",
+        target_updated_at: "2026-06-11T05:07:30Z",
+        reason: "a hydrated pull request contains the narrow streaming fix and regression coverage",
+        idempotency_key: "openclaw/openclaw#60063:close_fixed_by_candidate:60064:test",
       },
     ],
   };


### PR DESCRIPTION
Allows canonical and candidate-fix refs for close actions when they are fully hydrated in the worker preflight plan and are not security-sensitive.\n\nThe target being closed remains constrained to the job's explicit candidate list.