### PR TITLE
fix(intake): filter protected close targets

### DIFF
--- a/scripts/import-close-canaries-from-results.mjs
+++ b/scripts/import-close-canaries-from-results.mjs
@@ -12,6 +12,7 @@ const CLOSE_ACTIONS = new Set([
   "close_superseded",
   "close_low_signal",
 ]);
+const PROTECTED_AUTHOR_ASSOCIATIONS = new Set(["MEMBER", "OWNER", "COLLABORATOR"]);
 
 const args = parseArgs(process.argv.slice(2));
 const repo = String(args.repo ?? "openclaw/openclaw");
@@ -183,6 +184,7 @@ ${numbers
         body
         state
         updatedAt
+        authorAssociation
         labels(first: 30) { nodes { name } }
       }
       ... on PullRequest {
@@ -193,6 +195,7 @@ ${numbers
         updatedAt
         mergedAt
         isDraft
+        authorAssociation
         labels(first: 30) { nodes { name } }
       }
     }`,
@@ -211,6 +214,7 @@ function normalizeLiveNode(node) {
     state: String(node.state ?? ""),
     updatedAt: node.updatedAt ?? null,
     mergedAt: node.mergedAt ?? null,
+    authorAssociation: node.authorAssociation ?? null,
     labels: (node.labels?.nodes ?? []).map((label) => String(label.name ?? "")).filter(Boolean),
   };
 }
@@ -219,10 +223,32 @@ function dropReasonFor(item, target, canonical) {
   if (!target) return "target not found";
   if (!canonical) return "canonical not found";
   if (target.state !== "OPEN") return `target is ${target.state}`;
+  const protectionReason = targetProtectionDropReason(target);
+  if (protectionReason) return protectionReason;
   if (!canCloseAgainstCanonical(item, canonical)) return canonicalDropReason(item, canonical);
   const securityReason = securityDropReason(item, target, canonical);
   if (securityReason) return securityReason;
   return "";
+}
+
+function targetProtectionDropReason(target) {
+  if (PROTECTED_AUTHOR_ASSOCIATIONS.has(target.authorAssociation)) {
+    return `target author association is ${target.authorAssociation}`;
+  }
+  const holdLabel = target.labels.find(isHumanHoldLabel);
+  return holdLabel ? `target has human-hold label ${holdLabel}` : "";
+}
+
+function isHumanHoldLabel(label) {
+  const normalized = String(label ?? "").toLowerCase();
+  return (
+    normalized === "triage: needs-real-behavior-proof" ||
+    normalized === "clawsweeper:needs-maintainer-review" ||
+    normalized === "clawsweeper:needs-product-decision" ||
+    normalized === "clawsweeper:needs-live-repro" ||
+    /^status: .*needs proof$/.test(normalized) ||
+    /^status: .*waiting on author$/.test(normalized)
+  );
 }
 
 function canCloseAgainstCanonical(item, canonical) {

--- a/test/import-close-canaries-from-results.test.mjs
+++ b/test/import-close-canaries-from-results.test.mjs
@@ -283,6 +283,57 @@ test("import-close-canaries quarantines security-shaped canonical refs", () => {
   assert.equal(fs.existsSync(path.join(fixture.inbox, "pr-close-canary-92164-test.md")), false);
 });
 
+test("import-close-canaries skips maintainer targets and human-hold targets", () => {
+  const fixture = makeFixture();
+  fs.writeFileSync(
+    path.join(fixture.results, "127.json"),
+    JSON.stringify({
+      actions: [{ target: "#91770", action: "close_superseded", status: "planned", canonical: "#92892" }],
+    }),
+  );
+  fs.writeFileSync(
+    path.join(fixture.results, "128.json"),
+    JSON.stringify({
+      actions: [{ target: "#92526", action: "close_superseded", status: "planned", canonical: "#92892" }],
+    }),
+  );
+  writeFakeGhx(fixture.bin);
+
+  const run = spawnSync(
+    process.execPath,
+    [
+      "scripts/import-close-canaries-from-results.mjs",
+      "--results-dir",
+      fixture.results,
+      "--out",
+      fixture.inbox,
+      "--existing-dir",
+      fixture.existing,
+      "--suffix",
+      "test",
+      "--limit",
+      "2",
+      "--json",
+    ],
+    {
+      cwd: repoRoot,
+      env: { ...process.env, PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}` },
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(run.status, 0, run.stderr || run.stdout);
+  const payload = JSON.parse(run.stdout);
+  assert.deepEqual(payload.candidates, []);
+  assert.deepEqual(
+    new Map(payload.dropped.map((candidate) => [candidate.target, candidate.reason])),
+    new Map([
+      ["#91770", "target author association is MEMBER"],
+      ["#92526", "target has human-hold label status: needs proof"],
+    ]),
+  );
+});
+
 function makeFixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-close-canary-"));
   const results = path.join(root, "results");
@@ -394,6 +445,42 @@ console.log(JSON.stringify({
         body: "",
         state: "OPEN",
         updatedAt: "2026-06-15T17:20:00Z",
+        labels: { nodes: [] }
+      },
+      n91770: {
+        __typename: "PullRequest",
+        number: 91770,
+        title: "maintainer-owned duplicate",
+        body: "",
+        state: "OPEN",
+        updatedAt: "2026-06-15T17:20:00Z",
+        mergedAt: null,
+        authorAssociation: "MEMBER",
+        isDraft: false,
+        labels: { nodes: [] }
+      },
+      n92526: {
+        __typename: "PullRequest",
+        number: 92526,
+        title: "proof-blocked duplicate",
+        body: "",
+        state: "OPEN",
+        updatedAt: "2026-06-15T17:20:00Z",
+        mergedAt: null,
+        authorAssociation: "CONTRIBUTOR",
+        isDraft: false,
+        labels: { nodes: [{ name: "status: needs proof" }] }
+      },
+      n92892: {
+        __typename: "PullRequest",
+        number: 92892,
+        title: "canonical implementation",
+        body: "",
+        state: "OPEN",
+        updatedAt: "2026-06-15T17:20:00Z",
+        mergedAt: null,
+        authorAssociation: "CONTRIBUTOR",
+        isDraft: false,
         labels: { nodes: [] }
       }
     }


### PR DESCRIPTION
## Summary
- exclude maintainer-owned targets from generated close canaries
- exclude explicit proof and maintainer-decision hold labels
- cover the filters with focused importer tests

## Verification
- `node --test test/import-close-canaries-from-results.test.mjs`
- `npm run validate`
- `git diff --check`