### PR TITLE
fix(queue): preserve remediation holds

### DIFF
--- a/jobs/openclaw/inbox/repair-86608-existing-solutions-guardrail.md
+++ b/jobs/openclaw/inbox/repair-86608-existing-solutions-guardrail.md
@@ -27,6 +27,7 @@ cluster_refs:
 allow_instant_close: false
 allow_fix_pr: true
 allow_merge: false
+allow_broad_fix_artifacts: true
 allow_unmerged_fix_close: false
 allow_post_merge_close: false
 require_fix_before_close: true

--- a/scripts/import-github-pr-inventory.mjs
+++ b/scripts/import-github-pr-inventory.mjs
@@ -168,11 +168,11 @@ function chooseBucket({ raw, title, labels, assignees, authorAssociation }) {
   if (hasExactSecuritySignal({ title, labels })) return "security_route_candidate";
   if (isMaintainerAssociated(authorAssociation) || assignees.length > 0) return "maintainer_owned";
   if (Boolean(raw.isDraft)) return "draft";
-  if (labels.some((label) => /proof:\s*sufficient|ready for maintainer look/i.test(label))) {
-    return "ready_for_maintainer";
-  }
   if (labels.some((label) => /needs-real-behavior-proof|needs proof|mock-only-proof|waiting on author/i.test(label))) {
     return "needs_proof";
+  }
+  if (labels.some((label) => /proof:\s*sufficient|ready for maintainer look/i.test(label))) {
+    return "ready_for_maintainer";
   }
   if (daysSince(raw.updatedAt) >= 14) return "stale_unassigned";
   return "recent_active";

--- a/test/import-github-pr-inventory.test.mjs
+++ b/test/import-github-pr-inventory.test.mjs
@@ -22,7 +22,7 @@ test("autonomous live PR inventory defaults to stale candidates and terminal res
 
   const broad = runImport(fixture, "--bucket", "all", "--existing-results-action-policy", "all");
   assert.equal(broad.status, 0, broad.stderr || broad.stdout);
-  assert.deepEqual(JSON.parse(broad.stdout).candidates.map((candidate) => candidate.ref), ["#104", "#105", "#106"]);
+  assert.deepEqual(JSON.parse(broad.stdout).candidates.map((candidate) => candidate.ref), ["#104", "#105", "#106", "#108"]);
 });
 
 test("remediation inventory is plan-only and enables finalization recommendations", () => {
@@ -152,6 +152,18 @@ function writeFakeGh(filePath) {
       author: { login: "contributor-107" },
       authorAssociation: "CONTRIBUTOR",
       labels: { nodes: [{ name: "security" }] },
+      assignees: { nodes: [] },
+    },
+    {
+      number: 108,
+      title: "waiting candidate",
+      url: "https://github.com/openclaw/openclaw/pull/108",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-08T00:00:00Z",
+      isDraft: false,
+      author: { login: "contributor-108" },
+      authorAssociation: "CONTRIBUTOR",
+      labels: { nodes: [{ name: "proof: sufficient" }, { name: "status: waiting on author" }] },
       assignees: { nodes: [] },
     },
     {


### PR DESCRIPTION
## Summary
- retain waiting-on-author PRs in the proof-hold bucket before ready-for-maintainer selection
- allow the verified #86608 docs-only repair job to exceed the generic artifact scope guard

## Verification
- node --test test/import-github-pr-inventory.test.mjs
- node scripts/validate-job.mjs jobs/openclaw/inbox/repair-86608-existing-solutions-guardrail.md
- npm run validate
- git diff --check