### PR TITLE
feat(queue): promote repair candidates

### DIFF
--- a/scripts/promote-repair-candidates.mjs
+++ b/scripts/promote-repair-candidates.mjs
@@ -1,0 +1,415 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { parseArgs, parseJob, parseSimpleYaml, repoRoot, validateJob } from "./lib.mjs";
+
+const REPAIR_ACTIONS = new Set(["fix_needed", "build_fix_artifact", "open_fix_pr"]);
+const EXECUTABLE_STRATEGIES = new Set(["repair_contributor_branch", "replace_uneditable_branch", "new_fix_pr"]);
+const TERMINAL_FIX_STATUSES = new Set(["executed", "opened", "pushed", "merged", "closed", "already_closed"]);
+
+const args = parseArgs(process.argv.slice(2));
+const repo = String(args.repo ?? "openclaw/openclaw");
+const owner = repo.split("/")[0];
+const resultsDir = path.resolve(repoRoot(), String(args["results-dir"] ?? args.results_dir ?? path.join("results", owner)));
+const outDir = path.resolve(repoRoot(), String(args.out ?? path.join("jobs", owner, "inbox")));
+const existingDir = path.resolve(repoRoot(), String(args["existing-dir"] ?? args.existing_dir ?? path.join("jobs", owner)));
+const limit = numberArg("limit", 20);
+const suffix = sanitizeSuffix(String(args.suffix ?? todayStamp()));
+const write = Boolean(args.write);
+const jsonOutput = Boolean(args.json);
+
+if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) die("--repo must be owner/repo");
+if (!fs.existsSync(resultsDir)) die(`results dir not found: ${path.relative(repoRoot(), resultsDir)}`);
+
+const existingRefs = findExistingJobRefs([existingDir, outDir]);
+const reports = listReports(resultsDir);
+const latestCandidates = latestByTarget(reports.flatMap(candidateRowsFromReport));
+const selected = [];
+const skipped = [];
+
+for (const candidate of latestCandidates) {
+  const reason = promotionBlocker(candidate, existingRefs);
+  if (reason) {
+    skipped.push({ ...publicCandidate(candidate), reason });
+    continue;
+  }
+  selected.push(candidate);
+  if (selected.length >= limit) break;
+}
+
+if (write) fs.mkdirSync(outDir, { recursive: true });
+const generated = selected.map((candidate) => writeJob(candidate));
+const payload = {
+  status: write ? "written" : "dry_run",
+  repo,
+  results_dir: path.relative(repoRoot(), resultsDir),
+  out_dir: path.relative(repoRoot(), outDir),
+  existing_dir: path.relative(repoRoot(), existingDir),
+  generated,
+  skipped,
+  totals: {
+    reports: reports.length,
+    latest_candidates: latestCandidates.length,
+    selected: selected.length,
+    generated: generated.length,
+    skipped: skipped.length,
+    existing_refs: existingRefs.size,
+  },
+};
+
+if (jsonOutput) {
+  console.log(JSON.stringify(payload, null, 2));
+} else {
+  for (const item of generated) console.log(item.path);
+  console.error(
+    `status=${payload.status} reports=${reports.length} latest=${latestCandidates.length} selected=${selected.length} generated=${generated.length} skipped=${skipped.length}`,
+  );
+}
+
+function listReports(root) {
+  return fs
+    .readdirSync(root, { recursive: true })
+    .map((entry) => path.join(root, String(entry)))
+    .filter((file) => file.endsWith(".md") && fs.statSync(file).isFile())
+    .map((file) => readReport(file))
+    .filter(Boolean);
+}
+
+function readReport(file) {
+  const raw = fs.readFileSync(file, "utf8");
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) return null;
+  let frontmatter;
+  try {
+    frontmatter = parseSimpleYaml(match[1]);
+  } catch {
+    return null;
+  }
+  const repairCandidate = repairCandidateFromMarkdown(match[2]);
+  if (!repairCandidate) return null;
+  return {
+    file,
+    relative: path.relative(repoRoot(), file),
+    raw,
+    frontmatter,
+    repair_candidate: repairCandidate,
+    published_at: dateValue(frontmatter.published_at),
+    worker_actions: parseTable(match[2], "Worker Action Matrix"),
+    fix_actions: parseTable(match[2], "Fix Execution Actions"),
+  };
+}
+
+function repairCandidateFromMarkdown(body) {
+  const match = body.match(/(?:^|\n)## Repair Candidate\n+```json\n([\s\S]*?)\n```\s*(?=\n## |\s*$)/);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[1]);
+    return parsed && typeof parsed === "object" ? parsed.repair_candidate ?? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function candidateRowsFromReport(report) {
+  const candidate = report.repair_candidate;
+  const sourceRefs = normalizeRefs(candidate.source_refs ?? candidate.source_prs ?? candidate.refs ?? []);
+  const target = normalizeRef(candidate.target ?? candidate.target_ref ?? sourceRefs[0]);
+  const plannedActions = Array.isArray(candidate.planned_actions)
+    ? candidate.planned_actions
+    : [candidate.planned_action ?? candidate.action].filter(Boolean);
+  return [{
+    ...report,
+    target,
+    source_refs: sourceRefs,
+    repair_strategy: String(candidate.repair_strategy ?? ""),
+    planned_actions: plannedActions.map(String),
+    candidate,
+  }].filter((row) => row.target);
+}
+
+function latestByTarget(candidates) {
+  const byTarget = new Map();
+  for (const candidate of candidates) {
+    const previous = byTarget.get(candidate.target);
+    if (!previous || candidateSort(previous, candidate) < 0) byTarget.set(candidate.target, candidate);
+  }
+  return [...byTarget.values()].sort((left, right) => candidateSort(right, left));
+}
+
+function candidateSort(left, right) {
+  return left.published_at - right.published_at || left.relative.localeCompare(right.relative);
+}
+
+function promotionBlocker(candidate, existingRefs) {
+  if (candidate.frontmatter.repo !== repo) return "report repo does not match --repo";
+  if (candidate.frontmatter.result_status !== "planned") return "result is not planned";
+  if (!candidateIsComplete(candidate)) return "repair candidate is incomplete";
+  if (!EXECUTABLE_STRATEGIES.has(candidate.repair_strategy)) return "repair strategy is not executable";
+  if (!hasPlannedRepairAction(candidate)) return "no planned repair action";
+  if (hasSecuritySignal(candidate)) return "security-sensitive candidate";
+  if (hasHumanHold(candidate)) return "candidate requires human review";
+  if (hasTerminalRepairOutcome(candidate)) return "repair already has a terminal outcome";
+  if (candidate.source_refs.some((ref) => existingRefs.has(ref))) return "source ref already has a job";
+  return "";
+}
+
+function candidateIsComplete(candidate) {
+  const artifact = candidate.candidate;
+  return (
+    candidate.source_refs.length > 0 &&
+    typeof artifact.summary === "string" &&
+    artifact.summary.trim() !== "" &&
+    typeof artifact.pr_title === "string" &&
+    artifact.pr_title.trim() !== "" &&
+    typeof artifact.pr_body === "string" &&
+    artifact.pr_body.trim() !== "" &&
+    arrayOfStrings(artifact.likely_files).length > 0 &&
+    arrayOfStrings(artifact.validation_commands).length > 0 &&
+    arrayOfStrings(artifact.credit_notes).length > 0
+  );
+}
+
+function hasPlannedRepairAction(candidate) {
+  if (candidate.planned_actions.some((action) => REPAIR_ACTIONS.has(action))) return true;
+  return candidate.worker_actions.some(
+    (action) => REPAIR_ACTIONS.has(action.action) && action.status === "planned" && normalizeRef(action.target) === candidate.target,
+  );
+}
+
+function hasSecuritySignal(candidate) {
+  if (candidate.candidate.security_sensitive === true || candidate.frontmatter.security_sensitive === true) return true;
+  return candidate.worker_actions.some(
+    (action) => action.action === "route_security" || action.classification === "security_sensitive",
+  );
+}
+
+function hasHumanHold(candidate) {
+  if (Number(candidate.frontmatter.needs_human_count ?? 0) > 0) return true;
+  if (Array.isArray(candidate.candidate.needs_human) && candidate.candidate.needs_human.length > 0) return true;
+  return candidate.worker_actions.some((action) => action.action === "needs_human");
+}
+
+function hasTerminalRepairOutcome(candidate) {
+  if (TERMINAL_FIX_STATUSES.has(String(candidate.candidate.repair_status ?? "").toLowerCase())) return true;
+  if (Number(candidate.frontmatter.fix_executed ?? 0) > 0) return true;
+  return candidate.fix_actions.some((action) => TERMINAL_FIX_STATUSES.has(action.status));
+}
+
+function findExistingJobRefs(roots) {
+  const refs = new Set();
+  const files = new Set();
+  for (const root of roots) {
+    if (!fs.existsSync(root)) continue;
+    for (const entry of fs.readdirSync(root, { recursive: true })) {
+      const file = path.join(root, String(entry));
+      if (!file.endsWith(".md") || !fs.statSync(file).isFile() || files.has(file)) continue;
+      files.add(file);
+      try {
+        const job = parseJob(file);
+        for (const ref of [...(job.frontmatter.canonical ?? []), ...(job.frontmatter.candidates ?? []), ...(job.frontmatter.cluster_refs ?? [])]) {
+          const normalized = normalizeRef(ref);
+          if (normalized) refs.add(normalized);
+        }
+      } catch {
+        // Existing malformed files should not prevent a conservative promotion scan.
+      }
+    }
+  }
+  return refs;
+}
+
+function writeJob(candidate) {
+  const clusterId = `repair-${candidate.target.slice(1)}-${sanitizeSuffix(candidate.frontmatter.cluster_id)}-${suffix}`;
+  const filePath = path.join(outDir, `${clusterId}.md`);
+  const relative = path.relative(repoRoot(), filePath);
+  if (fs.existsSync(filePath)) die(`job already exists: ${relative}`);
+  const markdown = renderJob(candidate, clusterId);
+  if (write) {
+    fs.writeFileSync(filePath, markdown, "utf8");
+    const errors = validateJob(parseJob(filePath));
+    if (errors.length > 0) {
+      fs.rmSync(filePath, { force: true });
+      die(`generated invalid job ${relative}: ${errors.join("; ")}`);
+    }
+  }
+  return {
+    path: relative,
+    cluster_id: clusterId,
+    target: candidate.target,
+    source_refs: candidate.source_refs,
+    repair_strategy: candidate.repair_strategy,
+    source_report: candidate.relative,
+  };
+}
+
+function renderJob(candidate, clusterId) {
+  const artifact = candidate.candidate;
+  const branch = `clownfish/${clusterId}`.slice(0, 120);
+  const refs = candidate.source_refs;
+  const provenance = [
+    `- source report: ${candidate.relative}`,
+    `- source cluster: ${candidate.frontmatter.cluster_id ?? "unknown"}`,
+    `- source run: ${candidate.frontmatter.run_id ?? "unknown"}`,
+    `- source job: ${artifact.source_job ?? candidate.frontmatter.source_job ?? "unknown"}`,
+    `- repair strategy: ${candidate.repair_strategy}`,
+  ];
+  return [
+    "---",
+    `repo: ${quoteYaml(repo)}`,
+    `cluster_id: ${quoteYaml(clusterId)}`,
+    "mode: autonomous",
+    "allowed_actions:",
+    "  - fix",
+    "  - raise_pr",
+    "blocked_actions:",
+    "  - comment",
+    "  - label",
+    "  - close",
+    "  - merge",
+    "  - force_push",
+    "  - bypass_checks",
+    "require_human_for:",
+    "  - security_sensitive",
+    "  - failing_checks",
+    "  - conflicting_prs",
+    "  - broad_code_delta",
+    "canonical:",
+    `  - ${quoteYaml(candidate.target)}`,
+    "candidates:",
+    ...refs.map((ref) => `  - ${quoteYaml(ref)}`),
+    "cluster_refs:",
+    ...refs.map((ref) => `  - ${quoteYaml(ref)}`),
+    "allow_instant_close: false",
+    "allow_fix_pr: true",
+    "allow_merge: false",
+    "allow_unmerged_fix_close: false",
+    "allow_post_merge_close: false",
+    "require_fix_before_close: true",
+    "security_policy: central_security_only",
+    "security_sensitive: false",
+    `target_branch: ${quoteYaml(branch)}`,
+    "source: planner_promotion",
+    `source_result: ${quoteYaml(candidate.relative)}`,
+    `source_cluster_id: ${quoteYaml(String(candidate.frontmatter.cluster_id ?? ""))}`,
+    `source_run_id: ${quoteYaml(String(candidate.frontmatter.run_id ?? ""))}`,
+    `repair_strategy: ${quoteYaml(candidate.repair_strategy)}`,
+    "---",
+    "",
+    `# Repair Promotion ${candidate.target}`,
+    "",
+    "## Scope",
+    "",
+    artifact.summary.trim(),
+    "",
+    "## Provenance",
+    "",
+    ...provenance,
+    "",
+    "## Source Refs",
+    "",
+    ...refs.map((ref) => `- ${ref}`),
+    "",
+    "## Planned Repair",
+    "",
+    `- proposed PR title: ${artifact.pr_title.trim()}`,
+    "",
+    artifact.pr_body.trim(),
+    "",
+    "## Likely Files",
+    "",
+    ...arrayOfStrings(artifact.likely_files).map((file) => `- ${file}`),
+    "",
+    "## Validation",
+    "",
+    ...arrayOfStrings(artifact.validation_commands).map((command) => `- ${command}`),
+    "",
+    "## Credit",
+    "",
+    ...arrayOfStrings(artifact.credit_notes).map((note) => `- ${note}`),
+    "",
+    "## Guardrails",
+    "",
+    `- Re-fetch ${candidate.target} and current main before editing. This promotion is evidence, not a substitute for fresh preflight.`,
+    "- Do not comment, label, close, merge, force-push, or bypass checks.",
+    "- If the repair is no longer narrow, active, safe, or actionable, emit a blocked artifact with the exact reason.",
+    "",
+  ].join("\n");
+}
+
+function parseTable(body, heading) {
+  const match = body.match(new RegExp(`(?:^|\\n)## ${escapeRegExp(heading)}\\n\\n([\\s\\S]*?)(?=\\n## |\\s*$)`));
+  if (!match) return [];
+  const lines = match[1]
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("|"))
+    .map((line) => line.split("|").slice(1, -1).map((cell) => cell.trim()));
+  if (lines.length < 3) return [];
+  const header = lines[0].map((cell) => cell.toLowerCase());
+  return lines.slice(2).map((row) => ({
+    target: row[header.indexOf("target")] ?? "",
+    action: row[header.indexOf("action")] ?? "",
+    status: String(row[header.indexOf("status")] ?? "").toLowerCase(),
+    classification: row[header.indexOf("classification")] ?? "",
+  }));
+}
+
+function normalizeRefs(values) {
+  return [...new Set((Array.isArray(values) ? values : [values]).map(normalizeRef).filter(Boolean))];
+}
+
+function normalizeRef(value) {
+  const match = String(value ?? "").match(/github\.com\/[^/]+\/[^/]+\/(?:issues|pull)\/(\d+)\b|^#?(\d+)$/);
+  return match ? `#${match[1] ?? match[2]}` : "";
+}
+
+function arrayOfStrings(value) {
+  return (Array.isArray(value) ? value : []).filter((item) => typeof item === "string" && item.trim() !== "");
+}
+
+function dateValue(value) {
+  const parsed = Date.parse(String(value ?? ""));
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function numberArg(name, fallback) {
+  const raw = args[name] ?? args[name.replaceAll("-", "_")];
+  if (raw === undefined || raw === true) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 0) die(`--${name} must be a non-negative integer`);
+  return value;
+}
+
+function sanitizeSuffix(value) {
+  const sanitized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (!sanitized) die("suffix became empty after sanitizing");
+  return sanitized;
+}
+
+function todayStamp() {
+  return new Date().toISOString().slice(0, 10).replaceAll("-", "");
+}
+
+function quoteYaml(value) {
+  return JSON.stringify(String(value));
+}
+
+function publicCandidate(candidate) {
+  return {
+    target: candidate.target,
+    source_refs: candidate.source_refs,
+    repair_strategy: candidate.repair_strategy,
+    source_report: candidate.relative,
+  };
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function die(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/scripts/publish-result.mjs
+++ b/scripts/publish-result.mjs
@@ -19,6 +19,8 @@ const MERGE_APPLICATOR_ACTIONS = new Set(["merge_candidate", "merge_canonical"])
 const APPLICATOR_ACTIONS = new Set([...CLOSE_APPLICATOR_ACTIONS, ...MERGE_APPLICATOR_ACTIONS]);
 const POST_FLIGHT_APPLY_ACTIONS = new Set(["finalize_fix_pr", "post_merge_closeout"]);
 const PROBLEM_ACTION_STATUSES = new Set(["blocked", "failed"]);
+const REPAIR_ACTIONS = new Set(["fix_needed", "build_fix_artifact", "open_fix_pr"]);
+const TERMINAL_REPAIR_STATUSES = new Set(["executed", "opened", "pushed", "merged", "closed", "already_closed"]);
 const PR_INFO_CACHE = new Map();
 const ISSUE_INFO_CACHE = new Map();
 const archivedClusters = readArchivedClusters();
@@ -51,6 +53,7 @@ function publishResult(resultPath) {
   const postFlightReport = readSiblingJson(runDir, "post-flight-report.json") ?? { actions: [] };
   const fixReport = readSiblingJson(runDir, "fix-execution-report.json") ?? { actions: [] };
   const clusterPlan = readSiblingJson(runDir, "cluster-plan.json");
+  const fixArtifact = readSiblingJson(runDir, "fix-artifact.json");
   const identity = inferResultRunIdentity(resultPath);
   const runId = String(args["run-id"] ?? identity?.run_id ?? "");
   const workflowRunId = String(args["workflow-run-id"] ?? identity?.workflow_run_id ?? runId);
@@ -72,6 +75,12 @@ function publishResult(resultPath) {
     ...(postFlightReport.actions ?? []).filter(isPostFlightApplyAction).map(postFlightToApplyAction),
   ].filter(isApplicatorAction));
   const fixActions = (fixReport.actions ?? []).map(sanitizeFixAction);
+  const repairCandidate = sanitizeRepairCandidate({
+    result,
+    fixArtifact,
+    clusterPlan,
+    fixActions,
+  });
   const report = {
     repo,
     cluster_id: clusterId,
@@ -87,7 +96,7 @@ function publishResult(resultPath) {
     workflow_created_at: metadata?.createdAt ?? metadata?.created_at ?? previousRecord?.workflow_created_at ?? null,
     workflow_updated_at: metadata?.updatedAt ?? metadata?.updated_at ?? previousRecord?.workflow_updated_at ?? null,
     result_status: result.status ?? null,
-    source_job: clusterPlan?.source_job ?? null,
+    source_job: clusterPlan?.source_job ?? fixArtifact?.source_job ?? null,
     published_at: new Date().toISOString(),
     canonical: result.canonical ?? null,
     canonical_issue: result.canonical_issue ?? null,
@@ -99,6 +108,7 @@ function publishResult(resultPath) {
     fix_counts: countBy(fixActions, (action) => String(action.status ?? "unknown")),
     apply_counts: countBy(applyActions, (action) => String(action.status ?? "unknown")),
     needs_human: Array.isArray(result.needs_human) ? result.needs_human : [],
+    repair_candidate: repairCandidate,
     fix_actions: fixActions,
     apply_actions: applyActions.map(sanitizeApplyAction),
   };
@@ -148,6 +158,15 @@ function renderClusterReport(report) {
     report.needs_human.length > 0
       ? report.needs_human.map((item) => `- ${item}`).join("\n")
       : "- none";
+  const repairCandidate = report.repair_candidate
+    ? `## Repair Candidate
+
+\`\`\`json
+${JSON.stringify(report.repair_candidate, null, 2)}
+\`\`\`
+
+`
+    : "";
   return `---
 repo: ${quote(report.repo)}
 cluster_id: ${quote(report.cluster_id)}
@@ -201,7 +220,7 @@ ${report.summary || "_No summary emitted._"}
 | Apply skipped | ${report.apply_counts.skipped ?? 0} |
 | Needs human | ${report.needs_human.length} |
 
-## Fix Execution Actions
+${repairCandidate}## Fix Execution Actions
 
 | Action | Status | Target | Branch | Reason |
 | --- | --- | --- | --- | --- |
@@ -556,6 +575,128 @@ function readRunMetadata(filePath) {
   const data = readJson(filePath);
   const rows = Array.isArray(data) ? data : [data];
   return new Map(rows.map((row) => [String(row.databaseId ?? row.run_id ?? row.id), row]));
+}
+
+function sanitizeRepairCandidate({ result, fixArtifact, clusterPlan, fixActions }) {
+  const artifact = result?.fix_artifact;
+  if (!isObject(artifact) || !isObject(fixArtifact)) return null;
+
+  const artifactSourceRefs = sanitizeRefs([artifact.source_prs, artifact.linked_refs]);
+  const canonicalRefs = sanitizeRefs([result.canonical_pr, result.canonical, result.canonical_issue]);
+  const plannerRefs = sanitizeRefs([
+    (fixArtifact.canonical_candidates ?? []).map((item) => item?.ref),
+    (fixArtifact.item_matrix ?? []).map((item) => item?.ref),
+  ]);
+  const sourceRefs = uniqueStrings([...artifactSourceRefs, ...canonicalRefs, ...plannerRefs], 20);
+  const target = artifactSourceRefs[0] ?? canonicalRefs[0] ?? plannerRefs[0] ?? null;
+  const plannedActions = uniqueStrings(
+    (Array.isArray(result.actions) ? result.actions : [])
+      .filter((action) => action?.status === "planned" && REPAIR_ACTIONS.has(String(action?.action ?? "")))
+      .map((action) => String(action.action)),
+    8,
+  );
+  const securityRoutedRefs = sanitizeRefs(
+    (Array.isArray(result.actions) ? result.actions : [])
+      .filter(
+        (action) =>
+          action?.action === "route_security" ||
+          action?.classification === "security_sensitive" ||
+          action?.security_sensitive === true,
+      )
+      .map((action) => action?.target),
+  );
+  const targetItem = (fixArtifact.item_matrix ?? []).find((item) => normalizeGithubRef(item?.ref) === target);
+  const targetAction = (Array.isArray(result.actions) ? result.actions : []).find(
+    (action) => normalizeGithubRef(action?.target) === target,
+  );
+  const securitySensitive =
+    typeof targetItem?.security_sensitive === "boolean"
+      ? targetItem.security_sensitive
+      : targetAction
+        ? targetAction.action === "route_security" ||
+          targetAction.classification === "security_sensitive" ||
+          targetAction.security_sensitive === true
+        : null;
+  const reportedStatus = sanitizeText(artifact.repair_status, 80);
+  const terminalStatus = (fixActions ?? []).find((action) =>
+    TERMINAL_REPAIR_STATUSES.has(String(action.status ?? "").toLowerCase()),
+  )?.status;
+  const repairStatus = sanitizeText(terminalStatus ?? reportedStatus, 80) || null;
+
+  return {
+    target,
+    source_refs: sourceRefs,
+    repair_strategy: sanitizeText(artifact.repair_strategy, 120) || null,
+    planned_actions: plannedActions,
+    summary: sanitizeText(artifact.summary, 2_000),
+    pr_title: sanitizeText(artifact.pr_title, 300),
+    pr_body: sanitizeText(artifact.pr_body, 6_000),
+    likely_files: sanitizeStringList(artifact.likely_files, 24, 400),
+    validation_commands: sanitizeStringList(artifact.validation_commands, 16, 800),
+    credit_notes: sanitizeStringList(artifact.credit_notes, 16, 1_000),
+    source_job: sanitizeText(clusterPlan?.source_job ?? fixArtifact.source_job, 500) || null,
+    security_sensitive: securitySensitive,
+    security_routed_refs: securityRoutedRefs,
+    needs_human: sanitizeNeedsHuman(result.needs_human),
+    repair_status: repairStatus,
+    terminal: repairStatus ? TERMINAL_REPAIR_STATUSES.has(repairStatus.toLowerCase()) : null,
+  };
+}
+
+function sanitizeRefs(values) {
+  const flattened = Array.isArray(values) ? values.flat(Infinity) : [values];
+  return uniqueStrings(flattened.map(normalizeGithubRef).filter(Boolean), 20);
+}
+
+function normalizeGithubRef(value) {
+  const match = String(value ?? "").match(/github\.com\/[^/\s]+\/[^/\s]+\/(?:issues|pull)\/(\d+)\b|^#?(\d+)$/);
+  return match ? `#${match[1] ?? match[2]}` : "";
+}
+
+function sanitizeStringList(value, limit, maxLength) {
+  return uniqueStrings(
+    (Array.isArray(value) ? value : [])
+      .filter((item) => typeof item === "string")
+      .map((item) => sanitizeText(item, maxLength))
+      .filter(Boolean),
+    limit,
+  );
+}
+
+function sanitizeNeedsHuman(value) {
+  return uniqueStrings(
+    (Array.isArray(value) ? value : [])
+      .map((item) => {
+        if (typeof item === "string") return item;
+        if (!isObject(item)) return "";
+        return item.reason ?? item.summary ?? item.title ?? item.ref ?? "";
+      })
+      .map((item) => sanitizeText(item, 1_000))
+      .filter(Boolean),
+    16,
+  );
+}
+
+function sanitizeText(value, maxLength) {
+  if (typeof value !== "string") return "";
+  return truncate(
+    value
+      .replace(/\u0000/g, "")
+      .replace(
+        /(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,}|(?:api[_ -]?key|token|secret|password)\s*[:=]\s*[^\s"'`]+)/gi,
+        "[REDACTED]",
+      )
+      .trim(),
+    maxLength,
+  );
+}
+
+function uniqueStrings(values, limit) {
+  return [...new Set(values)].slice(0, limit);
+}
+
+function isObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function summarizeActions(actions) {

--- a/test/promote-repair-candidates.test.mjs
+++ b/test/promote-repair-candidates.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("promote-repair-candidates selects only the newest viable repair, dedupes jobs, and requires --write", () => {
+  const fixture = makeFixture();
+  writeReport(fixture.results, "eligible-old.md", {
+    clusterId: "eligible-old",
+    publishedAt: "2026-06-14T00:00:00.000Z",
+    target: "#101",
+  });
+  writeReport(fixture.results, "eligible-new.md", {
+    clusterId: "eligible-new",
+    publishedAt: "2026-06-15T00:00:00.000Z",
+    target: "#101",
+    strategy: "replace_uneditable_branch",
+  });
+  writeReport(fixture.results, "terminal.md", {
+    clusterId: "terminal",
+    publishedAt: "2026-06-16T00:00:00.000Z",
+    target: "#102",
+    repairStatus: "pushed",
+  });
+  writeReport(fixture.results, "security.md", {
+    clusterId: "security",
+    publishedAt: "2026-06-16T00:00:00.000Z",
+    target: "#103",
+    security: true,
+  });
+  writeReport(fixture.results, "hold.md", {
+    clusterId: "hold",
+    publishedAt: "2026-06-16T00:00:00.000Z",
+    target: "#104",
+    hold: true,
+  });
+  writeReport(fixture.results, "dedupe.md", {
+    clusterId: "dedupe",
+    publishedAt: "2026-06-16T00:00:00.000Z",
+    target: "#105",
+  });
+  fs.writeFileSync(
+    path.join(fixture.existing, "already-queued.md"),
+    `---
+repo: openclaw/openclaw
+cluster_id: existing-105
+mode: autonomous
+allowed_actions:
+  - fix
+candidates:
+  - "#105"
+---
+`,
+  );
+
+  const dryRun = runPromoter(fixture);
+  assert.equal(dryRun.status, 0, dryRun.stderr || dryRun.stdout);
+  const dryPayload = JSON.parse(dryRun.stdout);
+  assert.equal(dryPayload.status, "dry_run");
+  assert.deepEqual(dryPayload.generated.map((item) => item.target), ["#101"]);
+  assert.equal(fs.readdirSync(fixture.out).length, 0);
+  assert.deepEqual(
+    new Map(dryPayload.skipped.map((item) => [item.target, item.reason])),
+    new Map([
+      ["#102", "repair already has a terminal outcome"],
+      ["#103", "security-sensitive candidate"],
+      ["#104", "candidate requires human review"],
+      ["#105", "source ref already has a job"],
+    ]),
+  );
+
+  const write = runPromoter(fixture, "--write");
+  assert.equal(write.status, 0, write.stderr || write.stdout);
+  const payload = JSON.parse(write.stdout);
+  assert.equal(payload.status, "written");
+  assert.deepEqual(payload.generated.map((item) => item.target), ["#101"]);
+
+  const job = fs.readFileSync(path.join(fixture.out, "repair-101-eligible-new-test.md"), "utf8");
+  assert.match(job, /mode: autonomous/);
+  assert.match(job, /allowed_actions:\n  - fix\n  - raise_pr/);
+  assert.match(job, /blocked_actions:\n  - comment\n  - label\n  - close\n  - merge\n  - force_push\n  - bypass_checks/);
+  assert.match(job, /repair_strategy: "replace_uneditable_branch"/);
+  assert.match(job, /source report: .*eligible-new\.md/);
+  assert.match(job, /#101/);
+});
+
+function makeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-promote-repair-"));
+  const results = path.join(root, "results");
+  const out = path.join(root, "out");
+  const existing = path.join(root, "existing");
+  fs.mkdirSync(results, { recursive: true });
+  fs.mkdirSync(out, { recursive: true });
+  fs.mkdirSync(existing, { recursive: true });
+  return { root, results, out, existing };
+}
+
+function writeReport(
+  results,
+  filename,
+  {
+    clusterId,
+    publishedAt,
+    target,
+    strategy = "repair_contributor_branch",
+    repairStatus = "",
+    security = false,
+    hold = false,
+  },
+) {
+  const candidate = {
+    target,
+    source_refs: [target],
+    repair_strategy: strategy,
+    planned_action: "build_fix_artifact",
+    summary: `Repair ${target} narrowly.`,
+    pr_title: `fix: repair ${target}`,
+    pr_body: `Preserve credit for ${target}.`,
+    likely_files: ["src/example.ts"],
+    validation_commands: ["pnpm test:serial src/example.test.ts"],
+    credit_notes: [`Preserve source credit for ${target}.`],
+    source_job: `jobs/openclaw/inbox/${clusterId}.md`,
+    repair_status: repairStatus,
+    security_sensitive: security,
+    needs_human: hold ? ["await maintainer decision"] : [],
+  };
+  fs.writeFileSync(
+    path.join(results, filename),
+    `---
+repo: "openclaw/openclaw"
+cluster_id: "${clusterId}"
+mode: "plan"
+run_id: "${clusterId}-run"
+result_status: "planned"
+published_at: "${publishedAt}"
+needs_human_count: ${hold ? 1 : 0}
+fix_executed: 0
+---
+
+# ${clusterId}
+
+## Repair Candidate
+
+\`\`\`json
+${JSON.stringify(candidate, null, 2)}
+\`\`\`
+
+## Worker Action Matrix
+
+| Target | Action | Status | Classification | Reason |
+| --- | --- | --- | --- | --- |
+| ${target} | build_fix_artifact | planned | canonical | narrow repair |
+
+## Fix Execution Actions
+
+| Action | Status | Target | Branch | Reason |
+| --- | --- | --- | --- | --- |
+`,
+    "utf8",
+  );
+}
+
+function runPromoter(fixture, ...extraArgs) {
+  return spawnSync(
+    process.execPath,
+    [
+      "scripts/promote-repair-candidates.mjs",
+      "--repo",
+      "openclaw/openclaw",
+      "--results-dir",
+      fixture.results,
+      "--out",
+      fixture.out,
+      "--existing-dir",
+      fixture.existing,
+      "--suffix",
+      "test",
+      "--json",
+      ...extraArgs,
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+}

--- a/test/publish-result.test.mjs
+++ b/test/publish-result.test.mjs
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("publish-result publishes a bounded repair candidate from sibling artifacts", (t) => {
+  const fixture = makeFixture();
+  const runId = `publish-result-${process.pid}-${Date.now()}`;
+  const clusterId = `publish-result-candidate-${process.pid}-${Date.now()}`;
+  const reportPath = path.join(repoRoot, "results", "openclaw", `${clusterId}.md`);
+  const runRecordPath = path.join(repoRoot, "results", "runs", `${runId}.json`);
+  const previousReport = readIfExists(reportPath);
+  const previousRunRecord = readIfExists(runRecordPath);
+  t.after(() => {
+    restore(reportPath, previousReport);
+    restore(runRecordPath, previousRunRecord);
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  });
+
+  fs.writeFileSync(
+    path.join(fixture.runDir, "result.json"),
+    `${JSON.stringify(
+      {
+        status: "planned",
+        repo: "openclaw/openclaw",
+        cluster_id: clusterId,
+        mode: "plan",
+        canonical_pr: "#501",
+        summary: "Plan a narrow repair.",
+        needs_human: ["wait for maintainer confirmation"],
+        actions: [
+          {
+            target: "cluster:publish-result-candidate",
+            action: "build_fix_artifact",
+            status: "planned",
+          },
+          {
+            target: "#777",
+            action: "route_security",
+            status: "planned",
+            classification: "security_sensitive",
+          },
+        ],
+        fix_artifact: {
+          source_prs: ["https://github.com/openclaw/openclaw/pull/501"],
+          summary: "Repair the contributor branch with the smallest compatible change.",
+          pr_title: "fix: preserve repair candidate publication",
+          pr_body: "Keep the branch repair scoped. token=super-secret-value",
+          likely_files: ["scripts/publish-result.mjs", "test/publish-result.test.mjs"],
+          validation_commands: ["node --test test/publish-result.test.mjs"],
+          credit_notes: ["Preserve credit for #501."],
+          repair_strategy: "repair_contributor_branch",
+          giant_raw_context: "x".repeat(20_000),
+          api_key: "should-not-be-published",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  fs.writeFileSync(
+    path.join(fixture.runDir, "fix-artifact.json"),
+    `${JSON.stringify(
+      {
+        source_job: "jobs/openclaw/inbox/repair-501.md",
+        canonical_candidates: [{ ref: "#501" }],
+        item_matrix: [
+          { ref: "#501", security_sensitive: false },
+          { ref: "#777", security_sensitive: true },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  fs.writeFileSync(
+    path.join(fixture.runDir, "fix-execution-report.json"),
+    `${JSON.stringify(
+      {
+        actions: [
+          {
+            action: "repair_contributor_branch",
+            status: "pushed",
+            target: "#501",
+            repair_strategy: "repair_contributor_branch",
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/publish-result.mjs", fixture.runDir, "--run-id", runId, "--skip-aggregate", "--no-run-url"],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  const report = fs.readFileSync(reportPath, "utf8");
+  const candidate = JSON.parse(report.match(/## Repair Candidate\n\n```json\n([\s\S]*?)\n```/)?.[1] ?? "");
+
+  assert.deepEqual(candidate.source_refs, ["#501", "#777"]);
+  assert.equal(candidate.target, "#501");
+  assert.equal(candidate.repair_strategy, "repair_contributor_branch");
+  assert.deepEqual(candidate.planned_actions, ["build_fix_artifact"]);
+  assert.equal(candidate.source_job, "jobs/openclaw/inbox/repair-501.md");
+  assert.equal(candidate.security_sensitive, false);
+  assert.deepEqual(candidate.security_routed_refs, ["#777"]);
+  assert.deepEqual(candidate.needs_human, ["wait for maintainer confirmation"]);
+  assert.equal(candidate.repair_status, "pushed");
+  assert.equal(candidate.terminal, true);
+  assert.match(candidate.pr_body, /\[REDACTED\]/);
+  assert.doesNotMatch(report, /super-secret-value|should-not-be-published|giant_raw_context/);
+  assert.deepEqual(candidate.validation_commands, ["node --test test/publish-result.test.mjs"]);
+  assert.deepEqual(candidate.credit_notes, ["Preserve credit for #501."]);
+});
+
+test("publish-result leaves reports unchanged when fix-artifact.json is absent", (t) => {
+  const fixture = makeFixture();
+  const runId = `publish-result-no-artifact-${process.pid}-${Date.now()}`;
+  const clusterId = `publish-result-no-artifact-${process.pid}-${Date.now()}`;
+  const reportPath = path.join(repoRoot, "results", "openclaw", `${clusterId}.md`);
+  const runRecordPath = path.join(repoRoot, "results", "runs", `${runId}.json`);
+  const previousReport = readIfExists(reportPath);
+  const previousRunRecord = readIfExists(runRecordPath);
+  t.after(() => {
+    restore(reportPath, previousReport);
+    restore(runRecordPath, previousRunRecord);
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  });
+
+  fs.writeFileSync(
+    path.join(fixture.runDir, "result.json"),
+    `${JSON.stringify(
+      {
+        status: "planned",
+        repo: "openclaw/openclaw",
+        cluster_id: clusterId,
+        mode: "plan",
+        actions: [],
+        needs_human: [],
+        fix_artifact: {
+          summary: "A worker artifact without a planner sibling must not be promoted.",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/publish-result.mjs", fixture.runDir, "--run-id", runId, "--skip-aggregate", "--no-run-url"],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  assert.doesNotMatch(fs.readFileSync(reportPath, "utf8"), /## Repair Candidate/);
+});
+
+function makeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-publish-result-"));
+  const runDir = path.join(root, "run");
+  fs.mkdirSync(runDir, { recursive: true });
+  return { root, runDir };
+}
+
+function readIfExists(filePath) {
+  return fs.existsSync(filePath) ? fs.readFileSync(filePath) : null;
+}
+
+function restore(filePath, contents) {
+  if (contents) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, contents);
+  } else {
+    fs.rmSync(filePath, { force: true });
+  }
+}


### PR DESCRIPTION
## Summary
- publish bounded, redacted repair-candidate data with cluster results
- add a dry-run-by-default promotion command for fresh autonomous repair jobs
- preserve security, human-hold, terminal, and duplicate guards in the generated jobs

## Verification
- node --test test/publish-result.test.mjs test/promote-repair-candidates.test.mjs
- node --check scripts/publish-result.mjs
- node --check scripts/promote-repair-candidates.mjs
- npm run validate
- git diff --check