### PR TITLE
fix(worker): align target checkout execution

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -140,6 +140,18 @@ const report = {
   actions: [],
 };
 
+if (["blocked", "failed"].includes(result.status)) {
+  report.status = "skipped";
+  report.reason = `worker result status ${result.status} is not executable`;
+  report.actions.push({
+    action: "execute_fix",
+    status: "skipped",
+    reason: report.reason,
+  });
+  writeReport(report, resultPath);
+  process.exit(0);
+}
+
 if (plannedFixActions.length === 0) {
   report.status = "skipped";
   report.reason = "no planned fix actions";

--- a/scripts/plan-cluster.mjs
+++ b/scripts/plan-cluster.mjs
@@ -415,7 +415,7 @@ function buildFixArtifact(plan, job) {
     mode: plan.mode,
     generated_at: plan.generated_at,
     source_job: plan.source_job,
-    target_checkout: job.frontmatter.target_checkout ?? process.env.CLOWNFISH_TARGET_CHECKOUT ?? null,
+    target_checkout: process.env.CLOWNFISH_TARGET_CHECKOUT ?? job.frontmatter.target_checkout ?? null,
     permissions: {
       allow_instant_close: job.frontmatter.allow_instant_close === true,
       allow_low_signal_pr_close: job.frontmatter.allow_low_signal_pr_close === true,

--- a/scripts/run-worker.mjs
+++ b/scripts/run-worker.mjs
@@ -60,9 +60,17 @@ const runDir = makeRunDir(job, mode);
 const promptPath = path.join(runDir, "prompt.md");
 const resultPath = path.join(runDir, "result.json");
 const transcriptPath = path.join(runDir, "codex.jsonl");
+const targetCheckout = resolveTargetCheckout(job.frontmatter.repo);
+if (targetCheckout.error) {
+  writeBlockedResult(targetCheckout.error);
+  console.error(targetCheckout.error);
+  process.exit(0);
+}
+
+const codexWorkingDir = targetCheckout.path ?? repoRoot();
 const promptContext = {};
-if (process.env.CLOWNFISH_TARGET_CHECKOUT) {
-  promptContext.targetCheckoutPath = process.env.CLOWNFISH_TARGET_CHECKOUT;
+if (targetCheckout.path) {
+  promptContext.targetCheckoutPath = targetCheckout.path;
   promptContext.targetCheckoutRepo = job.frontmatter.repo;
 }
 
@@ -173,7 +181,7 @@ function runCodex({ input, outputPath, transcriptPath: codexTranscriptPath, stde
   const codexArgs = [
     "exec",
     "--cd",
-    repoRoot(),
+    codexWorkingDir,
     "--model",
     model,
     "--sandbox",
@@ -189,7 +197,7 @@ function runCodex({ input, outputPath, transcriptPath: codexTranscriptPath, stde
   ];
 
   const child = spawnSync("codex", codexArgs, {
-    cwd: repoRoot(),
+    cwd: codexWorkingDir,
     input,
     encoding: "utf8",
     env: codexEnv(),
@@ -317,6 +325,46 @@ function parsePositiveIntegerEnv(value, fallback) {
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed <= 0) return fallback;
   return parsed;
+}
+
+function resolveTargetCheckout(expectedRepo) {
+  const configuredPath = process.env.CLOWNFISH_TARGET_CHECKOUT;
+  if (!configuredPath) return { path: null };
+
+  const targetPath = path.resolve(configuredPath);
+  const checkout = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    cwd: targetPath,
+    encoding: "utf8",
+  });
+  if (checkout.status !== 0 || checkout.stdout.trim() !== "true") {
+    return { error: "CLOWNFISH_TARGET_CHECKOUT is not a git checkout" };
+  }
+
+  const origin = spawnSync("git", ["config", "--get", "remote.origin.url"], {
+    cwd: targetPath,
+    encoding: "utf8",
+  });
+  const actualRepo = repoFromGithubRemote(origin.stdout);
+  if (origin.status !== 0 || !actualRepo) {
+    return { error: "CLOWNFISH_TARGET_CHECKOUT origin is not a GitHub repository remote" };
+  }
+
+  if (actualRepo.toLowerCase() !== expectedRepo.toLowerCase()) {
+    return {
+      error: `CLOWNFISH_TARGET_CHECKOUT origin repo mismatch: expected ${expectedRepo}, got ${actualRepo}`,
+    };
+  }
+
+  return { path: targetPath };
+}
+
+function repoFromGithubRemote(remote) {
+  const value = String(remote ?? "").trim();
+  const match = value.match(
+    /^(?:git@github\.com:|(?:https?|ssh):\/\/(?:[^@/\s]+@)?github\.com\/)([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i,
+  );
+  if (!match) return null;
+  return `${match[1]}/${match[2]}`;
 }
 
 function writeBlockedResult(summary) {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -18,6 +18,79 @@ test("execute-fix-artifact gives every Codex subprocess an explicit stdout buffe
   assert.match(source, /child\.error\?\.code === "ENOBUFS"/);
 });
 
+test("execute-fix-artifact skips blocked worker results before invoking Codex or mutating", () => {
+  const fixture = makeFixture();
+  const resultPath = path.join(fixture.runDir, "result.json");
+  const reportPath = path.join(fixture.runDir, "fix-execution-report.json");
+  const codexMarker = path.join(fixture.root, "codex-invoked");
+
+  fs.writeFileSync(fixture.jobPath, jobFile("blocked-result-cluster"));
+  fs.writeFileSync(
+    resultPath,
+    `${JSON.stringify(
+      {
+        ...resultFile("blocked-result-cluster"),
+        status: "blocked",
+        actions: [
+          { action: "fix_needed", status: "planned", target: "cluster:blocked-result-cluster" },
+          { action: "build_fix_artifact", status: "planned", target: "cluster:blocked-result-cluster" },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeExecutable(
+    path.join(fixture.binDir, "codex"),
+    `#!/usr/bin/env node
+require("node:fs").writeFileSync(${JSON.stringify(codexMarker)}, "invoked\\n");
+process.exit(99);
+`,
+  );
+
+  const child = spawnSync(
+    process.execPath,
+    [
+      "scripts/execute-fix-artifact.mjs",
+      fixture.jobPath,
+      resultPath,
+      "--target-dir",
+      fixture.targetDir,
+      "--work-dir",
+      fixture.workDir,
+      "--report",
+      reportPath,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+        CLOWNFISH_ALLOW_EXECUTE: "1",
+        CLOWNFISH_ALLOW_FIX_PR: "1",
+      },
+    },
+  );
+
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  assert.equal(fs.existsSync(codexMarker), false);
+  assert.equal(git(["status", "--porcelain"], { cwd: fixture.targetDir }), "");
+  assert.equal(git(["ls-remote", "--heads", fixture.originDir, "clownfish/blocked-result-cluster"], { cwd: fixture.root }), "");
+
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.status, "skipped");
+  assert.equal(report.reason, "worker result status blocked is not executable");
+  assert.deepEqual(report.actions, [
+    {
+      action: "execute_fix",
+      status: "skipped",
+      reason: "worker result status blocked is not executable",
+    },
+  ]);
+});
+
 test("execute-fix-artifact preserves recoverable replacement branch when review deadline blocks", () => {
   const fixture = makeFixture();
   const resultPath = path.join(fixture.runDir, "result.json");

--- a/test/plan-cluster.test.mjs
+++ b/test/plan-cluster.test.mjs
@@ -7,6 +7,15 @@ import test from "node:test";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
+test("plan-cluster records the workflow target checkout ahead of a job-local override", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "plan-cluster.mjs"), "utf8");
+
+  assert.match(
+    source,
+    /target_checkout: process\.env\.CLOWNFISH_TARGET_CHECKOUT \?\? job\.frontmatter\.target_checkout \?\? null/,
+  );
+});
+
 test("plan-cluster records PR hydration errors without failing the run", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-plan-"));
   const binDir = path.join(tmp, "bin");

--- a/test/run-worker-source.test.mjs
+++ b/test/run-worker-source.test.mjs
@@ -12,3 +12,21 @@ test("run-worker gives Codex JSON transcripts an explicit stdout buffer", () => 
   assert.match(source, /maxBuffer:\s*codexStdoutMaxBufferBytes/);
   assert.match(source, /child\.error\?\.code === "ENOBUFS"/);
 });
+
+test("run-worker verifies a supplied target checkout before using it for Codex", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "run-worker.mjs"), "utf8");
+
+  assert.match(source, /const targetCheckout = resolveTargetCheckout\(job\.frontmatter\.repo\);/);
+  assert.match(source, /if \(targetCheckout\.error\) \{\s*writeBlockedResult\(targetCheckout\.error\);/s);
+  assert.match(source, /\["rev-parse", "--is-inside-work-tree"\]/);
+  assert.match(source, /\["config", "--get", "remote\.origin\.url"\]/);
+  assert.match(source, /CLOWNFISH_TARGET_CHECKOUT origin repo mismatch/);
+  assert.match(source, /const codexWorkingDir = targetCheckout\.path \?\? repoRoot\(\);/);
+});
+
+test("run-worker runs Codex from the verified target checkout", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "run-worker.mjs"), "utf8");
+
+  assert.match(source, /"--cd",\s*codexWorkingDir/);
+  assert.match(source, /spawnSync\("codex", codexArgs, \{\s*cwd: codexWorkingDir,/s);
+});


### PR DESCRIPTION
## Summary
- run worker Codex inside the verified target repository checkout
- block target checkout origin mismatches before planning or Codex
- prevent blocked or failed worker results from entering fix execution
- prefer the workflow target checkout over job-local artifact metadata

## Verification
- node --test test/run-worker-source.test.mjs test/execute-fix-artifact.test.mjs test/plan-cluster.test.mjs
- node --check scripts/run-worker.mjs
- node --check scripts/execute-fix-artifact.mjs
- node --check scripts/plan-cluster.mjs
- npm run validate
- git diff --check