### PR TITLE
chore(queue): stage remediation plan wave

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-001.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-001
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#87696"
+  - "#90819"
+  - "#88479"
+  - "#87681"
+  - "#87702"
+cluster_refs:
+  - "#87696"
+  - "#90819"
+  - "#88479"
+  - "#87681"
+  - "#87702"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.929Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #87696 fix(cli): load plugins for openclaw sandbox so OpenShell backend reports live status (#59528)
+
+- bucket: ready_for_maintainer
+- author: sweetcornna
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-03T09:34:59Z
+- live url: https://github.com/openclaw/openclaw/pull/87696
+
+### #90819 fix(gateway): pin plugin workspace dir during sessions.list to stop O(rows) metadata scans under concurrency
+
+- bucket: ready_for_maintainer
+- author: k-l-lambda
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-06T03:00:00Z
+- live url: https://github.com/openclaw/openclaw/pull/90819
+
+### #88479 feat(ui): inline rename in the in-chat session picker
+
+- bucket: ready_for_maintainer
+- author: BSG2000
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XL, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-08T07:59:21Z
+- live url: https://github.com/openclaw/openclaw/pull/88479
+
+### #87681 fix(exec): surface oom_score_adj raise when SIGKILLs hit broad find/grep on Linux (#69242)
+
+- bucket: ready_for_maintainer
+- author: sweetcornna
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-10T09:55:07Z
+- live url: https://github.com/openclaw/openclaw/pull/87681
+
+### #87702 fix(coding-agent): strip Claude Code nesting env vars when spawning claude (#57858)
+
+- bucket: ready_for_maintainer
+- author: sweetcornna
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, extensions: anthropic, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-10T09:55:51Z
+- live url: https://github.com/openclaw/openclaw/pull/87702

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-002.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-002
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#88551"
+  - "#88709"
+  - "#88581"
+  - "#88180"
+  - "#88885"
+cluster_refs:
+  - "#88551"
+  - "#88709"
+  - "#88581"
+  - "#88180"
+  - "#88885"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.930Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 2
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #88551 fix(agents): skip auth gate for CLI-owned transport
+
+- bucket: ready_for_maintainer
+- author: yu-xin-c
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-10T16:20:27Z
+- live url: https://github.com/openclaw/openclaw/pull/88551
+
+### #88709 fix(auth): cooldown inline api key billing failures
+
+- bucket: ready_for_maintainer
+- author: MertBasar0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: L, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-10T17:43:48Z
+- live url: https://github.com/openclaw/openclaw/pull/88709
+
+### #88581 feat(commands): add /name to rename the current session from chat
+
+- bucket: ready_for_maintainer
+- author: BSG2000
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: M, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look, proof: video
+- live updated: 2026-06-12T14:43:09Z
+- live url: https://github.com/openclaw/openclaw/pull/88581
+
+### #88180 fix(prompt): preserve IDENTITY defaults in system prompt
+
+- bucket: ready_for_maintainer
+- author: yozu
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-13T06:34:31Z
+- live url: https://github.com/openclaw/openclaw/pull/88180
+
+### #88885 fix(infra): wire session-delivery drain recovery guard onto the shared SQLite recovery_state column
+
+- bucket: ready_for_maintainer
+- author: Feelw00
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-13T06:35:13Z
+- live url: https://github.com/openclaw/openclaw/pull/88885

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-003.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-003
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#88743"
+  - "#88905"
+  - "#88919"
+  - "#88681"
+  - "#90998"
+cluster_refs:
+  - "#88743"
+  - "#88905"
+  - "#88919"
+  - "#88681"
+  - "#90998"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.930Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 3
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #88743 docs(sms): add Twilio A2P delivery guidance
+
+- bucket: ready_for_maintainer
+- author: clawSean
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, triage: refactor-only, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look, channel: sms
+- live updated: 2026-06-13T08:46:30Z
+- live url: https://github.com/openclaw/openclaw/pull/88743
+
+### #88905 feat(dreaming): expose shadow-trial scoring in reports
+
+- bucket: ready_for_maintainer
+- author: iFiras-Max1
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, extensions: memory-core, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T02:31:49Z
+- live url: https://github.com/openclaw/openclaw/pull/88905
+
+### #88919 fix: allow preflight compaction to reenter session locks
+
+- bucket: ready_for_maintainer
+- author: plexustech2006
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-14T02:32:14Z
+- live url: https://github.com/openclaw/openclaw/pull/88919
+
+### #88681 Make runtime plugin startup stalls name in-flight plugins
+
+- bucket: ready_for_maintainer
+- author: alexzhu0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T03:09:42Z
+- live url: https://github.com/openclaw/openclaw/pull/88681
+
+### #90998 fix(sms): authorize text slash commands
+
+- bucket: ready_for_maintainer
+- author: clawSean
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look, channel: sms
+- live updated: 2026-06-14T08:13:43Z
+- live url: https://github.com/openclaw/openclaw/pull/90998

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-004.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-004
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90885"
+  - "#89816"
+  - "#77127"
+  - "#90154"
+  - "#90202"
+cluster_refs:
+  - "#90885"
+  - "#89816"
+  - "#77127"
+  - "#90154"
+  - "#90202"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.930Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 4
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #90885 fix(agent): resolve compaction model alias to canonical model ref
+
+- bucket: ready_for_maintainer
+- author: Pick-cat
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: re-review loop
+- live updated: 2026-06-14T18:42:59Z
+- live url: https://github.com/openclaw/openclaw/pull/90885
+
+### #89816 docs(gateway): add launchd supervisor loop troubleshooting
+
+- bucket: ready_for_maintainer
+- author: Pick-cat
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: macos, gateway, size: XS, proof: supplied, P3, rating: platinum hermit, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-14T20:06:49Z
+- live url: https://github.com/openclaw/openclaw/pull/89816
+
+### #77127 feat(tools/write): add append mode for agent writes
+
+- bucket: ready_for_maintainer
+- author: anyech
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: L, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-14T20:15:11Z
+- live url: https://github.com/openclaw/openclaw/pull/77127
+
+### #90154 fix(gateway): restrict backend self-pairing shared auth
+
+- bucket: ready_for_maintainer
+- author: coygeek
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-14T20:45:01Z
+- live url: https://github.com/openclaw/openclaw/pull/90154
+
+### #90202 feat(memory-wiki): add managed local source imports
+
+- bucket: ready_for_maintainer
+- author: Sunjae-k
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: L, extensions: memory-wiki, proof: supplied, proof: sufficient, P2, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-14T20:46:38Z
+- live url: https://github.com/openclaw/openclaw/pull/90202

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-005.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-005
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89997"
+  - "#80235"
+  - "#80293"
+  - "#80383"
+  - "#80455"
+cluster_refs:
+  - "#89997"
+  - "#80235"
+  - "#80293"
+  - "#80383"
+  - "#80455"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.930Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 5
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89997 fix(cli): suppress mcp serve startup stdout
+
+- bucket: ready_for_maintainer
+- author: kenners22
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-14T20:49:10Z
+- live url: https://github.com/openclaw/openclaw/pull/89997
+
+### #80235 feat(discord): add implicit reply mention policy
+
+- bucket: ready_for_maintainer
+- author: JiehoonKwak
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: discord, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T21:29:59Z
+- live url: https://github.com/openclaw/openclaw/pull/80235
+
+### #80293 fix: apply thread routing to plugin actions
+
+- bucket: ready_for_maintainer
+- author: artdaal
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: slack, size: S, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-14T21:31:02Z
+- live url: https://github.com/openclaw/openclaw/pull/80293
+
+### #80383 acp: cancel queued SessionActorQueue items on caller abort
+
+- bucket: ready_for_maintainer
+- author: helaskeutuja
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-14T21:32:57Z
+- live url: https://github.com/openclaw/openclaw/pull/80383
+
+### #80455 fix(doctor): suppress --fix trailer when no pending config changes remain
+
+- bucket: ready_for_maintainer
+- author: KeWang0622
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T21:34:39Z
+- live url: https://github.com/openclaw/openclaw/pull/80455

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-006.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-006
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#80473"
+  - "#80818"
+  - "#80916"
+  - "#80929"
+  - "#80985"
+cluster_refs:
+  - "#80473"
+  - "#80818"
+  - "#80916"
+  - "#80929"
+  - "#80985"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.931Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 6
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #80473 fix(discord): resolve redundant type constituents in native-command-route
+
+- bucket: ready_for_maintainer
+- author: KhanCold
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T21:34:49Z
+- live url: https://github.com/openclaw/openclaw/pull/80473
+
+### #80818 googlechat: add appPrincipal setup input + docs
+
+- bucket: ready_for_maintainer
+- author: alexuser
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: googlechat, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T21:42:40Z
+- live url: https://github.com/openclaw/openclaw/pull/80818
+
+### #80916 fix(memory): skip empty dreaming placeholders
+
+- bucket: ready_for_maintainer
+- author: hyspacex
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-14T21:46:04Z
+- live url: https://github.com/openclaw/openclaw/pull/80916
+
+### #80929 fix(outbound): classify deterministic delivery errors
+
+- bucket: ready_for_maintainer
+- author: honor2030
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-14T21:46:51Z
+- live url: https://github.com/openclaw/openclaw/pull/80929
+
+### #80985 fix(cron): reject announce->webchat at create time and runtime
+
+- bucket: ready_for_maintainer
+- author: esqandil
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T21:48:38Z
+- live url: https://github.com/openclaw/openclaw/pull/80985

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-007.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-007.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-007
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#81157"
+  - "#81190"
+  - "#90227"
+  - "#92892"
+  - "#81243"
+cluster_refs:
+  - "#81157"
+  - "#81190"
+  - "#90227"
+  - "#92892"
+  - "#81243"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.931Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 7
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #81157 fix(agents): reject invalid process.action at the tool invocation boundary
+
+- bucket: ready_for_maintainer
+- author: adone0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-14T21:52:34Z
+- live url: https://github.com/openclaw/openclaw/pull/81157
+
+### #81190 fix(agents): truncate tool results before overflow compaction
+
+- bucket: ready_for_maintainer
+- author: LLagoon3
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-14T21:53:49Z
+- live url: https://github.com/openclaw/openclaw/pull/81190
+
+### #90227 test: make zalo credentials tests compatible with Windows
+
+- bucket: ready_for_maintainer
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: zalouser, size: XS, proof: sufficient, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-14T21:58:19Z
+- live url: https://github.com/openclaw/openclaw/pull/90227
+
+### #92892 fix(gateway): allow Gemini CLI image-capable models
+
+- bucket: ready_for_maintainer
+- author: YonganZhang
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:05:45Z
+- live url: https://github.com/openclaw/openclaw/pull/92892
+
+### #81243 feat(discord): add fetch action to retrieve a single message by ID or URL
+
+- bucket: ready_for_maintainer
+- author: yousan
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, scripts, agents, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-14T22:13:00Z
+- live url: https://github.com/openclaw/openclaw/pull/81243

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-008.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-008.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-008
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#81641"
+  - "#81778"
+  - "#81825"
+  - "#81864"
+  - "#81916"
+cluster_refs:
+  - "#81641"
+  - "#81778"
+  - "#81825"
+  - "#81864"
+  - "#81916"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.931Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 8
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #81641 fix(cli): make `models aliases remove` honest about built-in aliases
+
+- bucket: ready_for_maintainer
+- author: ScientificProgrammer
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:17:50Z
+- live url: https://github.com/openclaw/openclaw/pull/81641
+
+### #81778 fix(status): detect shell-wrapped gateway services
+
+- bucket: ready_for_maintainer
+- author: liaoandi
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:19:09Z
+- live url: https://github.com/openclaw/openclaw/pull/81778
+
+### #81825 fix(skills/1password): stop forcing tmux for desktop app auth (#52540)
+
+- bucket: ready_for_maintainer
+- author: koshaji
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:46:17Z
+- live url: https://github.com/openclaw/openclaw/pull/81825
+
+### #81864 feat(approvals): add plain-language plugin approvals
+
+- bucket: ready_for_maintainer
+- author: kennykankush
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: discord, channel: imessage, channel: matrix, channel: nostr, channel: signal, channel: slack, channel: telegram, channel: whatsapp-web, channel: zalo, app: web-ui, extensions: memory-core, scripts, docker, agents, stale, size: XL, extensions: qa-lab, extensions: memory-wiki, extensions: codex, extensions: diagnostics-prometheus, extensions: deepinfra, proof: supplied, proof: sufficient, extensions: oc-path, mantis: telegram-visible-proof, extensions: diffs, extensions: google, extensions: openrouter, P2
+- live updated: 2026-06-14T22:47:39Z
+- live url: https://github.com/openclaw/openclaw/pull/81864
+
+### #81916 fix(compaction): bound stale transcript usage
+
+- bucket: ready_for_maintainer
+- author: jbetala7
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-14T22:48:53Z
+- live url: https://github.com/openclaw/openclaw/pull/81916

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-009.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-009.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-009
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#82495"
+  - "#82514"
+  - "#82562"
+  - "#82665"
+  - "#82870"
+cluster_refs:
+  - "#82495"
+  - "#82514"
+  - "#82562"
+  - "#82665"
+  - "#82870"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.931Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 9
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #82495 fix(doctor): scope state dir scan to current home
+
+- bucket: ready_for_maintainer
+- author: lidge-jun
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T23:01:56Z
+- live url: https://github.com/openclaw/openclaw/pull/82495
+
+### #82514 feat(ui-i18n): localize Settings toolbar chrome strings (#46217 partial)
+
+- bucket: ready_for_maintainer
+- author: ObliviateRickLin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XL, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-14T23:03:02Z
+- live url: https://github.com/openclaw/openclaw/pull/82514
+
+### #82562 fix(plugins): retain plugin tool registry after replacement
+
+- bucket: ready_for_maintainer
+- author: luoyanglang
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T23:05:24Z
+- live url: https://github.com/openclaw/openclaw/pull/82562
+
+### #82665 docs(messages): clarify session key queue lanes
+
+- bucket: ready_for_maintainer
+- author: vingov
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-14T23:06:31Z
+- live url: https://github.com/openclaw/openclaw/pull/82665
+
+### #82870 fix(agent): keep tool media authoritative in replies
+
+- bucket: ready_for_maintainer
+- author: Merlinzy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P1, rating: gold shrimp, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-14T23:08:50Z
+- live url: https://github.com/openclaw/openclaw/pull/82870

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-010.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-010.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-010
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#82906"
+  - "#82909"
+  - "#82985"
+  - "#83041"
+  - "#83048"
+cluster_refs:
+  - "#82906"
+  - "#82909"
+  - "#82985"
+  - "#83041"
+  - "#83048"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.931Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 10
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #82906 fix(codex): gate CLI session resume behind plugin approval
+
+- bucket: ready_for_maintainer
+- author: LaPhilosophie
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: M, extensions: codex, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-14T23:09:44Z
+- live url: https://github.com/openclaw/openclaw/pull/82906
+
+### #82909 fix(telegram): repair message cache reply types
+
+- bucket: ready_for_maintainer
+- author: lidge-jun
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T23:09:55Z
+- live url: https://github.com/openclaw/openclaw/pull/82909
+
+### #82985 feat(plugins): pass engine candidates to MemoryCorpusSupplement.search
+
+- bucket: ready_for_maintainer
+- author: ubehera
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, extensions: memory-core, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T23:11:37Z
+- live url: https://github.com/openclaw/openclaw/pull/82985
+
+### #83041 Fix config patch restart-required notices
+
+- bucket: ready_for_maintainer
+- author: xuruiray
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: supplied, proof: sufficient, P3, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-14T23:12:29Z
+- live url: https://github.com/openclaw/openclaw/pull/83041
+
+### #83048 fix(a2a): resolve direct/dm announce target from session-key fallback
+
+- bucket: ready_for_maintainer
+- author: avatasia
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T23:12:51Z
+- live url: https://github.com/openclaw/openclaw/pull/83048

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-011.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-011.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-011
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90489"
+  - "#90537"
+  - "#79832"
+  - "#83227"
+  - "#83296"
+cluster_refs:
+  - "#90489"
+  - "#90537"
+  - "#79832"
+  - "#83227"
+  - "#83296"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.931Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 11
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #90489 fix(sessions): clarify cross-agent visibility guidance
+
+- bucket: ready_for_maintainer
+- author: sahibzada-allahyar
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T23:18:05Z
+- live url: https://github.com/openclaw/openclaw/pull/90489
+
+### #90537 Warn on generated wrapper overwrites and status diagnostics
+
+- bucket: ready_for_maintainer
+- author: TurboTheTurtle
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, cli, commands, size: M, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-14T23:51:45Z
+- live url: https://github.com/openclaw/openclaw/pull/90537
+
+### #79832 feishu: replace deprecated card V2 `action` container with `column_set`
+
+- bucket: ready_for_maintainer
+- author: xiabee
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: M, proof: supplied, proof: sufficient, P1, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-15T00:00:49Z
+- live url: https://github.com/openclaw/openclaw/pull/79832
+
+### #83227 fix(openai): mark mp3 TTS voice output compatible
+
+- bucket: ready_for_maintainer
+- author: HemantSudarshan
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: openai, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T00:06:09Z
+- live url: https://github.com/openclaw/openclaw/pull/83227
+
+### #83296 Avoid writing plaintext profile keys to models.json
+
+- bucket: ready_for_maintainer
+- author: JackSpiece
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: gold shrimp, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-15T00:08:31Z
+- live url: https://github.com/openclaw/openclaw/pull/83296

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-012.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-012.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-012
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93093"
+  - "#83489"
+  - "#83718"
+  - "#83842"
+  - "#90738"
+cluster_refs:
+  - "#93093"
+  - "#83489"
+  - "#83718"
+  - "#83842"
+  - "#90738"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.931Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 12
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #93093 docs(memory): warn about session memory overlap
+
+- bucket: ready_for_maintainer
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T00:10:15Z
+- live url: https://github.com/openclaw/openclaw/pull/93093
+
+### #83489 Fix gateway service startup race
+
+- bucket: ready_for_maintainer
+- author: ThiagoCAltoe
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, triage: refactor-only, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-15T00:12:16Z
+- live url: https://github.com/openclaw/openclaw/pull/83489
+
+### #83718 fix(memory-core): treat dreaming fence marker lines as inside-fence in promotion guard (#80613)
+
+- bucket: ready_for_maintainer
+- author: grifjef
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T00:17:12Z
+- live url: https://github.com/openclaw/openclaw/pull/83718
+
+### #83842 fix(discord): add native reply opt-out
+
+- bucket: ready_for_maintainer
+- author: reirei-agent
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T00:18:49Z
+- live url: https://github.com/openclaw/openclaw/pull/83842
+
+### #90738 fix(msteams): read file attachments on Teams channel messages (team GUID + channel fallback + thread-reply URL)
+
+- bucket: ready_for_maintainer
+- author: colton-octaria
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: msteams, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T00:25:56Z
+- live url: https://github.com/openclaw/openclaw/pull/90738

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-013.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-013.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-013
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#79397"
+  - "#79910"
+  - "#80681"
+  - "#80928"
+  - "#80981"
+cluster_refs:
+  - "#79397"
+  - "#79910"
+  - "#80681"
+  - "#80928"
+  - "#80981"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.932Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 13
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #79397 fix(nextcloud-talk): parse structured mention payloads
+
+- bucket: ready_for_maintainer
+- author: iclem
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: nextcloud-talk, size: L, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T00:36:59Z
+- live url: https://github.com/openclaw/openclaw/pull/79397
+
+### #79910 fix(sessions): recover store from stale temp artifacts safely
+
+- bucket: ready_for_maintainer
+- author: wAngByg
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, triage: blank-template, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-15T00:37:18Z
+- live url: https://github.com/openclaw/openclaw/pull/79910
+
+### #80681 feat(trajectory): allow OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES override for per-event byte cap
+
+- bucket: ready_for_maintainer
+- author: wAngByg
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: M, extensions: codex, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T00:38:02Z
+- live url: https://github.com/openclaw/openclaw/pull/80681
+
+### #80928 fix(telegram): suppress fallback reply when plugin command returns suppressReply: true
+
+- bucket: ready_for_maintainer
+- author: alexuser
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, size: XS, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look, proof: video
+- live updated: 2026-06-15T00:38:32Z
+- live url: https://github.com/openclaw/openclaw/pull/80928
+
+### #80981 docs(cli): clarify strict json parsing
+
+- bucket: ready_for_maintainer
+- author: addu2612
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-15T00:38:36Z
+- live url: https://github.com/openclaw/openclaw/pull/80981

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-014.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-014.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-014
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#81572"
+  - "#84028"
+  - "#84140"
+  - "#84156"
+  - "#84288"
+cluster_refs:
+  - "#81572"
+  - "#84028"
+  - "#84140"
+  - "#84156"
+  - "#84288"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.932Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 14
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #81572 fix(cron): persist due job outcomes incrementally
+
+- bucket: ready_for_maintainer
+- author: efpiva
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-15T00:43:37Z
+- live url: https://github.com/openclaw/openclaw/pull/81572
+
+### #84028 fix(ui): improve Arabic Control UI translations
+
+- bucket: ready_for_maintainer
+- author: aim9sour
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T00:50:26Z
+- live url: https://github.com/openclaw/openclaw/pull/84028
+
+### #84140 chore: format oxfmt-touched files
+
+- bucket: ready_for_maintainer
+- author: tw19880217-creator
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, cli, scripts, commands, agents, size: M, extensions: kimi-coding, extensions: qa-lab, extensions: memory-wiki, triage: refactor-only, triage: dirty-candidate, extensions: deepinfra, proof: supplied, proof: sufficient, extensions: oc-path, extensions: google, extensions: openrouter, P3, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-15T00:52:52Z
+- live url: https://github.com/openclaw/openclaw/pull/84140
+
+### #84156 fix(cron): respect recovered tool errors
+
+- bucket: ready_for_maintainer
+- author: Elarwei001
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T00:53:09Z
+- live url: https://github.com/openclaw/openclaw/pull/84156
+
+### #84288 fix(discord): avoid duplicate typing keepalive for tool replies
+
+- bucket: ready_for_maintainer
+- author: dr00-eth
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: S, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T00:56:08Z
+- live url: https://github.com/openclaw/openclaw/pull/84288

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-015.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-015.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-015
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#81467"
+  - "#77539"
+  - "#84453"
+  - "#84485"
+  - "#84554"
+cluster_refs:
+  - "#81467"
+  - "#77539"
+  - "#84453"
+  - "#84485"
+  - "#84554"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.932Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 15
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #81467 fix(usage): show every calendar day in Daily Token Usage / Daily Cost chart
+
+- bucket: ready_for_maintainer
+- author: adapepper
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T01:00:46Z
+- live url: https://github.com/openclaw/openclaw/pull/81467
+
+### #77539 fix(subagent): preserve steered task text on restart redispatch
+
+- bucket: ready_for_maintainer
+- author: amittell
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, agents, size: S, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-15T01:21:59Z
+- live url: https://github.com/openclaw/openclaw/pull/77539
+
+### #84453 fix(scripts): detect destructured/re-export/dynamic imports in dist scanner
+
+- bucket: ready_for_maintainer
+- author: iFwu
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: L, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: automation, status: ready for maintainer look
+- live updated: 2026-06-15T01:27:26Z
+- live url: https://github.com/openclaw/openclaw/pull/84453
+
+### #84485 fix(discord): guard message-tool-only final delivery
+
+- bucket: ready_for_maintainer
+- author: anyech
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XL, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T01:28:08Z
+- live url: https://github.com/openclaw/openclaw/pull/84485
+
+### #84554 fix(memory-core): guard builtin fallback after qmd failures
+
+- bucket: ready_for_maintainer
+- author: jetd1
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T01:28:59Z
+- live url: https://github.com/openclaw/openclaw/pull/84554

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-016.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-016.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-016
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#84584"
+  - "#84589"
+  - "#84636"
+  - "#84708"
+  - "#84728"
+cluster_refs:
+  - "#84584"
+  - "#84589"
+  - "#84636"
+  - "#84708"
+  - "#84728"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.932Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 16
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #84584 fix: enforce slash command boundaries
+
+- bucket: ready_for_maintainer
+- author: JulyanXu
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T01:30:28Z
+- live url: https://github.com/openclaw/openclaw/pull/84584
+
+### #84589 fix(message): describe channel parameter as provider name
+
+- bucket: ready_for_maintainer
+- author: spacegeologist
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: automation, status: ready for maintainer look
+- live updated: 2026-06-15T01:30:34Z
+- live url: https://github.com/openclaw/openclaw/pull/84589
+
+### #84636 memory: add local continuity snapshot helpers
+
+- bucket: ready_for_maintainer
+- author: iHow1
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XL, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T01:31:48Z
+- live url: https://github.com/openclaw/openclaw/pull/84636
+
+### #84708 fix(agents): recover message-tool mirror replay poison
+
+- bucket: ready_for_maintainer
+- author: anyech
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-15T01:33:55Z
+- live url: https://github.com/openclaw/openclaw/pull/84708
+
+### #84728 Repair orphaned Codex custom tool outputs before resume
+
+- bucket: ready_for_maintainer
+- author: pfrederiksen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, extensions: codex, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-15T01:34:33Z
+- live url: https://github.com/openclaw/openclaw/pull/84728

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-017.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-017.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-017
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#84738"
+  - "#84772"
+  - "#90836"
+  - "#73704"
+  - "#80823"
+cluster_refs:
+  - "#84738"
+  - "#84772"
+  - "#90836"
+  - "#73704"
+  - "#80823"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.932Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 17
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #84738 Stop writing plaintext provider keys to models.json
+
+- bucket: ready_for_maintainer
+- author: Finesssee
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-15T01:34:40Z
+- live url: https://github.com/openclaw/openclaw/pull/84738
+
+### #84772 fix(codex): honor tool result cap in app-server transcripts
+
+- bucket: ready_for_maintainer
+- author: hansolo949
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: M, extensions: codex, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-15T01:35:23Z
+- live url: https://github.com/openclaw/openclaw/pull/84772
+
+### #90836 fix(cron): block self-narrating auto-announce replies
+
+- bucket: ready_for_maintainer
+- author: jsasson
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look, proof: video
+- live updated: 2026-06-15T01:41:31Z
+- live url: https://github.com/openclaw/openclaw/pull/90836
+
+### #73704 fix(safeguard): resolve compaction provider/model before registering runtime
+
+- bucket: ready_for_maintainer
+- author: joeykrug
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: slack, channel: whatsapp-web, app: web-ui, gateway, cli, scripts, agents, size: L, extensions: memory-wiki, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-15T01:57:52Z
+- live url: https://github.com/openclaw/openclaw/pull/73704
+
+### #80823 fix(cli): differentiate gateway-restart hint for hot-loadable agent config sets (#80722)
+
+- bucket: ready_for_maintainer
+- author: kiranmagic7
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, cli, size: M, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-15T01:58:15Z
+- live url: https://github.com/openclaw/openclaw/pull/80823

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-018.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-018.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-018
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#81341"
+  - "#83698"
+  - "#84871"
+  - "#84894"
+  - "#84895"
+cluster_refs:
+  - "#81341"
+  - "#83698"
+  - "#84871"
+  - "#84894"
+  - "#84895"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.932Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 18
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #81341 [AI-assisted] Fix ACP bound thread follow-up delivery
+
+- bucket: ready_for_maintainer
+- author: qiyueqiu
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: sufficient, P2, rating: gold shrimp, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T01:58:41Z
+- live url: https://github.com/openclaw/openclaw/pull/81341
+
+### #83698 fix(gateway): rejected config.patch/apply never queues SIGUSR1 restart
+
+- bucket: ready_for_maintainer
+- author: adapepper
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-15T02:02:04Z
+- live url: https://github.com/openclaw/openclaw/pull/83698
+
+### #84871 fix(codex): preserve responses session streams
+
+- bucket: ready_for_maintainer
+- author: nxmxbbd
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: auth-provider, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-15T02:04:18Z
+- live url: https://github.com/openclaw/openclaw/pull/84871
+
+### #84894 [codex] Fix empty result after exec stdout turns
+
+- bucket: ready_for_maintainer
+- author: zhulijin1991
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, extensions: codex, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: message-delivery, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-15T02:04:52Z
+- live url: https://github.com/openclaw/openclaw/pull/84894
+
+### #84895 Forward cron toolsAllow to CLI runs
+
+- bucket: ready_for_maintainer
+- author: zhulijin1991
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T02:05:02Z
+- live url: https://github.com/openclaw/openclaw/pull/84895

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-019.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-019.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-019
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#85003"
+  - "#85112"
+  - "#85155"
+  - "#85238"
+  - "#85292"
+cluster_refs:
+  - "#85003"
+  - "#85112"
+  - "#85155"
+  - "#85238"
+  - "#85292"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.932Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 19
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #85003 fix(line): register credential secret targets
+
+- bucket: ready_for_maintainer
+- author: DYSfu
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: line, commands, size: L, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T02:07:47Z
+- live url: https://github.com/openclaw/openclaw/pull/85003
+
+### #85112 feat(matrix): opt-in mention bypass for in-thread replies (threadBindings.bypassMentionInBoundThreads)
+
+- bucket: ready_for_maintainer
+- author: paulmeier
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: matrix, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T02:11:06Z
+- live url: https://github.com/openclaw/openclaw/pull/85112
+
+### #85155 fix(agents): avoid inviting provider swaps in model alias guidance
+
+- bucket: ready_for_maintainer
+- author: extrasmall0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-15T02:12:02Z
+- live url: https://github.com/openclaw/openclaw/pull/85155
+
+### #85238 fix: include pnpm 11 bins in gateway PATH
+
+- bucket: ready_for_maintainer
+- author: shbernal
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T02:14:27Z
+- live url: https://github.com/openclaw/openclaw/pull/85238
+
+### #85292 fix(config): scope dry-run bundled channel validation
+
+- bucket: ready_for_maintainer
+- author: zarapharr
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T02:15:34Z
+- live url: https://github.com/openclaw/openclaw/pull/85292

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-020.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-020.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-020
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#85296"
+  - "#85308"
+  - "#85368"
+  - "#85396"
+  - "#85400"
+cluster_refs:
+  - "#85296"
+  - "#85308"
+  - "#85368"
+  - "#85396"
+  - "#85400"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.932Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 20
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #85296 fix(codex): derive terminal-idle watchdog from effective run timeout
+
+- bucket: ready_for_maintainer
+- author: alkor2000
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, extensions: codex, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-15T02:15:41Z
+- live url: https://github.com/openclaw/openclaw/pull/85296
+
+### #85308 fix(subagents): preserve requester wake on visible delivery failure
+
+- bucket: ready_for_maintainer
+- author: DolencLuka
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T02:15:45Z
+- live url: https://github.com/openclaw/openclaw/pull/85308
+
+### #85368 fix(media): avoid eager provider startup for audio listing
+
+- bucket: ready_for_maintainer
+- author: FelixIsaac
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: M, extensions: senseaudio, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T02:16:57Z
+- live url: https://github.com/openclaw/openclaw/pull/85368
+
+### #85396 perf(cli): skip config load for default root help
+
+- bucket: ready_for_maintainer
+- author: FelixIsaac
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T02:17:24Z
+- live url: https://github.com/openclaw/openclaw/pull/85396
+
+### #85400 test(perf): compare saved CLI startup benchmarks
+
+- bucket: ready_for_maintainer
+- author: FelixIsaac
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T02:17:44Z
+- live url: https://github.com/openclaw/openclaw/pull/85400

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-021.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-021.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-021
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90870"
+  - "#90882"
+  - "#90924"
+  - "#90933"
+  - "#90942"
+cluster_refs:
+  - "#90870"
+  - "#90882"
+  - "#90924"
+  - "#90933"
+  - "#90942"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.933Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 21
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #90870 [AI] fix(memory-wiki): index wiki pages in query-dir subfolders
+
+- bucket: ready_for_maintainer
+- author: Agent-Aurelius
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: memory-wiki, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-15T02:32:10Z
+- live url: https://github.com/openclaw/openclaw/pull/90870
+
+### #90882 fix: add self-knowledge docs rule to system prompt
+
+- bucket: ready_for_maintainer
+- author: SutraHsing
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T02:32:33Z
+- live url: https://github.com/openclaw/openclaw/pull/90882
+
+### #90924 fix(gateway): sanitize assistant reasoning before history truncation
+
+- bucket: ready_for_maintainer
+- author: 849261680
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T02:34:00Z
+- live url: https://github.com/openclaw/openclaw/pull/90924
+
+### #90933 [AI-assisted] fix(cli): surface session lane busy exits
+
+- bucket: ready_for_maintainer
+- author: IWhatsskill
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, commands, agents, size: L, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T02:34:29Z
+- live url: https://github.com/openclaw/openclaw/pull/90933
+
+### #90942 fix(doctor): follow symlinked launcher when locating sandbox setup scripts
+
+- bucket: ready_for_maintainer
+- author: sasan1200
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T02:34:49Z
+- live url: https://github.com/openclaw/openclaw/pull/90942

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-022.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-022.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-022
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#85466"
+  - "#85616"
+  - "#85710"
+  - "#85866"
+  - "#85899"
+cluster_refs:
+  - "#85466"
+  - "#85616"
+  - "#85710"
+  - "#85866"
+  - "#85899"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.933Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 22
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #85466 Capture image-generation provider usage metadata
+
+- bucket: ready_for_maintainer
+- author: promptclickrun
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: openai, extensions: fal, proof: supplied, proof: sufficient, extensions: google, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T02:43:28Z
+- live url: https://github.com/openclaw/openclaw/pull/85466
+
+### #85616 fix(auto-reply): fast path text control commands
+
+- bucket: ready_for_maintainer
+- author: litang9
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, channel: feishu, size: L, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: automation, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T02:47:26Z
+- live url: https://github.com/openclaw/openclaw/pull/85616
+
+### #85710 fix: use FLAG_TERMINATOR constant in getCommandPathInternal
+
+- bucket: ready_for_maintainer
+- author: d3Lap1ace
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T02:52:25Z
+- live url: https://github.com/openclaw/openclaw/pull/85710
+
+### #85866 [codex] Add WhatsApp phone-code login
+
+- bucket: ready_for_maintainer
+- author: VishalJ99
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: whatsapp-web, app: macos, cli, size: L, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-15T02:57:15Z
+- live url: https://github.com/openclaw/openclaw/pull/85866
+
+### #85899 docs(memory): align descriptors and docs with recursive memory/**/*.md
+
+- bucket: ready_for_maintainer
+- author: leafbird
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, extensions: memory-core, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T02:58:34Z
+- live url: https://github.com/openclaw/openclaw/pull/85899

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-023.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-023.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-023
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#86062"
+  - "#86085"
+  - "#86088"
+  - "#86233"
+  - "#86893"
+cluster_refs:
+  - "#86062"
+  - "#86085"
+  - "#86088"
+  - "#86233"
+  - "#86893"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.933Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 23
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #86062 feat(ui): timestamp unnamed dashboard sessions
+
+- bucket: ready_for_maintainer
+- author: davidmosiah
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T03:03:15Z
+- live url: https://github.com/openclaw/openclaw/pull/86062
+
+### #86085 i18n(zh-TW): align Control UI locale with Taiwan-standard terminology
+
+- bucket: ready_for_maintainer
+- author: p3nchan
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: M, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T03:03:59Z
+- live url: https://github.com/openclaw/openclaw/pull/86085
+
+### #86088 fix(tasks): recover terminal lost cron rows
+
+- bucket: ready_for_maintainer
+- author: liaoandi
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-15T03:04:07Z
+- live url: https://github.com/openclaw/openclaw/pull/86088
+
+### #86233 fix(codex): cap managed app-server trace logs
+
+- bucket: ready_for_maintainer
+- author: ghitafilali
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: L, extensions: codex, proof: supplied, proof: sufficient, P1, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T03:08:53Z
+- live url: https://github.com/openclaw/openclaw/pull/86233
+
+### #86893 Fix isolated cron cold runner setup timeout
+
+- bucket: ready_for_maintainer
+- author: dredozubov
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P1, rating: gold shrimp, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-15T03:31:00Z
+- live url: https://github.com/openclaw/openclaw/pull/86893

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-024.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-024.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-024
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#86900"
+  - "#86913"
+  - "#87061"
+  - "#88908"
+  - "#87121"
+cluster_refs:
+  - "#86900"
+  - "#86913"
+  - "#87061"
+  - "#88908"
+  - "#87121"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.933Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 24
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #86900 fix(compaction): add circuit breaker to stop token burn when summarizer unavailable
+
+- bucket: ready_for_maintainer
+- author: tanshanshan
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-15T03:31:09Z
+- live url: https://github.com/openclaw/openclaw/pull/86900
+
+### #86913 fix(gateway): expose restart pending state
+
+- bucket: ready_for_maintainer
+- author: Dizesales
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: M, proof: supplied, proof: sufficient, extensions: admin-http-rpc, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T03:31:31Z
+- live url: https://github.com/openclaw/openclaw/pull/86913
+
+### #87061 feat(agents): add top-level subsystem logger
+
+- bucket: ready_for_maintainer
+- author: caulslorenzo1-png
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T03:35:08Z
+- live url: https://github.com/openclaw/openclaw/pull/87061
+
+### #88908 fix(gateway): force exit on zombie shutdown + 503 healthz during shutdown
+
+- bucket: ready_for_maintainer
+- author: amittell
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, cli, size: L, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-15T03:35:42Z
+- live url: https://github.com/openclaw/openclaw/pull/88908
+
+### #87121 test(cli): add banner emission reset helper
+
+- bucket: ready_for_maintainer
+- author: lizuju
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T03:36:46Z
+- live url: https://github.com/openclaw/openclaw/pull/87121

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-025.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-025.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-025
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#87231"
+  - "#79568"
+  - "#84540"
+  - "#86279"
+  - "#87800"
+cluster_refs:
+  - "#87231"
+  - "#79568"
+  - "#84540"
+  - "#86279"
+  - "#87800"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.933Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 25
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #87231 feat(feishu): include reply context in comment auto replies
+
+- bucket: ready_for_maintainer
+- author: wittam-01
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T03:39:33Z
+- live url: https://github.com/openclaw/openclaw/pull/87231
+
+### #79568 docs(vps): move related links into standard Related section
+
+- bucket: ready_for_maintainer
+- author: GGzili
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T03:54:00Z
+- live url: https://github.com/openclaw/openclaw/pull/79568
+
+### #84540 fix(cli-runner): emit run.progress diagnostic events during CLI stdou
+
+- bucket: ready_for_maintainer
+- author: SkyWolfDreamer
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-15T04:35:34Z
+- live url: https://github.com/openclaw/openclaw/pull/84540
+
+### #86279 fix: keep media generation success on delivery failure
+
+- bucket: ready_for_maintainer
+- author: tianxiaochannel-oss88
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, stale, size: XS, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T05:05:54Z
+- live url: https://github.com/openclaw/openclaw/pull/86279
+
+### #87800 fix(google-vertex): add Google Vertex AI onboarding wizard, fix ADC auth, add provider docs
+
+- bucket: ready_for_maintainer
+- author: koverholt
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: M, proof: supplied, proof: sufficient, extensions: google, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-15T05:12:01Z
+- live url: https://github.com/openclaw/openclaw/pull/87800

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-026.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-026.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-026
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#87861"
+  - "#88886"
+  - "#87891"
+  - "#87923"
+  - "#87986"
+cluster_refs:
+  - "#87861"
+  - "#88886"
+  - "#87891"
+  - "#87923"
+  - "#87986"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.933Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 26
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #87861 fix(model-usage): coerce numeric-string costs and ignore non-finite values
+
+- bucket: ready_for_maintainer
+- author: coder999999999
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-15T05:13:28Z
+- live url: https://github.com/openclaw/openclaw/pull/87861
+
+### #88886 docs(agents): add recovery card handoff guidance
+
+- bucket: ready_for_maintainer
+- author: m4stanuj
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, stale, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T05:13:49Z
+- live url: https://github.com/openclaw/openclaw/pull/88886
+
+### #87891 fix(telegram): expose spooled handler timeout config
+
+- bucket: ready_for_maintainer
+- author: khang-dogo
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, size: XS, triage: dirty-candidate, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T05:14:08Z
+- live url: https://github.com/openclaw/openclaw/pull/87891
+
+### #87923 fix(thinking): keep explicit session thinkingLevel when runtime downgrades (#87740)
+
+- bucket: ready_for_maintainer
+- author: hoobnn
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T05:14:37Z
+- live url: https://github.com/openclaw/openclaw/pull/87923
+
+### #87986 docs(skills): allow model-usage with Linux codexbar
+
+- bucket: ready_for_maintainer
+- author: shbernal
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: sufficient, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-15T05:16:25Z
+- live url: https://github.com/openclaw/openclaw/pull/87986

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-027.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-027.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-027
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#88052"
+  - "#88061"
+  - "#88085"
+  - "#88098"
+  - "#88150"
+cluster_refs:
+  - "#88052"
+  - "#88061"
+  - "#88085"
+  - "#88098"
+  - "#88150"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.933Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 27
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #88052 fix(proxy): add error handler on upstream response stream
+
+- bucket: ready_for_maintainer
+- author: SebTardif
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T05:18:13Z
+- live url: https://github.com/openclaw/openclaw/pull/88052
+
+### #88061 docs: fix accuracy drift across docs (config defaults, model aliases, anchors, terminology)
+
+- bucket: ready_for_maintainer
+- author: hoobnn
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, channel: tlon, channel: zalouser, app: android, app: macos, gateway, channel: feishu, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look, extensions: copilot
+- live updated: 2026-06-15T05:18:33Z
+- live url: https://github.com/openclaw/openclaw/pull/88061
+
+### #88085 fix(cli): guard against commander rawArgs API drift in action reparse
+
+- bucket: ready_for_maintainer
+- author: Ylsssq926
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T05:19:36Z
+- live url: https://github.com/openclaw/openclaw/pull/88085
+
+### #88098 feat(onboard): add --custom-context-window flag for non-interactive setup
+
+- bucket: ready_for_maintainer
+- author: ericlevine
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, commands, size: S, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T05:19:46Z
+- live url: https://github.com/openclaw/openclaw/pull/88098
+
+### #88150 fix(config): cap runtime session-store cache retention
+
+- bucket: ready_for_maintainer
+- author: yozakura-ava
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T05:20:19Z
+- live url: https://github.com/openclaw/openclaw/pull/88150

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-028.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-028.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-028
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#88203"
+  - "#88206"
+  - "#88400"
+  - "#88401"
+  - "#73163"
+cluster_refs:
+  - "#88203"
+  - "#88206"
+  - "#88400"
+  - "#88401"
+  - "#73163"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.933Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 28
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #88203 fix(approvals): handle stale plugin waits
+
+- bucket: ready_for_maintainer
+- author: TurboTheTurtle
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, extensions: codex, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T05:21:17Z
+- live url: https://github.com/openclaw/openclaw/pull/88203
+
+### #88206 fix(codex): coalesce in-flight dynamic tool calls
+
+- bucket: ready_for_maintainer
+- author: litang9
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, extensions: codex, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T05:21:31Z
+- live url: https://github.com/openclaw/openclaw/pull/88206
+
+### #88400 fix(config): accept overlays for bundled provider aliases
+
+- bucket: ready_for_maintainer
+- author: Pluviobyte
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: blank-template, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T05:26:28Z
+- live url: https://github.com/openclaw/openclaw/pull/88400
+
+### #88401 fix(agents): safely record non-json transport errors
+
+- bucket: ready_for_maintainer
+- author: Pluviobyte
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T05:26:31Z
+- live url: https://github.com/openclaw/openclaw/pull/88401
+
+### #73163 fix(gateway): warn for insecure Control UI access
+
+- bucket: ready_for_maintainer
+- author: pfrederiksen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, scripts, stale, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T06:35:24Z
+- live url: https://github.com/openclaw/openclaw/pull/73163

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-029.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-029.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-029
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#81696"
+  - "#81731"
+  - "#80627"
+  - "#86901"
+  - "#71863"
+cluster_refs:
+  - "#81696"
+  - "#81731"
+  - "#80627"
+  - "#86901"
+  - "#71863"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.934Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 29
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #81696 fix: guard tool event callbacks (AI-assisted)
+
+- bucket: ready_for_maintainer
+- author: enjoylife1243
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-15T06:46:56Z
+- live url: https://github.com/openclaw/openclaw/pull/81696
+
+### #81731 fix(cron): treat exact-second cron slots as valid in stale-future repair
+
+- bucket: ready_for_maintainer
+- author: yashkot007
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-15T06:47:11Z
+- live url: https://github.com/openclaw/openclaw/pull/81731
+
+### #80627 fix: improve error messages for skills update argument validation
+
+- bucket: ready_for_maintainer
+- author: Sujabaral
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T07:05:08Z
+- live url: https://github.com/openclaw/openclaw/pull/80627
+
+### #86901 fix(feishu): fall back to post mode when markdown tables exceed card limit
+
+- bucket: ready_for_maintainer
+- author: name5566
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: XS, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T07:15:28Z
+- live url: https://github.com/openclaw/openclaw/pull/86901
+
+### #71863 fix(signal): await daemon shutdown on restart
+
+- bucket: ready_for_maintainer
+- author: ZHOUKAILIAN
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: signal, size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-15T07:19:03Z
+- live url: https://github.com/openclaw/openclaw/pull/71863

--- a/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-030.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260617T073528-030.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260617T073528-030
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#73079"
+  - "#73338"
+  - "#75371"
+  - "#75662"
+  - "#78381"
+cluster_refs:
+  - "#73079"
+  - "#73338"
+  - "#75371"
+  - "#75662"
+  - "#78381"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently and only recommend merge or repair after complete live preflight."
+notes: "Generated from live GitHub open PR inventory on 2026-06-17T07:35:28.934Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 30
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` when a maintainer-safe repair path is concrete. Use `needs_human` for unclear scope, active author follow-up, broad work, or missing proof. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #73079 fix(minimax): request hex TTS output explicitly
+
+- bucket: ready_for_maintainer
+- author: efe-arv
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, extensions: minimax, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T07:21:13Z
+- live url: https://github.com/openclaw/openclaw/pull/73079
+
+### #73338 fix(tui): follow active gateway port
+
+- bucket: ready_for_maintainer
+- author: haishmg
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, cli, size: M, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-15T07:22:02Z
+- live url: https://github.com/openclaw/openclaw/pull/73338
+
+### #75371 Gateway: guard session-run cancel requester in minimal tests
+
+- bucket: ready_for_maintainer
+- author: seoseo-ai
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, scripts, size: L, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-15T07:30:19Z
+- live url: https://github.com/openclaw/openclaw/pull/75371
+
+### #75662 fix(agents): pause yielded main-session runs
+
+- bucket: ready_for_maintainer
+- author: amittell
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, agents, size: L, extensions: codex, triage: dirty-candidate, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-15T07:30:48Z
+- live url: https://github.com/openclaw/openclaw/pull/75662
+
+### #78381 feat(embedded-runner): expose prep stage timings
+
+- bucket: ready_for_maintainer
+- author: guanbear
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: slack, channel: telegram, channel: whatsapp-web, app: web-ui, gateway, extensions: memory-core, cli, scripts, agents, size: M, extensions: memory-wiki, triage: blank-template, triage: dirty-candidate, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T07:31:28Z
+- live url: https://github.com/openclaw/openclaw/pull/78381


### PR DESCRIPTION
Stages 30 fresh, plan-only remediation shards over 150 live `ready_for_maintainer` OpenClaw PRs.

The jobs block close, comment, label, branch push, and bypass actions. Each worker must rehydrate current state and emit bounded merge/repair candidates for promotion.

Validation: `npm run validate` (5,781 jobs); `git diff --check`.