### PR TITLE
fix(results): preserve executed apply actions

### DIFF
--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -108,8 +108,32 @@ const reportPath =
   typeof reportPathArg === "string"
     ? path.resolve(reportPathArg)
     : path.join(path.dirname(resultPath), "apply-report.json");
+report.apply_attempts = [
+  ...readApplyAttempts(reportPath),
+  {
+    dry_run: report.dry_run,
+    result_path: report.result_path,
+    applied_at: report.applied_at,
+    actions: report.actions,
+  },
+];
 fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
 console.log(JSON.stringify(report, null, 2));
+
+function readApplyAttempts(reportPath) {
+  if (!fs.existsSync(reportPath)) return [];
+  const previous = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  if (Array.isArray(previous.apply_attempts)) return previous.apply_attempts;
+  if (!Array.isArray(previous.actions)) return [];
+  return [
+    {
+      dry_run: previous.dry_run ?? null,
+      result_path: previous.result_path ?? null,
+      applied_at: previous.applied_at ?? null,
+      actions: previous.actions,
+    },
+  ];
+}
 
 function findLatestResultPath() {
   const runsRoot = path.join(repoRoot(), ".projectclownfish", "runs");

--- a/scripts/publish-result.mjs
+++ b/scripts/publish-result.mjs
@@ -70,10 +70,14 @@ function publishResult(resultPath) {
   const repo = String(result.repo ?? "unknown/unknown");
   const owner = repo.split("/")[0] || "unknown";
   const clusterId = String(result.cluster_id ?? path.basename(runDir));
-  const applyActions = uniquePlainActionRows([
-    ...(applyReport.actions ?? []),
-    ...(postFlightReport.actions ?? []).filter(isPostFlightApplyAction).map(postFlightToApplyAction),
-  ].filter(isApplicatorAction));
+  const applyAuditActions = [
+    ...readApplyAuditActions(applyReport),
+    ...(postFlightReport.actions ?? [])
+      .filter(isPostFlightApplyAction)
+      .map(postFlightToApplyAction)
+      .map((action) => ({ ...action, report_source: "post_flight" })),
+  ].filter(isApplicatorAction);
+  const applyActions = uniquePlainActionRows(applyAuditActions);
   const fixActions = (fixReport.actions ?? []).map(sanitizeFixAction);
   const repairCandidate = sanitizeRepairCandidate({
     result,
@@ -111,6 +115,7 @@ function publishResult(resultPath) {
     repair_candidate: repairCandidate,
     fix_actions: fixActions,
     apply_actions: applyActions.map(sanitizeApplyAction),
+    apply_audit_actions: applyAuditActions.map(sanitizeApplyAction),
   };
 
   const reportDir = path.join(repoRoot(), "results", owner);
@@ -149,6 +154,12 @@ function renderClusterReport(report) {
     .map(
       (action) =>
         `| ${action.target || ""} | ${action.action || ""} | ${action.status || ""} | ${action.classification || ""} | ${action.reason || ""} |`,
+    )
+    .join("\n");
+  const applyAuditActions = report.apply_audit_actions
+    .map(
+      (action) =>
+        `| ${action.apply_attempt ?? ""} | ${action.report_source || ""} | ${action.target || ""} | ${action.action || ""} | ${action.status || ""} | ${action.reason || ""} |`,
     )
     .join("\n");
   const fixActions = (report.fix_actions ?? [])
@@ -231,6 +242,12 @@ ${fixActions || "| _None_ |  |  |  |  |"}
 | Target | Action | Status | Classification | Reason |
 | --- | --- | --- | --- | --- |
 ${applyActions || "| _None_ |  |  |  |  |"}
+
+## Apply Audit
+
+| Attempt | Source | Target | Action | Status | Reason |
+| --- | --- | --- | --- | --- |
+${applyAuditActions || "| _None_ |  |  |  |  |  |"}
 
 ## Worker Action Matrix
 
@@ -728,7 +745,29 @@ function sanitizeApplyAction(action) {
     merge_commit_sha: action.merge_commit_sha ?? null,
     live_state: action.live_state ?? null,
     live_updated_at: action.live_updated_at ?? null,
+    apply_attempt: action.apply_attempt ?? null,
+    applied_at: action.applied_at ?? null,
+    report_source: action.report_source ?? null,
   };
+}
+
+function readApplyAuditActions(report) {
+  const attempts = Array.isArray(report?.apply_attempts)
+    ? report.apply_attempts
+    : [
+        {
+          applied_at: report?.applied_at ?? null,
+          actions: report?.actions ?? [],
+        },
+      ];
+  return attempts.flatMap((attempt, index) =>
+    (attempt?.actions ?? []).map((action) => ({
+      ...action,
+      apply_attempt: index + 1,
+      applied_at: attempt?.applied_at ?? null,
+      report_source: "apply",
+    })),
+  );
 }
 
 function sanitizeFixAction(action) {

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -148,6 +148,43 @@ test("apply-result treats closed target with matching marker as idempotently exe
   assert.equal(report.actions[0].live_state, "closed");
 });
 
+test("apply-result retains prior reports as apply attempts", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeGhStub(binDir);
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, jobMarkdown({ allowUnmergedFixClose: true }));
+  fs.writeFileSync(resultPath, `${JSON.stringify(resultJson(), null, 2)}\n`);
+  fs.writeFileSync(
+    reportPath,
+    `${JSON.stringify(
+      {
+        repo: "openclaw/openclaw",
+        cluster_id: "ghcrawl-199237-agentic-merge",
+        dry_run: false,
+        result_path: "result.json",
+        applied_at: "2026-06-17T00:00:00.000Z",
+        actions: [{ target: "#60063", action: "close_fixed_by_candidate", status: "executed" }],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const result = apply(jobPath, resultPath, reportPath, binDir);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "planned");
+  assert.equal(report.apply_attempts.length, 2);
+  assert.equal(report.apply_attempts[0].actions[0].status, "executed");
+  assert.equal(report.apply_attempts[1].actions[0].status, "planned");
+});
+
 test("apply-result records primary GitHub rate limits as retryable blocks", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");

--- a/test/publish-result.test.mjs
+++ b/test/publish-result.test.mjs
@@ -164,6 +164,104 @@ test("publish-result leaves reports unchanged when fix-artifact.json is absent",
   assert.doesNotMatch(fs.readFileSync(reportPath, "utf8"), /## Repair Candidate/);
 });
 
+test("publish-result preserves executed apply actions across later apply attempts", (t) => {
+  const fixture = makeFixture();
+  const runId = `publish-result-apply-attempts-${process.pid}-${Date.now()}`;
+  const clusterId = `publish-result-apply-attempts-${process.pid}-${Date.now()}`;
+  const reportPath = path.join(repoRoot, "results", "openclaw", `${clusterId}.md`);
+  const runRecordPath = path.join(repoRoot, "results", "runs", `${runId}.json`);
+  const closedRecordPath = path.join(repoRoot, "jobs", "openclaw", "closed", "90876.md");
+  const previousReport = readIfExists(reportPath);
+  const previousRunRecord = readIfExists(runRecordPath);
+  const previousClosedRecord = readIfExists(closedRecordPath);
+  t.after(() => {
+    restore(reportPath, previousReport);
+    restore(runRecordPath, previousRunRecord);
+    restore(closedRecordPath, previousClosedRecord);
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  });
+
+  fs.writeFileSync(
+    path.join(fixture.runDir, "result.json"),
+    `${JSON.stringify(
+      {
+        status: "planned",
+        repo: "openclaw/openclaw",
+        cluster_id: clusterId,
+        mode: "autonomous",
+        actions: [],
+        needs_human: [],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  fs.writeFileSync(
+    path.join(fixture.runDir, "apply-report.json"),
+    `${JSON.stringify(
+      {
+        repo: "openclaw/openclaw",
+        cluster_id: clusterId,
+        actions: [
+          {
+            target: "#90876",
+            action: "close_low_signal",
+            status: "blocked",
+            reason: "already closed",
+          },
+        ],
+        apply_attempts: [
+          {
+            applied_at: "2026-06-17T00:00:00.000Z",
+            actions: [
+              {
+                target: "#90876",
+                action: "close_low_signal",
+                status: "executed",
+                reason: "closed by ProjectClownfish",
+              },
+            ],
+          },
+          {
+            applied_at: "2026-06-17T00:01:00.000Z",
+            actions: [
+              {
+                target: "#90876",
+                action: "close_low_signal",
+                status: "blocked",
+                reason: "already closed",
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/publish-result.mjs", fixture.runDir, "--run-id", runId, "--skip-aggregate", "--no-run-url"],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  const record = JSON.parse(fs.readFileSync(runRecordPath, "utf8"));
+  assert.deepEqual(record.apply_counts, { executed: 1 });
+  assert.equal(record.apply_actions.length, 1);
+  assert.equal(record.apply_actions[0].status, "executed");
+  assert.deepEqual(
+    record.apply_audit_actions.map((action) => [action.apply_attempt, action.status]),
+    [
+      [1, "executed"],
+      [2, "blocked"],
+    ],
+  );
+  assert.match(fs.readFileSync(reportPath, "utf8"), /## Apply Audit/);
+  assert.match(fs.readFileSync(reportPath, "utf8"), /\| 2 \| apply \| #90876 \| close_low_signal \| blocked \| already closed \|/);
+});
+
 function makeFixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-publish-result-"));
   const runDir = path.join(root, "run");


### PR DESCRIPTION
Preserves every applicator invocation so a later post-flight idempotency replay cannot overwrite an earlier executed closure in published run summaries.

Validation:
- `node --test test/apply-result.test.mjs test/publish-result.test.mjs`
- `node --check scripts/apply-result.mjs`
- `node --check scripts/publish-result.mjs`