### PR TITLE
fix(executor): preserve unchanged changed-gate diagnostics

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -948,6 +948,10 @@ function editValidatePrepareMerge({
   refreshBaseBeforeReview = false,
   pushCheckpoint = null,
 }) {
+  const changedGateBaseline = captureChangedGateBaseline({ fixArtifact, targetDir, baseBranch });
+  if (changedGateBaseline) {
+    report.changed_gate_baseline = changedGateBaseline.report;
+  }
   let producedChanges = allowExistingChanges;
   let previousSummary = "";
   const checkpointCommits = [];
@@ -1029,6 +1033,7 @@ function editValidatePrepareMerge({
     allowReviewFixes,
     refreshBaseBeforeReview,
     branch,
+    changedGateBaseline,
     onReviewFix: (attempt, reviewFix) => {
       const checkpoint = commitCheckpointIfNeeded({
         targetDir,
@@ -1396,13 +1401,14 @@ function validateAndReviewLoop({
   allowReviewFixes = true,
   refreshBaseBeforeReview = false,
   branch = null,
+  changedGateBaseline = null,
   onReviewFix = null,
 }) {
   let lastReview = null;
   let validationCommands = [];
   for (let attempt = 1; attempt <= maxReviewAttempts; attempt += 1) {
     noteFixStage("validation_start", { mode, attempt });
-    validationCommands = runAllowedValidationCommands(fixArtifact.validation_commands, targetDir, baseBranch);
+    validationCommands = runAllowedValidationCommands(fixArtifact.validation_commands, targetDir, baseBranch, changedGateBaseline);
     runDiffCheck({ targetDir, baseBranch });
     noteFixStage("validation_complete", { mode, attempt, command_count: validationCommands.length });
     if (refreshBaseBeforeReview && branch && refreshValidatedBranchBase({ targetDir, branch, baseBranch })) {
@@ -2098,7 +2104,7 @@ function setupGitIdentity(cwd) {
   run("git", ["config", "user.email", process.env.CLOWNFISH_GIT_USER_EMAIL ?? "projectclownfish@users.noreply.github.com"], { cwd });
 }
 
-function runAllowedValidationCommands(commands, cwd, baseBranch = DEFAULT_BASE_BRANCH) {
+function runAllowedValidationCommands(commands, cwd, baseBranch = DEFAULT_BASE_BRANCH, changedGateBaseline = null) {
   ensureMergeBaseAvailable({ targetDir: cwd, baseBranch });
   const validationEnv = targetValidationEnv();
   const executed = [];
@@ -2113,7 +2119,7 @@ function runAllowedValidationCommands(commands, cwd, baseBranch = DEFAULT_BASE_B
         executed.push(rendered);
         noteFixStage("validation_command_complete", { command: rendered });
       } catch (error) {
-        const fallbackCommands = validationFallbackCommands({ parts, error, cwd, baseBranch });
+        const fallbackCommands = validationFallbackCommands({ parts, error, cwd, baseBranch, changedGateBaseline });
         if (fallbackCommands.length > 0) {
           for (const fallbackParts of fallbackCommands) {
             const fallbackRendered = fallbackParts.join(" ");
@@ -2137,7 +2143,7 @@ function runAllowedValidationCommands(commands, cwd, baseBranch = DEFAULT_BASE_B
   return executed;
 }
 
-function runValidationCommand(parts, { cwd, env, rendered, fallback = false }) {
+function runValidationCommand(parts, { cwd, env, rendered, fallback = false, phase = "validation", allowFailure = false }) {
   const timeoutMs = remainingFixExecutionMs(rendered, { minMs: 10 * 1000 });
   const startedAt = new Date().toISOString();
   const startedAtMs = Date.now();
@@ -2159,6 +2165,7 @@ function runValidationCommand(parts, { cwd, env, rendered, fallback = false }) {
     command: rendered,
     argv: parts,
     fallback,
+    phase,
     started_at: startedAt,
     duration_ms: Date.now() - startedAtMs,
     timeout_ms: timeoutMs,
@@ -2173,14 +2180,32 @@ function runValidationCommand(parts, { cwd, env, rendered, fallback = false }) {
     stderr_original_chars: stderr.originalChars,
     stderr_truncated: stderr.truncated,
   });
+  const diagnosticOutput = redactValidationDebugText(`${child.stderr ?? ""}\n${child.stdout ?? ""}`);
+  let failure = null;
   if (child.error?.code === "ETIMEDOUT") {
-    throw new Error(`${rendered} timed out after ${timeoutMs}ms before fix execution deadline`);
-  }
-  if (child.error) throw child.error;
-  if (child.status !== 0) {
+    failure = new Error(`${rendered} timed out after ${timeoutMs}ms before fix execution deadline`);
+    failure.validation_result = {
+      kind: "timeout",
+      diagnostic_output: diagnosticOutput,
+    };
+  } else if (child.error) {
+    failure = child.error;
+    failure.validation_result = {
+      kind: "process_error",
+      diagnostic_output: diagnosticOutput,
+    };
+  } else if (child.status !== 0) {
     const detail = child.stderr || child.stdout || `${rendered} exited ${child.status}`;
-    throw new Error(String(detail).trim());
+    failure = new Error(redactValidationDebugText(String(detail).trim()));
+    failure.validation_result = {
+      kind: "exit_failure",
+      diagnostic_output: diagnosticOutput,
+    };
   }
+  if (failure && !allowFailure) {
+    throw failure;
+  }
+  return { ok: !failure, failure };
 }
 
 function writeValidationDebugRecord(record) {
@@ -2269,23 +2294,179 @@ function packageScriptRequirement(parts) {
   return { name: script, command: ["pnpm", script].join(" ") };
 }
 
-function validationFallbackCommands({ parts, error, cwd, baseBranch }) {
+function captureChangedGateBaseline({ fixArtifact, targetDir, baseBranch = DEFAULT_BASE_BRANCH }) {
+  if (strictTargetValidation) return null;
+  const resolvedCommands = uniqueStrings(
+    (fixArtifact.validation_commands ?? []).flatMap((command) =>
+      resolveAllowedValidationCommands(command, targetDir, baseBranch).map((parts) => parts.join(" ")),
+    ),
+  );
+  if (!resolvedCommands.includes("pnpm check:changed")) return null;
+
+  noteFixStage("validation_baseline_start", { command: "pnpm check:changed" });
+  const outcome = runValidationCommand(["pnpm", "check:changed"], {
+    cwd: targetDir,
+    env: targetValidationEnv(),
+    rendered: "pnpm check:changed",
+    phase: "baseline",
+    allowFailure: true,
+  });
+  if (outcome.ok) {
+    noteFixStage("validation_baseline_complete", { status: "passed" });
+    return {
+      status: "passed",
+      diagnostics: [],
+      report: {
+        command: "pnpm check:changed",
+        status: "passed",
+        diagnostic_count: 0,
+      },
+    };
+  }
+
+  const failure = outcome.failure?.validation_result;
+  if (failure?.kind !== "exit_failure") throw outcome.failure;
+  const diagnostics = changedGateDiagnostics(failure.diagnostic_output);
+  const eligible =
+    diagnostics.items.length > 0 && !diagnostics.has_test_failure && diagnostics.unparsed_failure_lines.length === 0;
+  noteFixStage("validation_baseline_complete", {
+    status: "failed",
+    eligible,
+    diagnostic_count: diagnostics.items.length,
+  });
+  return {
+    status: "failed",
+    diagnostics,
+    report: {
+      command: "pnpm check:changed",
+      status: "failed",
+      eligible,
+      diagnostic_count: diagnostics.items.length,
+      unparsed_failure_count: diagnostics.unparsed_failure_lines.length,
+      has_test_failure: diagnostics.has_test_failure,
+    },
+  };
+}
+
+function validationFallbackCommands({ parts, error, cwd, baseBranch, changedGateBaseline }) {
   if (strictTargetValidation) return [];
   if (parts[0] !== "pnpm" || parts[1] !== "check:changed" || parts.length !== 2) return [];
   if (/no merge base/i.test(String(error?.message ?? ""))) {
     ensureMergeBaseAvailable({ targetDir: cwd, baseBranch });
     return [parts];
   }
-  if (!isChangedGateStall(error)) return [];
   const changedTests = changedTestFiles(cwd, baseBranch);
-  return [
-    ["git", "diff", "--check", `origin/${baseBranch}...HEAD`],
-    ...(changedTests.length > 0 ? [["pnpm", "test:serial", ...changedTests]] : []),
-  ];
+  if (canTolerateUnchangedChangedGateFailure({ error, cwd, baseBranch, changedGateBaseline })) {
+    return [
+      ["git", "diff", "--check", `origin/${baseBranch}...HEAD`],
+      ...(changedTests.length > 0 ? [["pnpm", "test:serial", ...changedTests]] : []),
+    ];
+  }
+  return [];
 }
 
-function isChangedGateStall(error) {
-  return /no output for \d+ms|terminating stalled Vitest|stalled Vitest process/i.test(String(error?.message ?? ""));
+function canTolerateUnchangedChangedGateFailure({ error, cwd, baseBranch, changedGateBaseline }) {
+  if (!changedGateBaseline?.report?.eligible) return false;
+  const failure = error?.validation_result;
+  if (failure?.kind !== "exit_failure") return false;
+
+  const currentDiagnostics = changedGateDiagnostics(failure.diagnostic_output);
+  if (
+    currentDiagnostics.items.length === 0 ||
+    currentDiagnostics.has_test_failure ||
+    currentDiagnostics.unparsed_failure_lines.length > 0 ||
+    !sameDiagnosticSet(changedGateBaseline.diagnostics.items, currentDiagnostics.items)
+  ) {
+    return false;
+  }
+
+  const changedFiles = new Set(gitChangedFiles(cwd, baseBranch).map(normalizeDiagnosticFile));
+  return !currentDiagnostics.items.some((diagnostic) => changedFiles.has(normalizeDiagnosticFile(diagnostic.file)));
+}
+
+function changedGateDiagnostics(output) {
+  const items = [];
+  const unparsedFailureLines = [];
+  let hasTestFailure = false;
+  for (const rawLine of String(output ?? "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const diagnostic = parseChangedGateDiagnostic(line);
+    if (diagnostic) {
+      items.push(diagnostic);
+      continue;
+    }
+    if (isTestFailureLine(line)) {
+      hasTestFailure = true;
+      continue;
+    }
+    if (isPotentialFailureLine(line) && !isKnownChangedGateFailureSummary(line)) {
+      unparsedFailureLines.push(line);
+    }
+  }
+  return {
+    items,
+    has_test_failure: hasTestFailure,
+    unparsed_failure_lines: uniqueStrings(unparsedFailureLines),
+  };
+}
+
+function parseChangedGateDiagnostic(line) {
+  const typescript = line.match(
+    /^(.+?\.[cm]?[jt]sx?)\((\d+),(\d+)\):\s*(?:error|warning)\s+([A-Z]+\d+):\s*(.+)$/i,
+  );
+  if (typescript) {
+    return {
+      file: typescript[1],
+      line: Number(typescript[2]),
+      column: Number(typescript[3]),
+      code: typescript[4].toUpperCase(),
+      message: typescript[5].trim(),
+    };
+  }
+  const colon = line.match(/^(.+?\.[cm]?[jt]sx?):(\d+):(\d+):\s*(?:error|warning)\s*(.*)$/i);
+  if (!colon) return null;
+  return {
+    file: colon[1],
+    line: Number(colon[2]),
+    column: Number(colon[3]),
+    code: "",
+    message: colon[4].trim(),
+  };
+}
+
+function isTestFailureLine(line) {
+  return /\b(?:assertionerror|test files?|tests?\s+\d+|vitest|jest|mocha|tap|test failed)\b|^(?:fail|x|\u2715|\u00d7)\b/im.test(line);
+}
+
+function isPotentialFailureLine(line) {
+  return /\b(?:error|fail(?:ed|ure)?|exception|assertion)\b/i.test(line);
+}
+
+function isKnownChangedGateFailureSummary(line) {
+  return /^(?:[>\u2713\u2714]|\s)*(?:ELIFECYCLE|ERR_PNPM_|command failed with exit code|found \d+ errors?|failed with exit code)/i.test(
+    line,
+  );
+}
+
+function sameDiagnosticSet(left, right) {
+  const leftSignatures = left.map(changedGateDiagnosticSignature).sort();
+  const rightSignatures = right.map(changedGateDiagnosticSignature).sort();
+  return leftSignatures.length === rightSignatures.length && leftSignatures.every((value, index) => value === rightSignatures[index]);
+}
+
+function changedGateDiagnosticSignature(diagnostic) {
+  return [
+    normalizeDiagnosticFile(diagnostic.file),
+    diagnostic.line,
+    diagnostic.column,
+    diagnostic.code,
+    diagnostic.message,
+  ].join("\u0000");
+}
+
+function normalizeDiagnosticFile(file) {
+  return String(file ?? "").replace(/\\/g, "/").replace(/^\.\//, "");
 }
 
 function targetValidationEnv() {

--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2195,6 +2195,12 @@ function runValidationCommand(parts, { cwd, env, rendered, fallback = false, pha
       kind: "process_error",
       diagnostic_output: diagnosticOutput,
     };
+  } else if (child.signal) {
+    failure = new Error(`${rendered} terminated by ${child.signal}`);
+    failure.validation_result = {
+      kind: "signal",
+      diagnostic_output: diagnosticOutput,
+    };
   } else if (child.status !== 0) {
     const detail = child.stderr || child.stdout || `${rendered} exited ${child.status}`;
     failure = new Error(redactValidationDebugText(String(detail).trim()));

--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2134,6 +2134,7 @@ function runAllowedValidationCommands(commands, cwd, baseBranch = DEFAULT_BASE_B
             executed.push(fallbackRendered);
             noteFixStage("validation_command_complete", { command: fallbackRendered, fallback: true });
           }
+          if (!executed.includes(rendered)) executed.push(rendered);
           continue;
         }
         throw new Error(`validation command failed (${parts.join(" ")}): ${compactText(error.message, 1200)}`);

--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2302,12 +2302,16 @@ function captureChangedGateBaseline({ fixArtifact, targetDir, baseBranch = DEFAU
     ),
   );
   if (!resolvedCommands.includes("pnpm check:changed")) return null;
+  const paths = changedGateBaselinePaths(fixArtifact, targetDir);
+  if (paths.length === 0) return null;
 
-  noteFixStage("validation_baseline_start", { command: "pnpm check:changed" });
-  const outcome = runValidationCommand(["pnpm", "check:changed"], {
+  const command = ["pnpm", "check:changed", "--", ...paths];
+  const rendered = command.join(" ");
+  noteFixStage("validation_baseline_start", { command: rendered, paths });
+  const outcome = runValidationCommand(command, {
     cwd: targetDir,
     env: targetValidationEnv(),
-    rendered: "pnpm check:changed",
+    rendered,
     phase: "baseline",
     allowFailure: true,
   });
@@ -2317,8 +2321,9 @@ function captureChangedGateBaseline({ fixArtifact, targetDir, baseBranch = DEFAU
       status: "passed",
       diagnostics: [],
       report: {
-        command: "pnpm check:changed",
+        command: rendered,
         status: "passed",
+        paths,
         diagnostic_count: 0,
       },
     };
@@ -2338,14 +2343,23 @@ function captureChangedGateBaseline({ fixArtifact, targetDir, baseBranch = DEFAU
     status: "failed",
     diagnostics,
     report: {
-      command: "pnpm check:changed",
+      command: rendered,
       status: "failed",
+      paths,
       eligible,
       diagnostic_count: diagnostics.items.length,
       unparsed_failure_count: diagnostics.unparsed_failure_lines.length,
       has_test_failure: diagnostics.has_test_failure,
     },
   };
+}
+
+function changedGateBaselinePaths(fixArtifact, targetDir) {
+  return uniqueStrings(
+    (fixArtifact.likely_files ?? [])
+      .map((value) => String(value ?? "").trim())
+      .filter((file) => file && !file.includes("*") && fs.existsSync(path.join(targetDir, file))),
+  );
 }
 
 function validationFallbackCommands({ parts, error, cwd, baseBranch, changedGateBaseline }) {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -420,6 +420,19 @@ test("execute-fix-artifact tolerates unchanged baseline changed-gate diagnostics
   assert.equal(fs.existsSync(run.targetedTestMarker), false);
 });
 
+test("execute-fix-artifact does not repeat a tolerated changed gate for normalized validation commands", () => {
+  const run = runBaselineChangedGateFixture({
+    clusterId: "deduplicated-changed-gate-cluster",
+    baselineOutput: "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+    postOutput: "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+    validationCommands: ["pnpm test:serial src/app.test.js", "pnpm check:changed"],
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "planned");
+  assert.equal(fs.readFileSync(run.changedGateMarker, "utf8").trim(), "2");
+});
+
 test("execute-fix-artifact rejects changed-gate failures with new diagnostics", () => {
   const run = runBaselineChangedGateFixture({
     clusterId: "new-diagnostic-cluster",
@@ -499,15 +512,23 @@ test("execute-fix-artifact keeps changed-gate failures strict when strict valida
   assert.equal(phases.includes("baseline"), false);
 });
 
-function runBaselineChangedGateFixture({ clusterId, baselineOutput, postOutput, strict = false, editedFile = "src/app.test.js" }) {
+function runBaselineChangedGateFixture({
+  clusterId,
+  baselineOutput,
+  postOutput,
+  strict = false,
+  editedFile = "src/app.test.js",
+  validationCommands = ["pnpm check:changed"],
+}) {
   const fixture = makeFixture();
   const resultPath = path.join(fixture.runDir, "result.json");
   const reportPath = path.join(fixture.runDir, "fix-execution-report.json");
   const targetedTestMarker = path.join(fixture.root, "targeted-test-command");
+  const changedGateMarker = path.join(fixture.root, "check-changed-calls");
 
   fs.writeFileSync(fixture.jobPath, jobFile(clusterId));
   const result = resultFile(clusterId);
-  result.fix_artifact.validation_commands = ["pnpm check:changed"];
+  result.fix_artifact.validation_commands = validationCommands;
   fs.writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`);
   writeExecutable(
     path.join(fixture.binDir, "codex"),
@@ -539,6 +560,9 @@ const fs = require("node:fs");
 const path = require("node:path");
 const args = process.argv.slice(2);
 if (args[0] === "check:changed") {
+  const marker = ${JSON.stringify(changedGateMarker)};
+  const count = fs.existsSync(marker) ? Number(fs.readFileSync(marker, "utf8")) : 0;
+  fs.writeFileSync(marker, String(count + 1));
   const output = fs.existsSync(path.join(process.cwd(), ".clownfish-edited"))
     ? ${JSON.stringify(postOutput)}
     : ${JSON.stringify(baselineOutput)};
@@ -592,6 +616,7 @@ process.exit(0);
     child,
     report: JSON.parse(fs.readFileSync(reportPath, "utf8")),
     targetedTestMarker,
+    changedGateMarker,
   };
 }
 

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -494,6 +494,25 @@ test("execute-fix-artifact does not mask stalled changed-gate failures", () => {
   assert.equal(fs.existsSync(run.targetedTestMarker), false);
 });
 
+test("execute-fix-artifact does not tolerate signaled changed-gate failures", () => {
+  const output = "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.";
+  const run = runBaselineChangedGateFixture({
+    clusterId: "signaled-changed-gate-cluster",
+    baselineOutput: output,
+    postOutput: output,
+    postSignal: "SIGKILL",
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "blocked");
+  assert.equal(fs.existsSync(run.targetedTestMarker), false);
+  const signals = fs
+    .readdirSync(path.join(run.fixture.runDir, "fix-executor-debug"))
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => JSON.parse(fs.readFileSync(path.join(run.fixture.runDir, "fix-executor-debug", file), "utf8")).signal);
+  assert.equal(signals.includes("SIGKILL"), true);
+});
+
 test("execute-fix-artifact keeps changed-gate failures strict when strict validation is enabled", () => {
   const run = runBaselineChangedGateFixture({
     clusterId: "strict-baseline-cluster",
@@ -519,6 +538,7 @@ function runBaselineChangedGateFixture({
   strict = false,
   editedFile = "src/app.test.js",
   validationCommands = ["pnpm check:changed"],
+  postSignal = null,
 }) {
   const fixture = makeFixture();
   const resultPath = path.join(fixture.runDir, "result.json");
@@ -567,6 +587,9 @@ if (args[0] === "check:changed") {
     ? ${JSON.stringify(postOutput)}
     : ${JSON.stringify(baselineOutput)};
   console.error(output);
+  if (fs.existsSync(path.join(process.cwd(), ".clownfish-edited")) && ${JSON.stringify(postSignal)}) {
+    process.kill(process.pid, ${JSON.stringify(postSignal)});
+  }
   process.exit(1);
 }
 if (args[0] === "test:serial") {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -379,6 +379,220 @@ process.exit(9);
   assert.match(diagnostics.stderr, /api_key=\[redacted\]/);
 });
 
+test("execute-fix-artifact tolerates unchanged baseline changed-gate diagnostics only after changed-test proof", () => {
+  const run = runBaselineChangedGateFixture({
+    clusterId: "baseline-diagnostic-cluster",
+    baselineOutput: "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+    postOutput: "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "planned");
+  assert.deepEqual(run.report.changed_gate_baseline, {
+    command: "pnpm check:changed",
+    status: "failed",
+    eligible: true,
+    diagnostic_count: 1,
+    unparsed_failure_count: 0,
+    has_test_failure: false,
+  });
+  assert.equal(fs.readFileSync(run.targetedTestMarker, "utf8").trim(), "test:serial src/app.test.js");
+
+  const baselineDebug = JSON.parse(
+    fs.readFileSync(path.join(run.fixture.runDir, "fix-executor-debug", "validation-command-001.json"), "utf8"),
+  );
+  assert.equal(baselineDebug.phase, "baseline");
+  assert.equal(baselineDebug.exit_code, 1);
+});
+
+test("execute-fix-artifact tolerates unchanged baseline changed-gate diagnostics for source-only repairs", () => {
+  const run = runBaselineChangedGateFixture({
+    clusterId: "baseline-source-only-cluster",
+    baselineOutput: "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+    postOutput: "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+    editedFile: "src/app.js",
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "planned");
+  assert.equal(fs.existsSync(run.targetedTestMarker), false);
+});
+
+test("execute-fix-artifact rejects changed-gate failures with new diagnostics", () => {
+  const run = runBaselineChangedGateFixture({
+    clusterId: "new-diagnostic-cluster",
+    baselineOutput: "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+    postOutput: [
+      "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+      "src/app.test.js(2,1): error TS2322: Type 'string' is not assignable to type 'number'.",
+    ].join("\n"),
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "blocked");
+  assert.match(run.report.actions[0].reason, /validation command failed/);
+  assert.equal(fs.existsSync(run.targetedTestMarker), false);
+});
+
+test("execute-fix-artifact rejects unchanged baseline diagnostics that touch changed files", () => {
+  const output = "src/app.test.js(2,1): error TS2322: Type 'string' is not assignable to type 'number'.";
+  const run = runBaselineChangedGateFixture({
+    clusterId: "changed-file-diagnostic-cluster",
+    baselineOutput: output,
+    postOutput: output,
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "blocked");
+  assert.equal(run.report.changed_gate_baseline.eligible, true);
+  assert.equal(fs.existsSync(run.targetedTestMarker), false);
+});
+
+test("execute-fix-artifact does not tolerate baseline test failures", () => {
+  const output = [
+    "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+    "FAIL src/app.test.js",
+  ].join("\n");
+  const run = runBaselineChangedGateFixture({
+    clusterId: "baseline-test-failure-cluster",
+    baselineOutput: output,
+    postOutput: output,
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "blocked");
+  assert.equal(run.report.changed_gate_baseline.eligible, false);
+  assert.equal(run.report.changed_gate_baseline.has_test_failure, true);
+  assert.equal(fs.existsSync(run.targetedTestMarker), false);
+});
+
+test("execute-fix-artifact does not mask stalled changed-gate failures", () => {
+  const run = runBaselineChangedGateFixture({
+    clusterId: "stalled-changed-gate-cluster",
+    baselineOutput: "stalled Vitest process",
+    postOutput: "stalled Vitest process",
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "blocked");
+  assert.equal(run.report.changed_gate_baseline.eligible, false);
+  assert.equal(fs.existsSync(run.targetedTestMarker), false);
+});
+
+test("execute-fix-artifact keeps changed-gate failures strict when strict validation is enabled", () => {
+  const run = runBaselineChangedGateFixture({
+    clusterId: "strict-baseline-cluster",
+    baselineOutput: "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+    postOutput: "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+    strict: true,
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "blocked");
+  assert.equal(run.report.changed_gate_baseline, undefined);
+  const phases = fs
+    .readdirSync(path.join(run.fixture.runDir, "fix-executor-debug"))
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => JSON.parse(fs.readFileSync(path.join(run.fixture.runDir, "fix-executor-debug", file), "utf8")).phase);
+  assert.equal(phases.includes("baseline"), false);
+});
+
+function runBaselineChangedGateFixture({ clusterId, baselineOutput, postOutput, strict = false, editedFile = "src/app.test.js" }) {
+  const fixture = makeFixture();
+  const resultPath = path.join(fixture.runDir, "result.json");
+  const reportPath = path.join(fixture.runDir, "fix-execution-report.json");
+  const targetedTestMarker = path.join(fixture.root, "targeted-test-command");
+
+  fs.writeFileSync(fixture.jobPath, jobFile(clusterId));
+  const result = resultFile(clusterId);
+  result.fix_artifact.validation_commands = ["pnpm check:changed"];
+  fs.writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`);
+  writeExecutable(
+    path.join(fixture.binDir, "codex"),
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+const cd = args[args.indexOf("--cd") + 1];
+const output = args.includes("--output-last-message") ? args[args.indexOf("--output-last-message") + 1] : "";
+if (args.includes("--output-schema")) {
+  fs.writeFileSync(output, JSON.stringify({
+    status: "passed",
+    summary: "clean",
+    findings: [],
+    findings_addressed: true,
+    evidence: ["fixture review passed"],
+  }));
+  process.exit(0);
+}
+fs.writeFileSync(path.join(cd, ${JSON.stringify(editedFile)}), "export const fixture = true;\\n");
+fs.writeFileSync(path.join(cd, ".clownfish-edited"), "true\\n");
+if (output) fs.writeFileSync(output, "edited\\n");
+`,
+  );
+  writeExecutable(
+    path.join(fixture.binDir, "pnpm"),
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+if (args[0] === "check:changed") {
+  const output = fs.existsSync(path.join(process.cwd(), ".clownfish-edited"))
+    ? ${JSON.stringify(postOutput)}
+    : ${JSON.stringify(baselineOutput)};
+  console.error(output);
+  process.exit(1);
+}
+if (args[0] === "test:serial") {
+  fs.writeFileSync(${JSON.stringify(targetedTestMarker)}, args.join(" "));
+  process.exit(0);
+}
+process.exit(0);
+`,
+  );
+
+  const child = spawnSync(
+    process.execPath,
+    [
+      "scripts/execute-fix-artifact.mjs",
+      fixture.jobPath,
+      resultPath,
+      "--target-dir",
+      fixture.targetDir,
+      "--work-dir",
+      fixture.workDir,
+      "--report",
+      reportPath,
+      "--dry-run",
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+        CLOWNFISH_ALLOW_EXECUTE: "1",
+        CLOWNFISH_ALLOW_FIX_PR: "1",
+        CLOWNFISH_FIX_STEP_TIMEOUT_MS: "120000",
+        CLOWNFISH_FIX_TIMEOUT_RESERVE_MS: "0",
+        CLOWNFISH_FIX_REPORT_RESERVE_MS: "0",
+        CLOWNFISH_INSTALL_TARGET_DEPS: "0",
+        CLOWNFISH_SKIP_CODEX_WRITE_PREFLIGHT: "1",
+        CLOWNFISH_CODEX_REVIEW_ATTEMPTS: "1",
+        ...(strict ? { CLOWNFISH_TARGET_VALIDATION_MODE: "strict" } : {}),
+      },
+    },
+  );
+
+  return {
+    fixture,
+    child,
+    report: JSON.parse(fs.readFileSync(reportPath, "utf8")),
+    targetedTestMarker,
+  };
+}
+
 function makeFixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-fix-exec-"));
   const binDir = path.join(root, "bin");

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -372,7 +372,7 @@ process.exit(9);
   const diagnostics = JSON.parse(
     fs.readFileSync(path.join(fixture.runDir, "fix-executor-debug", "validation-command-001.json"), "utf8"),
   );
-  assert.equal(diagnostics.command, "pnpm check:changed");
+  assert.equal(diagnostics.command, "pnpm check:changed -- src/app.js");
   assert.equal(diagnostics.exit_code, 9);
   assert.equal(diagnostics.timed_out, false);
   assert.match(diagnostics.stdout, /validation stdout token=\[redacted\]/);
@@ -389,8 +389,9 @@ test("execute-fix-artifact tolerates unchanged baseline changed-gate diagnostics
   assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
   assert.equal(run.report.status, "planned");
   assert.deepEqual(run.report.changed_gate_baseline, {
-    command: "pnpm check:changed",
+    command: "pnpm check:changed -- src/app.js",
     status: "failed",
+    paths: ["src/app.js"],
     eligible: true,
     diagnostic_count: 1,
     unparsed_failure_count: 0,
@@ -402,6 +403,7 @@ test("execute-fix-artifact tolerates unchanged baseline changed-gate diagnostics
     fs.readFileSync(path.join(run.fixture.runDir, "fix-executor-debug", "validation-command-001.json"), "utf8"),
   );
   assert.equal(baselineDebug.phase, "baseline");
+  assert.deepEqual(baselineDebug.argv, ["pnpm", "check:changed", "--", "src/app.js"]);
   assert.equal(baselineDebug.exit_code, 1);
 });
 


### PR DESCRIPTION
## Summary
- capture a `check:changed` baseline for the repair artifact's planned file lanes before Codex edits
- tolerate only identical diagnostics outside the changed files, with fallback diff and targeted-test proof
- keep timeouts, signals, strict mode, new diagnostics, and test failures blocking

## Verification
- `node --test test/execute-fix-artifact.test.mjs`
- `npm test -- --test-name-pattern=execute-fix-artifact`
- `npm run validate`
- Codex review