### PR TITLE
fix(queue): limit autonomous repair promotions

### DIFF
--- a/jobs/openclaw/inbox/repair-77537-live-pr-inventory-20260617t080414-005-repair-wave-20260617.md
+++ b/jobs/openclaw/inbox/repair-77537-live-pr-inventory-20260617t080414-005-repair-wave-20260617.md
@@ -1,0 +1,116 @@
+---
+repo: "openclaw/openclaw"
+cluster_id: "repair-77537-live-pr-inventory-20260617t080414-005-repair-wave-20260617"
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - active_author_followup
+  - broad_code_delta
+canonical:
+  - "#77537"
+candidates:
+  - "#77537"
+  - "#77432"
+  - "#77904"
+  - "#78606"
+  - "#78747"
+cluster_refs:
+  - "#77537"
+  - "#77432"
+  - "#77904"
+  - "#78606"
+  - "#78747"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: "clownfish/repair-77537-live-pr-inventory-20260617t080414-005-repair-wave-20260617"
+source: planner_promotion
+source_result: "results/openclaw/live-pr-inventory-20260617t080414-005.md"
+source_cluster_id: "live-pr-inventory-20260617T080414-005"
+source_run_id: "27674868914-1-4"
+repair_strategy: "repair_contributor_branch"
+---
+
+# Repair Promotion #77537
+
+## Scope
+
+Repair contributor PR #77537 by investigating and fixing the current Real behavior proof failure for TUI commentary progress rendering, then rerun the narrow TUI validation and required pre-merge review gates on the repaired branch.
+
+## Provenance
+
+- source report: results/openclaw/live-pr-inventory-20260617t080414-005.md
+- source cluster: live-pr-inventory-20260617T080414-005
+- source run: 27674868914-1-4
+- source job: jobs/openclaw/inbox/live-pr-inventory-20260617T080414-005.md
+- repair strategy: repair_contributor_branch
+
+## Source Refs
+
+- #77537
+- #77432
+- #77904
+- #78606
+- #78747
+
+## Planned Repair
+
+- proposed PR title: Repair TUI commentary progress proof for #77537
+
+Repairs the current Real behavior proof failure on #77537 while preserving the contributor's original TUI commentary progress implementation and attribution.
+
+Source PR: https://github.com/openclaw/openclaw/pull/77537
+Credit: @grosen / Greg Rosen
+
+Validation plan:
+- pnpm test src/tui/tui-event-handlers.test.ts src/tui/tui-command-handlers.test.ts src/tui/embedded-backend.test.ts
+- OPENCLAW_LOCAL_CHECK=1 OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed
+- pnpm exec oxfmt --check --threads=1 src/tui/tui-event-handlers.ts src/tui/tui-event-handlers.test.ts src/tui/tui-command-handlers.ts src/tui/tui-command-handlers.test.ts
+- git diff --check origin/main..HEAD
+- Real behavior proof workflow
+- Codex /review with all findings addressed
+
+## Likely Files
+
+- src/tui/tui-event-handlers.ts
+- src/tui/tui-event-handlers.test.ts
+- src/tui/tui-command-handlers.ts
+- src/tui/tui-command-handlers.test.ts
+- src/tui/embedded-backend.test.ts
+- CHANGELOG.md
+
+## Validation
+
+- pnpm test src/tui/tui-event-handlers.test.ts src/tui/tui-command-handlers.test.ts src/tui/embedded-backend.test.ts
+- OPENCLAW_LOCAL_CHECK=1 OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed
+- pnpm exec oxfmt --check --threads=1 src/tui/tui-event-handlers.ts src/tui/tui-event-handlers.test.ts src/tui/tui-command-handlers.ts src/tui/tui-command-handlers.test.ts
+- git diff --check origin/main..HEAD
+- Run or replay the PR's Real behavior proof workflow after the repair
+- Run Codex /review and address every finding before any merge recommendation
+
+## Credit
+
+- Preserve source PR credit for @grosen / Greg Rosen from https://github.com/openclaw/openclaw/pull/77537.
+- Keep the repair on the contributor branch when possible because maintainer_can_modify=true.
+- Any replacement path must mention #77537 as the source PR and carry attribution in the PR body and changelog plan.
+
+## Guardrails
+
+- Re-fetch #77537 and current main before editing. This promotion is evidence, not a substitute for fresh preflight.
+- Do not comment, label, close, merge, force-push, or bypass checks.
+- If the repair is no longer narrow, active, safe, or actionable, emit a blocked artifact with the exact reason.

--- a/jobs/openclaw/inbox/repair-94022-live-pr-inventory-20260617t082059-005-repair-wave-20260617.md
+++ b/jobs/openclaw/inbox/repair-94022-live-pr-inventory-20260617t082059-005-repair-wave-20260617.md
@@ -1,0 +1,114 @@
+---
+repo: "openclaw/openclaw"
+cluster_id: "repair-94022-live-pr-inventory-20260617t082059-005-repair-wave-20260617"
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - active_author_followup
+  - broad_code_delta
+canonical:
+  - "#94022"
+candidates:
+  - "#94022"
+  - "#93935"
+  - "#93810"
+  - "#94017"
+  - "#93835"
+cluster_refs:
+  - "#94022"
+  - "#93935"
+  - "#93810"
+  - "#94017"
+  - "#93835"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: "clownfish/repair-94022-live-pr-inventory-20260617t082059-005-repair-wave-20260617"
+source: planner_promotion
+source_result: "results/openclaw/live-pr-inventory-20260617t082059-005.md"
+source_cluster_id: "live-pr-inventory-20260617T082059-005"
+source_run_id: "27675728438"
+repair_strategy: "repair_contributor_branch"
+---
+
+# Repair Promotion #94022
+
+## Scope
+
+Repair #94022 on the contributor branch so the cron startup catch-up deferral state survives all maintenance recompute callers, then rerun merge preflight before any merge recommendation.
+
+## Provenance
+
+- source report: results/openclaw/live-pr-inventory-20260617t082059-005.md
+- source cluster: live-pr-inventory-20260617T082059-005
+- source run: 27675728438
+- source job: jobs/openclaw/inbox/live-pr-inventory-20260617T082059-005.md
+- repair strategy: repair_contributor_branch
+
+## Source Refs
+
+- #94022
+- #93935
+- #93810
+- #94017
+- #93835
+
+## Planned Repair
+
+- proposed PR title: fix(cron): preserve startup catch-up deferrals across maintenance recomputes
+
+Fixes #93935. Repairs the #94022 approach by keeping startup catch-up deferral ids in cron service state so read RPCs, finalize paths, empty-due timer maintenance, manual run preflight, and reservation release do not advance deferred catch-up runs to the next natural schedule before the staggered catch-up fires.
+
+Credit: based on source PR #94022 by @Jah-xy, with #93810 by @yetval as prior related cron deferral work.
+
+Validation plan:
+- node scripts/run-vitest.mjs src/cron/service.startup-overflow-clobber.test.ts src/cron/service.restart-catchup.test.ts src/cron/service/ops.test.ts src/cron/service/ops.regression.test.ts src/cron/service/timer.regression.test.ts src/cron/service/timer.test.ts src/cron/service.jobs.test.ts
+- pnpm check:changed
+- scripts/pr review-validate-artifacts 94022
+- scripts/pr prepare-run 94022
+- /review
+
+## Likely Files
+
+- src/cron/service/jobs.ts
+- src/cron/service/ops.ts
+- src/cron/service/state.ts
+- src/cron/service/timer.ts
+- src/cron/service.startup-overflow-clobber.test.ts
+- src/cron/service/timer.regression.test.ts
+- src/cron/service/jobs.test.ts
+
+## Validation
+
+- node scripts/run-vitest.mjs src/cron/service.startup-overflow-clobber.test.ts src/cron/service.restart-catchup.test.ts src/cron/service/ops.test.ts src/cron/service/ops.regression.test.ts src/cron/service/timer.regression.test.ts src/cron/service/timer.test.ts src/cron/service.jobs.test.ts
+- pnpm check:changed
+- scripts/pr review-validate-artifacts 94022
+- scripts/pr prepare-run 94022
+- /review
+
+## Credit
+
+- Credit Jah-xy as the source PR author for #94022.
+- Preserve #93810/yetval as historical context for the earlier startup-only fix and regression analysis.
+- If a replacement PR becomes necessary, the PR body and any closeout comment must mention #94022 as the source PR and preserve contributor attribution.
+
+## Guardrails
+
+- Re-fetch #94022 and current main before editing. This promotion is evidence, not a substitute for fresh preflight.
+- Do not comment, label, close, merge, force-push, or bypass checks.
+- If the repair is no longer narrow, active, safe, or actionable, emit a blocked artifact with the exact reason.

--- a/scripts/promote-repair-candidates.mjs
+++ b/scripts/promote-repair-candidates.mjs
@@ -6,6 +6,7 @@ import { parseArgs, parseJob, parseSimpleYaml, repoRoot, validateJob } from "./l
 const REPAIR_ACTIONS = new Set(["fix_needed", "build_fix_artifact", "open_fix_pr"]);
 const EXECUTABLE_STRATEGIES = new Set(["repair_contributor_branch", "replace_uneditable_branch", "new_fix_pr"]);
 const TERMINAL_FIX_STATUSES = new Set(["executed", "opened", "pushed", "merged", "closed", "already_closed"]);
+const maxAutonomousFixFiles = Math.max(1, Number(process.env.CLOWNFISH_MAX_AUTONOMOUS_FIX_FILES ?? 8));
 
 const args = parseArgs(process.argv.slice(2));
 const repo = String(args.repo ?? "openclaw/openclaw");
@@ -148,6 +149,9 @@ function promotionBlocker(candidate, existingRefs) {
   if (!hasPlannedRepairAction(candidate)) return "no planned repair action";
   if (hasSecuritySignal(candidate)) return "security-sensitive candidate";
   if (hasHumanHold(candidate)) return "candidate requires human review";
+  if (arrayOfStrings(candidate.candidate.likely_files).length > maxAutonomousFixFiles) {
+    return `repair candidate exceeds autonomous file limit (${maxAutonomousFixFiles})`;
+  }
   if (hasTerminalRepairOutcome(candidate)) return "repair already has a terminal outcome";
   if (candidate.source_refs.some((ref) => existingRefs.has(ref))) return "source ref already has a job";
   return "";

--- a/test/promote-repair-candidates.test.mjs
+++ b/test/promote-repair-candidates.test.mjs
@@ -38,6 +38,12 @@ test("promote-repair-candidates selects only the newest viable repair, dedupes j
     target: "#104",
     hold: true,
   });
+  writeReport(fixture.results, "broad.md", {
+    clusterId: "broad",
+    publishedAt: "2026-06-16T00:00:00.000Z",
+    target: "#108",
+    likelyFiles: Array.from({ length: 9 }, (_, index) => `src/broad-${index}.ts`),
+  });
   writeReport(fixture.results, "dedupe.md", {
     clusterId: "dedupe",
     publishedAt: "2026-06-16T00:00:00.000Z",
@@ -106,6 +112,7 @@ candidates:
       ["#103", "security-sensitive candidate"],
       ["#104", "candidate requires human review"],
       ["#105", "source ref already has a job"],
+      ["#108", "repair candidate exceeds autonomous file limit (8)"],
     ]),
   );
 
@@ -148,6 +155,7 @@ function writeReport(
     repairStatus = "",
     security = false,
     hold = false,
+    likelyFiles = ["src/example.ts"],
   },
 ) {
   const candidate = {
@@ -158,7 +166,7 @@ function writeReport(
     summary: `Repair ${target} narrowly.`,
     pr_title: `fix: repair ${target}`,
     pr_body: `Preserve credit for ${target}.`,
-    likely_files: ["src/example.ts"],
+    likely_files: likelyFiles,
     validation_commands: ["pnpm test:serial src/example.test.ts"],
     credit_notes: [`Preserve source credit for ${target}.`],
     source_job: `jobs/openclaw/inbox/${clusterId}.md`,


### PR DESCRIPTION
Summary:
- reject repair promotions above the executor autonomous file limit
- add narrow repair jobs for OpenClaw PRs #77537 and #94022

Validation:
- npm test -- --test-name-pattern=promote-repair-candidates
- npm run validate