### PR TITLE
chore: add narrow repair replan wave

### DIFF
--- a/jobs/openclaw/inbox/repair-48942-single-replan-wave-20260617.md
+++ b/jobs/openclaw/inbox/repair-48942-single-replan-wave-20260617.md
@@ -1,0 +1,57 @@
+---
+repo: "openclaw/openclaw"
+cluster_id: "repair-48942-single-replan-wave-20260617"
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - active_author_followup
+  - broad_code_delta
+canonical:
+  - "#48942"
+candidates:
+  - "#48942"
+cluster_refs:
+  - "#48942"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: "clownfish/repair-48942-single-replan-wave-20260617"
+source: isolated_inventory_replan
+source_result: "results/openclaw/live-pr-inventory-20260617t015524-128.md"
+source_cluster_id: "live-pr-inventory-20260617T015524-128"
+repair_strategy: "repair_contributor_branch"
+---
+
+# Repair Replan #48942
+
+## Scope
+
+Re-plan contributor PR #48942 as an isolated session-title extraction repair. Resolve only the failing checks and review-bot findings needed to make the focused contributor branch merge-ready.
+
+## Provenance
+
+- source report: results/openclaw/live-pr-inventory-20260617t015524-128.md
+- source cluster: live-pr-inventory-20260617T015524-128
+- repair strategy: repair_contributor_branch
+
+## Guardrails
+
+- Re-fetch #48942, current main, checks, and review threads before editing.
+- Preserve JFWaskin's contribution and keep Android/dependency work out of this job.
+- Do not comment, label, close, merge, force-push, or bypass checks.
+- If the repair is no longer narrow, safe, or actionable, emit a blocked artifact with the exact reason.

--- a/jobs/openclaw/inbox/repair-53920-single-replan-wave-20260617.md
+++ b/jobs/openclaw/inbox/repair-53920-single-replan-wave-20260617.md
@@ -1,0 +1,57 @@
+---
+repo: "openclaw/openclaw"
+cluster_id: "repair-53920-single-replan-wave-20260617"
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - active_author_followup
+  - broad_code_delta
+canonical:
+  - "#53920"
+candidates:
+  - "#53920"
+cluster_refs:
+  - "#53920"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: "clownfish/repair-53920-single-replan-wave-20260617"
+source: isolated_inventory_replan
+source_result: "results/openclaw/live-pr-inventory-20260617t015524-134.md"
+source_cluster_id: "live-pr-inventory-20260617T015524-134"
+repair_strategy: "repair_contributor_branch"
+---
+
+# Repair Replan #53920
+
+## Scope
+
+Re-plan contributor PR #53920 as an isolated finalization repair. Hydrate and address actionable bot-review findings, then run the required focused validation and Codex review gates without merging or closing anything.
+
+## Provenance
+
+- source report: results/openclaw/live-pr-inventory-20260617t015524-134.md
+- source cluster: live-pr-inventory-20260617T015524-134
+- repair strategy: repair_contributor_branch
+
+## Guardrails
+
+- Re-fetch #53920, current main, checks, and review threads before editing.
+- Preserve JackWuGlobal's contribution and do not expand into unrelated auth-monitor work.
+- Do not comment, label, close, merge, force-push, or bypass checks.
+- If the repair is no longer narrow, safe, or actionable, emit a blocked artifact with the exact reason.

--- a/jobs/openclaw/inbox/repair-54904-single-replan-wave-20260617.md
+++ b/jobs/openclaw/inbox/repair-54904-single-replan-wave-20260617.md
@@ -1,0 +1,57 @@
+---
+repo: "openclaw/openclaw"
+cluster_id: "repair-54904-single-replan-wave-20260617"
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - active_author_followup
+  - broad_code_delta
+canonical:
+  - "#54904"
+candidates:
+  - "#54904"
+cluster_refs:
+  - "#54904"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: "clownfish/repair-54904-single-replan-wave-20260617"
+source: isolated_inventory_replan
+source_result: "results/openclaw/live-pr-inventory-20260617t015524-149.md"
+source_cluster_id: "live-pr-inventory-20260617T015524-149"
+repair_strategy: "repair_contributor_branch"
+---
+
+# Repair Replan #54904
+
+## Scope
+
+Re-plan contributor PR #54904 as an isolated Feishu webhook-path repair. Preserve the focused contributor implementation and resolve only current validation and review blockers.
+
+## Provenance
+
+- source report: results/openclaw/live-pr-inventory-20260617t015524-149.md
+- source cluster: live-pr-inventory-20260617T015524-149
+- repair strategy: repair_contributor_branch
+
+## Guardrails
+
+- Re-fetch #54904, current main, checks, and review threads before editing.
+- Preserve ruanrrn's contribution and exclude unrelated cluster members.
+- Do not comment, label, close, merge, force-push, or bypass checks.
+- If the repair is no longer narrow, safe, or actionable, emit a blocked artifact with the exact reason.

--- a/jobs/openclaw/inbox/repair-59695-single-replan-wave-20260617.md
+++ b/jobs/openclaw/inbox/repair-59695-single-replan-wave-20260617.md
@@ -1,0 +1,57 @@
+---
+repo: "openclaw/openclaw"
+cluster_id: "repair-59695-single-replan-wave-20260617"
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - active_author_followup
+  - broad_code_delta
+canonical:
+  - "#59695"
+candidates:
+  - "#59695"
+cluster_refs:
+  - "#59695"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: "clownfish/repair-59695-single-replan-wave-20260617"
+source: isolated_inventory_replan
+source_result: "results/openclaw/live-pr-inventory-20260617t015524-138.md"
+source_cluster_id: "live-pr-inventory-20260617T015524-138"
+repair_strategy: "repair_contributor_branch"
+---
+
+# Repair Replan #59695
+
+## Scope
+
+Re-plan contributor PR #59695 as an isolated SHA-256 configuration fingerprinting repair. Keep the intended contributor change and resolve the current tooling failure with focused validation.
+
+## Provenance
+
+- source report: results/openclaw/live-pr-inventory-20260617t015524-138.md
+- source cluster: live-pr-inventory-20260617T015524-138
+- repair strategy: repair_contributor_branch
+
+## Guardrails
+
+- Re-fetch #59695, current main, checks, and review threads before editing.
+- Preserve YonganZhang's contribution and keep the repair on the contributor branch when possible.
+- Do not comment, label, close, merge, force-push, or bypass checks.
+- If the repair is no longer narrow, safe, or actionable, emit a blocked artifact with the exact reason.

--- a/jobs/openclaw/inbox/repair-59920-single-replan-wave-20260617.md
+++ b/jobs/openclaw/inbox/repair-59920-single-replan-wave-20260617.md
@@ -1,0 +1,57 @@
+---
+repo: "openclaw/openclaw"
+cluster_id: "repair-59920-single-replan-wave-20260617"
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - active_author_followup
+  - broad_code_delta
+canonical:
+  - "#59920"
+candidates:
+  - "#59920"
+cluster_refs:
+  - "#59920"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: "clownfish/repair-59920-single-replan-wave-20260617"
+source: isolated_inventory_replan
+source_result: "results/openclaw/live-pr-inventory-20260617t015524-145.md"
+source_cluster_id: "live-pr-inventory-20260617T015524-145"
+repair_strategy: "repair_contributor_branch"
+---
+
+# Repair Replan #59920
+
+## Scope
+
+Re-plan contributor PR #59920 as an isolated finalization repair. Resolve the current review-bot and Codex review proof blockers without expanding into other inventory-shard work.
+
+## Provenance
+
+- source report: results/openclaw/live-pr-inventory-20260617t015524-145.md
+- source cluster: live-pr-inventory-20260617T015524-145
+- repair strategy: repair_contributor_branch
+
+## Guardrails
+
+- Re-fetch #59920, current main, checks, and review threads before editing.
+- Preserve mySebbe's contribution and any existing co-author attribution.
+- Do not comment, label, close, merge, force-push, or bypass checks.
+- If the repair is no longer narrow, safe, or actionable, emit a blocked artifact with the exact reason.

--- a/jobs/openclaw/inbox/repair-68677-single-replan-wave-20260617.md
+++ b/jobs/openclaw/inbox/repair-68677-single-replan-wave-20260617.md
@@ -1,0 +1,57 @@
+---
+repo: "openclaw/openclaw"
+cluster_id: "repair-68677-single-replan-wave-20260617"
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - active_author_followup
+  - broad_code_delta
+canonical:
+  - "#68677"
+candidates:
+  - "#68677"
+cluster_refs:
+  - "#68677"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: "clownfish/repair-68677-single-replan-wave-20260617"
+source: isolated_inventory_replan
+source_result: "results/openclaw/live-pr-inventory-20260617t015524-149.md"
+source_cluster_id: "live-pr-inventory-20260617T015524-149"
+repair_strategy: "repair_contributor_branch"
+---
+
+# Repair Replan #68677
+
+## Scope
+
+Re-plan contributor PR #68677 as an isolated focused repair. Preserve the existing contributor branch where possible and resolve only the current validation and review blockers.
+
+## Provenance
+
+- source report: results/openclaw/live-pr-inventory-20260617t015524-149.md
+- source cluster: live-pr-inventory-20260617T015524-149
+- repair strategy: repair_contributor_branch
+
+## Guardrails
+
+- Re-fetch #68677, current main, checks, and review threads before editing.
+- Preserve nitinjwadhawan's contribution and exclude unrelated cluster members.
+- Do not comment, label, close, merge, force-push, or bypass checks.
+- If the repair is no longer narrow, safe, or actionable, emit a blocked artifact with the exact reason.

--- a/jobs/openclaw/inbox/repair-75754-single-replan-wave-20260617.md
+++ b/jobs/openclaw/inbox/repair-75754-single-replan-wave-20260617.md
@@ -1,0 +1,57 @@
+---
+repo: "openclaw/openclaw"
+cluster_id: "repair-75754-single-replan-wave-20260617"
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - active_author_followup
+  - broad_code_delta
+canonical:
+  - "#75754"
+candidates:
+  - "#75754"
+cluster_refs:
+  - "#75754"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: "clownfish/repair-75754-single-replan-wave-20260617"
+source: isolated_inventory_replan
+source_result: "results/openclaw/live-pr-inventory-20260617t015524-134.md"
+source_cluster_id: "live-pr-inventory-20260617T015524-134"
+repair_strategy: "repair_contributor_branch"
+---
+
+# Repair Replan #75754
+
+## Scope
+
+Re-plan contributor PR #75754 as an isolated Clawdock dashboard published-port repair. Address only the failing Real behavior proof and retain the contributor's intended implementation.
+
+## Provenance
+
+- source report: results/openclaw/live-pr-inventory-20260617t015524-134.md
+- source cluster: live-pr-inventory-20260617T015524-134
+- repair strategy: repair_contributor_branch
+
+## Guardrails
+
+- Re-fetch #75754, current main, checks, and review threads before editing.
+- Preserve dhoman's contribution and verify the published-port behavior with focused proof.
+- Do not comment, label, close, merge, force-push, or bypass checks.
+- If the repair is no longer narrow, safe, or actionable, emit a blocked artifact with the exact reason.

--- a/jobs/openclaw/inbox/repair-77921-single-replan-wave-20260617.md
+++ b/jobs/openclaw/inbox/repair-77921-single-replan-wave-20260617.md
@@ -1,0 +1,57 @@
+---
+repo: "openclaw/openclaw"
+cluster_id: "repair-77921-single-replan-wave-20260617"
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - active_author_followup
+  - broad_code_delta
+canonical:
+  - "#77921"
+candidates:
+  - "#77921"
+cluster_refs:
+  - "#77921"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: "clownfish/repair-77921-single-replan-wave-20260617"
+source: isolated_inventory_replan
+source_result: "results/openclaw/live-pr-inventory-20260617t015524-131.md"
+source_cluster_id: "live-pr-inventory-20260617T015524-131"
+repair_strategy: "repair_contributor_branch"
+---
+
+# Repair Replan #77921
+
+## Scope
+
+Re-plan contributor PR #77921 as an isolated Inworld TTS repair. Determine whether the Real behavior proof failure is caused by branch content, then make only the narrow repair required to prove the intended behavior.
+
+## Provenance
+
+- source report: results/openclaw/live-pr-inventory-20260617t015524-131.md
+- source cluster: live-pr-inventory-20260617T015524-131
+- repair strategy: repair_contributor_branch
+
+## Guardrails
+
+- Re-fetch #77921, current main, checks, and review threads before editing.
+- Preserve cshape's contribution and run focused Inworld TTS validation.
+- Do not comment, label, close, merge, force-push, or bypass checks.
+- If the repair is no longer narrow, safe, or actionable, emit a blocked artifact with the exact reason.

--- a/jobs/openclaw/inbox/repair-90468-single-replan-wave-20260617.md
+++ b/jobs/openclaw/inbox/repair-90468-single-replan-wave-20260617.md
@@ -1,0 +1,57 @@
+---
+repo: "openclaw/openclaw"
+cluster_id: "repair-90468-single-replan-wave-20260617"
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - active_author_followup
+  - broad_code_delta
+canonical:
+  - "#90468"
+candidates:
+  - "#90468"
+cluster_refs:
+  - "#90468"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: "clownfish/repair-90468-single-replan-wave-20260617"
+source: isolated_inventory_replan
+source_result: "results/openclaw/live-pr-inventory-20260617t015524-132.md"
+source_cluster_id: "live-pr-inventory-20260617T015524-132"
+repair_strategy: "repair_contributor_branch"
+---
+
+# Repair Replan #90468
+
+## Scope
+
+Re-plan contributor PR #90468 as an isolated repair. Preserve its apostrophe parsing fix while addressing the concrete parser regressions from maintainer review.
+
+## Provenance
+
+- source report: results/openclaw/live-pr-inventory-20260617t015524-132.md
+- source cluster: live-pr-inventory-20260617T015524-132
+- repair strategy: repair_contributor_branch
+
+## Guardrails
+
+- Re-fetch #90468, current main, checks, and review threads before editing.
+- Keep valid shell-style single-quote concatenation working and prevent pluralization/parser regressions.
+- Do not comment, label, close, merge, force-push, or bypass checks.
+- If the current repair is no longer narrow, safe, or actionable, emit a blocked artifact with the exact reason.

--- a/jobs/openclaw/inbox/repair-93814-single-replan-wave-20260617.md
+++ b/jobs/openclaw/inbox/repair-93814-single-replan-wave-20260617.md
@@ -1,0 +1,57 @@
+---
+repo: "openclaw/openclaw"
+cluster_id: "repair-93814-single-replan-wave-20260617"
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - active_author_followup
+  - broad_code_delta
+canonical:
+  - "#93814"
+candidates:
+  - "#93814"
+cluster_refs:
+  - "#93814"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: "clownfish/repair-93814-single-replan-wave-20260617"
+source: isolated_inventory_replan
+source_result: "results/openclaw/live-pr-inventory-20260617t015524-145.md"
+source_cluster_id: "live-pr-inventory-20260617T015524-145"
+repair_strategy: "repair_contributor_branch"
+---
+
+# Repair Replan #93814
+
+## Scope
+
+Re-plan contributor PR #93814 as an isolated small repair/finalization path. Keep the scope limited to the target PR and resolve only current review and validation blockers.
+
+## Provenance
+
+- source report: results/openclaw/live-pr-inventory-20260617t015524-145.md
+- source cluster: live-pr-inventory-20260617T015524-145
+- repair strategy: repair_contributor_branch
+
+## Guardrails
+
+- Re-fetch #93814, current main, checks, and review threads before editing.
+- Preserve yetval's contribution and exclude all other inventory-shard targets from this job.
+- Do not comment, label, close, merge, force-push, or bypass checks.
+- If the repair is no longer narrow, safe, or actionable, emit a blocked artifact with the exact reason.


### PR DESCRIPTION
Adds 10 isolated autonomous repair-replan jobs from the fresh June 17 inventory review.

Each job is single-target and permits only guarded fix-PR work; comments, labels, close, merge, force-push, and check bypasses remain blocked.

Validation: `npm run validate`, `npm test`, `git diff --check`.