### PR TITLE
fix(executor): allow OpenClaw validation prefixes

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -17,6 +17,10 @@ const FIX_ACTIONS = new Set(["fix_needed", "build_fix_artifact", "open_fix_pr"])
 const REPAIR_STRATEGIES = new Set(["repair_contributor_branch", "replace_uneditable_branch", "new_fix_pr"]);
 const NON_EXECUTABLE_REPAIR_STRATEGIES = new Set(["already_fixed_on_main", "needs_human"]);
 const DEFAULT_BASE_BRANCH = "main";
+const ALLOWED_VALIDATION_ENV_PREFIXES = new Map([
+  ["OPENCLAW_LOCAL_CHECK", new Set(["0", "1"])],
+  ["OPENCLAW_LOCAL_CHECK_MODE", new Set(["throttled"])],
+]);
 
 const args = parseArgs(process.argv.slice(2));
 const jobPath = args._[0];
@@ -2895,11 +2899,25 @@ function uniqueStrings(values) {
 function parseAllowedValidationCommand(command) {
   const text = String(command ?? "").trim();
   if (!text) throw new Error("empty validation command");
-  const parts = splitValidationCommand(text);
+  const parts = stripAllowedValidationEnvPrefixes(splitValidationCommand(text), text);
   if (!["pnpm", "npm", "node", "git"].includes(parts[0])) {
     throw new Error(`unsupported validation command: ${text}`);
   }
   return parts;
+}
+
+function stripAllowedValidationEnvPrefixes(parts, originalText) {
+  let commandStart = 0;
+  while (commandStart < parts.length) {
+    const match = /^([A-Z_][A-Z0-9_]*)=(.*)$/.exec(parts[commandStart]);
+    if (!match) break;
+    const allowedValues = ALLOWED_VALIDATION_ENV_PREFIXES.get(match[1]);
+    if (!allowedValues?.has(match[2])) {
+      throw new Error(`unsupported validation command: ${originalText}`);
+    }
+    commandStart += 1;
+  }
+  return parts.slice(commandStart);
 }
 
 function splitValidationCommand(text) {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -556,6 +556,34 @@ test("execute-fix-artifact does not repeat a tolerated changed gate for normaliz
   assert.equal(fs.readFileSync(run.changedGateMarker, "utf8").trim(), "2");
 });
 
+test("execute-fix-artifact accepts the allowed OpenClaw env prefixes for changed validation", () => {
+  const output = "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.";
+  const run = runBaselineChangedGateFixture({
+    clusterId: "openclaw-validation-env-prefix-cluster",
+    baselineOutput: output,
+    postOutput: output,
+    validationCommands: ["OPENCLAW_LOCAL_CHECK=1 OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed"],
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "planned");
+  assert.equal(fs.readFileSync(run.changedGateMarker, "utf8").trim(), "2");
+});
+
+test("execute-fix-artifact rejects unrecognized validation env prefixes", () => {
+  const run = runBaselineChangedGateFixture({
+    clusterId: "unsupported-validation-env-prefix-cluster",
+    baselineOutput: "",
+    postOutput: "",
+    validationCommands: ["UNSAFE_VALIDATION_FLAG=1 pnpm check:changed"],
+  });
+
+  assert.equal(run.child.status, 1, run.child.stderr || run.child.stdout);
+  assert.match(run.child.stderr, /unsupported validation command/);
+  assert.equal(run.report.status, "failed");
+  assert.match(run.report.actions[0].reason, /unsupported validation command/);
+});
+
 test("execute-fix-artifact rejects changed-gate failures with new diagnostics", () => {
   const run = runBaselineChangedGateFixture({
     clusterId: "new-diagnostic-cluster",


### PR DESCRIPTION
## Summary
- normalize the supported OpenClaw validation env prefixes before command allowlisting
- retain rejection for unrecognized prefixes
- cover the canary regression and rejection path

## Validation
- npm test
- npm run validate