### PR TITLE
fix(worker): avoid Actions bwrap checkout failures

### DIFF
--- a/scripts/run-worker.mjs
+++ b/scripts/run-worker.mjs
@@ -28,6 +28,8 @@ const codexStdoutMaxBufferBytes = parsePositiveIntegerEnv(
   process.env.CLOWNFISH_CODEX_STDOUT_MAX_BUFFER_BYTES,
   64 * 1024 * 1024,
 );
+const defaultCodexWorkerSandbox = process.env.GITHUB_ACTIONS === "true" ? "danger-full-access" : "read-only";
+const codexWorkerSandbox = String(process.env.CLOWNFISH_CODEX_WORKER_SANDBOX ?? defaultCodexWorkerSandbox);
 
 if (!jobPath) {
   console.error("usage: node scripts/run-worker.mjs <job.md> --mode plan|execute|autonomous [--dry-run]");
@@ -185,7 +187,7 @@ function runCodex({ input, outputPath, transcriptPath: codexTranscriptPath, stde
     "--model",
     model,
     "--sandbox",
-    "read-only",
+    codexWorkerSandbox,
     ...codexConfigArgs(),
     "--output-schema",
     path.join(repoRoot(), "schemas", "codex-result.schema.json"),
@@ -317,6 +319,10 @@ function codexEnv() {
   delete env.CLOWNFISH_GH_TOKEN;
   delete env.CLOWNFISH_READ_GH_TOKEN;
   delete env.CLOWNFISH_CODEX_GH_TOKEN;
+  if (process.env.GITHUB_ACTIONS === "true") {
+    delete env.OPENAI_API_KEY;
+    delete env.CODEX_API_KEY;
+  }
   return env;
 }
 

--- a/test/run-worker-source.test.mjs
+++ b/test/run-worker-source.test.mjs
@@ -30,3 +30,15 @@ test("run-worker runs Codex from the verified target checkout", () => {
   assert.match(source, /"--cd",\s*codexWorkingDir/);
   assert.match(source, /spawnSync\("codex", codexArgs, \{\s*cwd: codexWorkingDir,/s);
 });
+
+test("run-worker uses an Actions-safe sandbox without exposing credentials to Codex", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "run-worker.mjs"), "utf8");
+
+  assert.match(
+    source,
+    /const defaultCodexWorkerSandbox = process\.env\.GITHUB_ACTIONS === "true" \? "danger-full-access" : "read-only";/,
+  );
+  assert.match(source, /CLOWNFISH_CODEX_WORKER_SANDBOX \?\? defaultCodexWorkerSandbox/);
+  assert.match(source, /"--sandbox",\s*codexWorkerSandbox/);
+  assert.match(source, /if \(process\.env\.GITHUB_ACTIONS === "true"\) \{\s*delete env\.OPENAI_API_KEY;\s*delete env\.CODEX_API_KEY;/s);
+});


### PR DESCRIPTION
## Summary
- run Codex workers without bwrap on GitHub Actions, matching executor behavior
- strip OpenAI credentials from the Actions worker subprocess
- cover the sandbox policy with a regression test

## Validation
- npm test
- npm run validate