### PR TITLE
fix(executor): fall back to contributor head fetches

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -479,9 +479,14 @@ function boundedPreflightTimeoutMs(label) {
   return Math.min(codexPreflightTimeoutMs, remainingFixExecutionMs(label, { minMs: 15 * 1000 }));
 }
 
-function fetchContributorPullHead({ targetDir, sourcePr, branch, expectedHeadSha }) {
+function fetchContributorPullHead({ targetDir, sourcePr, pull, branch }) {
+  const expectedHeadSha = String(pull.head?.sha ?? "");
+  if (!expectedHeadSha) throw new Error(`source PR #${sourcePr.number} is missing head SHA`);
+  const strategies = contributorHeadFetchStrategies({ sourcePr, pull });
   let lastError;
+  const attemptedStrategies = [];
   for (let attempt = 1; attempt <= maxContributorFetchAttempts; attempt += 1) {
+    const strategy = strategies[(attempt - 1) % strategies.length];
     const timeoutMs = Math.min(
       contributorFetchTimeoutMs,
       remainingFixExecutionMs(`source PR #${sourcePr.number} head fetch`, { minMs: 10 * 1000 }),
@@ -489,11 +494,10 @@ function fetchContributorPullHead({ targetDir, sourcePr, branch, expectedHeadSha
     noteFixStage("source_pr_head_fetch_start", {
       pull_request: sourcePr.number,
       attempt,
+      strategy: strategy.name,
       timeout_ms: timeoutMs,
     });
     try {
-      // GitHub exposes fork heads through the base repo. Bound this network hop so a
-      // stalled smart-HTTP transfer cannot consume the entire executor deadline.
       run(
         "git",
         [
@@ -505,8 +509,8 @@ function fetchContributorPullHead({ targetDir, sourcePr, branch, expectedHeadSha
           "http.lowSpeedTime=30",
           "fetch",
           "--no-tags",
-          "origin",
-          `refs/pull/${sourcePr.number}/head:${branch}`,
+          strategy.remote,
+          `${strategy.ref}:${branch}`,
         ],
         {
           cwd: targetDir,
@@ -523,14 +527,17 @@ function fetchContributorPullHead({ targetDir, sourcePr, branch, expectedHeadSha
       noteFixStage("source_pr_head_fetch_complete", {
         pull_request: sourcePr.number,
         attempt,
+        strategy: strategy.name,
         head_sha: fetchedHeadSha,
       });
       return;
     } catch (error) {
       lastError = error;
+      attemptedStrategies.push(strategy.name);
       noteFixStage("source_pr_head_fetch_failed", {
         pull_request: sourcePr.number,
         attempt,
+        strategy: strategy.name,
         reason: redactValidationDebugText(String(error?.message ?? error)).slice(0, 500),
       });
       if (!isRetryableContributorFetchError(error) || attempt === maxContributorFetchAttempts) break;
@@ -548,8 +555,35 @@ function fetchContributorPullHead({ targetDir, sourcePr, branch, expectedHeadSha
   throw new Error(
     `source PR #${sourcePr.number} head fetch failed after ${maxContributorFetchAttempts} attempt(s): ${String(
       lastError?.message ?? lastError,
-    )}`,
+    )} (strategies: ${attemptedStrategies.join(", ")})`,
   );
+}
+
+function contributorHeadFetchStrategies({ sourcePr, pull }) {
+  const primary = {
+    name: "base_pull_ref",
+    remote: "origin",
+    ref: `refs/pull/${sourcePr.number}/head`,
+  };
+  const sourceHeadRef = `refs/heads/${pull.head.ref}`;
+  if (pull.head.repo.full_name === result.repo) {
+    return [
+      primary,
+      {
+        name: "same_repo_head_ref",
+        remote: "origin",
+        ref: sourceHeadRef,
+      },
+    ];
+  }
+  return [
+    primary,
+    {
+      name: "fork_head_ref",
+      remote: `https://github.com/${pull.head.repo.full_name}.git`,
+      ref: sourceHeadRef,
+    },
+  ];
 }
 
 function isRetryableContributorFetchError(error) {
@@ -628,6 +662,7 @@ function executeRepairBranch({ fixArtifact, targetDir, scopeBlock = null, rebase
   if (pull.maintainer_can_modify !== true && !sameRepoBranch) {
     throw new Error(`source PR #${sourcePr.number} has maintainer_can_modify=false`);
   }
+  if (!dryRun) ghAuthSetupGit(targetDir);
 
   const branch = safeBranchName(`projectclownfish/repair-${result.cluster_id}-${sourcePr.number}`);
   noteFixStage("rebase_prepare_start", { pull_request: sourcePr.number });
@@ -635,8 +670,8 @@ function executeRepairBranch({ fixArtifact, targetDir, scopeBlock = null, rebase
   fetchContributorPullHead({
     targetDir,
     sourcePr,
+    pull,
     branch,
-    expectedHeadSha: pull.head.sha,
   });
   run("git", ["checkout", branch], { cwd: targetDir });
   ensureMergeBaseAvailable({ targetDir, baseBranch });
@@ -666,7 +701,6 @@ function executeRepairBranch({ fixArtifact, targetDir, scopeBlock = null, rebase
     );
   }
   if (!sameRepoBranch && !dryRun) {
-    ghAuthSetupGit(targetDir);
     assertRepairBranchWritable({ targetDir, pull, rebased });
   }
   noteFixStage("target_toolchain_start");

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -284,7 +284,13 @@ test("execute-fix-artifact bounds and verifies contributor repair head fetches",
   assert.match(source, /function boundedPositiveIntegerEnv\(value, fallback, \{ min, max \}\)/);
   assert.match(source, /Number\.isInteger\(parsed\)/);
   assert.match(source, /\{ min: 10 \* 1000, max: 5 \* 60 \* 1000 \}/);
-  assert.match(source, /function fetchContributorPullHead\(\{ targetDir, sourcePr, branch, expectedHeadSha \}\)/);
+  assert.match(source, /function fetchContributorPullHead\(\{ targetDir, sourcePr, pull, branch \}\)/);
+  assert.match(source, /function contributorHeadFetchStrategies\(\{ sourcePr, pull \}\)/);
+  assert.match(source, /name: "base_pull_ref"/);
+  assert.match(source, /name: "same_repo_head_ref"/);
+  assert.match(source, /name: "fork_head_ref"/);
+  assert.match(source, /remote: `https:\/\/github\.com\/\$\{pull\.head\.repo\.full_name\}\.git`/);
+  assert.match(source, /strategies\[\(attempt - 1\) % strategies\.length\]/);
   assert.match(source, /GIT_TERMINAL_PROMPT: "0"/);
   assert.match(source, /"credential\.interactive=false"/);
   assert.match(source, /"http\.lowSpeedLimit=1"/);
@@ -296,9 +302,10 @@ test("execute-fix-artifact bounds and verifies contributor repair head fetches",
   assert.match(source, /code: "source_pr_head_fetch_failed"/);
   assert.match(
     repairFetch,
-    /fetchContributorPullHead\(\{\s*targetDir,\s*sourcePr,\s*branch,\s*expectedHeadSha: pull\.head\.sha,\s*\}\)/,
+    /fetchContributorPullHead\(\{\s*targetDir,\s*sourcePr,\s*pull,\s*branch,\s*\}\)/,
   );
-  assert.doesNotMatch(repairFetch, /https:\/\/github\.com\/\$\{pull\.head\.repo\.full_name\}\.git/);
+  assert.match(repairFetch, /if \(!dryRun\) ghAuthSetupGit\(targetDir\);[\s\S]*?fetchContributorPullHead/);
+  assert.match(source, /if \(!sameRepoBranch && !dryRun\) \{\s*assertRepairBranchWritable/);
 });
 
 test("execute-fix-artifact rejects review-fix workers that leave no diff", () => {


### PR DESCRIPTION
## Summary
- configure GitHub credentials before contributor source reads
- fall back from the base PR ref to the rehydrated source branch
- keep fetched-head SHA verification and shared attempt limits

## Validation
- npm test
- npm run validate