### PR TITLE
fix(executor): fetch contributor history lazily

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -498,6 +498,7 @@ function fetchContributorPullHead({ targetDir, sourcePr, pull, branch }) {
       timeout_ms: timeoutMs,
     });
     try {
+      const remote = ensureContributorFetchRemote({ targetDir, sourcePr, strategy });
       run(
         "git",
         [
@@ -509,7 +510,8 @@ function fetchContributorPullHead({ targetDir, sourcePr, pull, branch }) {
           "http.lowSpeedTime=30",
           "fetch",
           "--no-tags",
-          strategy.remote,
+          "--filter=blob:none",
+          remote,
           `${strategy.ref}:${branch}`,
         ],
         {
@@ -582,8 +584,28 @@ function contributorHeadFetchStrategies({ sourcePr, pull }) {
       name: "fork_head_ref",
       remote: `https://github.com/${pull.head.repo.full_name}.git`,
       ref: sourceHeadRef,
+      source_remote: true,
     },
   ];
+}
+
+function ensureContributorFetchRemote({ targetDir, sourcePr, strategy }) {
+  if (!strategy.source_remote) return strategy.remote;
+
+  const remote = `projectclownfish-source-${sourcePr.number}`;
+  const existing = spawnSync("git", ["remote", "get-url", remote], {
+    cwd: targetDir,
+    env: process.env,
+    encoding: "utf8",
+  });
+  if (existing.status === 0) {
+    run("git", ["remote", "set-url", remote, strategy.remote], { cwd: targetDir });
+  } else {
+    run("git", ["remote", "add", remote, strategy.remote], { cwd: targetDir });
+  }
+  run("git", ["config", `remote.${remote}.promisor`, "true"], { cwd: targetDir });
+  run("git", ["config", `remote.${remote}.partialclonefilter`, "blob:none"], { cwd: targetDir });
+  return remote;
 }
 
 function isRetryableContributorFetchError(error) {
@@ -2330,10 +2352,16 @@ function ensureTargetCheckout(repo, targetDir) {
   if (!fs.existsSync(targetDir)) {
     fs.mkdirSync(path.dirname(targetDir), { recursive: true });
     try {
-      run("gh", ["repo", "clone", repo, targetDir, "--", "--depth=1"], { cwd: repoRoot(), env: readGhEnv() });
+      run("gh", ["repo", "clone", repo, targetDir, "--", "--depth=1", "--filter=blob:none"], {
+        cwd: repoRoot(),
+        env: readGhEnv(),
+      });
     } catch (error) {
       if (readGhEnv().GH_TOKEN === ghEnv().GH_TOKEN) throw error;
-      run("gh", ["repo", "clone", repo, targetDir, "--", "--depth=1"], { cwd: repoRoot(), env: ghEnv() });
+      run("gh", ["repo", "clone", repo, targetDir, "--", "--depth=1", "--filter=blob:none"], {
+        cwd: repoRoot(),
+        env: ghEnv(),
+      });
     }
     return;
   }

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -290,7 +290,14 @@ test("execute-fix-artifact bounds and verifies contributor repair head fetches",
   assert.match(source, /name: "same_repo_head_ref"/);
   assert.match(source, /name: "fork_head_ref"/);
   assert.match(source, /remote: `https:\/\/github\.com\/\$\{pull\.head\.repo\.full_name\}\.git`/);
+  assert.match(source, /source_remote: true/);
   assert.match(source, /strategies\[\(attempt - 1\) % strategies\.length\]/);
+  assert.match(source, /function ensureContributorFetchRemote\(\{ targetDir, sourcePr, strategy \}\)/);
+  assert.match(source, /"remote", "add", remote, strategy\.remote/);
+  assert.match(source, /`remote\.\$\{remote\}\.promisor`, "true"/);
+  assert.match(source, /`remote\.\$\{remote\}\.partialclonefilter`, "blob:none"/);
+  assert.match(source, /"--filter=blob:none"/);
+  assert.match(source, /\["repo", "clone", repo, targetDir, "--", "--depth=1", "--filter=blob:none"\]/);
   assert.match(source, /GIT_TERMINAL_PROMPT: "0"/);
   assert.match(source, /"credential\.interactive=false"/);
   assert.match(source, /"http\.lowSpeedLimit=1"/);


### PR DESCRIPTION
## Summary
- fetch source PR history without blobs in the executor
- configure fork source remotes as partial-clone promisors
- preserve exact source-head verification before repair

## Validation
- npm test
- npm run validate