### PR TITLE
fix(executor): accept bounded autoreview validation

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2962,10 +2962,22 @@ function parseAllowedValidationCommand(command) {
   const text = String(command ?? "").trim();
   if (!text) throw new Error("empty validation command");
   const parts = stripAllowedValidationEnvPrefixes(splitValidationCommand(text), text);
+  if (isAllowedAutoreviewValidation(parts)) return parts;
   if (!["pnpm", "npm", "node", "git"].includes(parts[0])) {
     throw new Error(`unsupported validation command: ${text}`);
   }
   return parts;
+}
+
+function isAllowedAutoreviewValidation(parts) {
+  return (
+    parts.length === 5 &&
+    parts[0] === ".agents/skills/autoreview/scripts/autoreview" &&
+    parts[1] === "--mode" &&
+    parts[2] === "branch" &&
+    parts[3] === "--base" &&
+    /^origin\/[A-Za-z0-9._/-]+$/.test(parts[4])
+  );
 }
 
 function stripAllowedValidationEnvPrefixes(parts, originalText) {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -584,6 +584,19 @@ test("execute-fix-artifact accepts the allowed OpenClaw env prefixes for changed
   assert.equal(fs.readFileSync(run.changedGateMarker, "utf8").trim(), "2");
 });
 
+test("execute-fix-artifact accepts the bounded OpenClaw branch autoreview command", () => {
+  const output = "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.";
+  const run = runBaselineChangedGateFixture({
+    clusterId: "openclaw-autoreview-validation-cluster",
+    baselineOutput: output,
+    postOutput: output,
+    validationCommands: [".agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main"],
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "planned");
+});
+
 test("execute-fix-artifact rejects unrecognized validation env prefixes", () => {
   const run = runBaselineChangedGateFixture({
     clusterId: "unsupported-validation-env-prefix-cluster",


### PR DESCRIPTION
## Summary
- accept OpenClaw's exact branch autoreview validation command
- normalize it through the existing changed-surface validation path
- keep arbitrary script validation commands blocked

## Validation
- npm test
- npm run validate