### PR TITLE
fix: preserve portable artifact permissions

### DIFF
--- a/scripts/plan-cluster.mjs
+++ b/scripts/plan-cluster.mjs
@@ -41,6 +41,7 @@ if (errors.length > 0) {
 }
 
 assertAllowedOwner(job.frontmatter.repo, process.env.CLOWNFISH_ALLOWED_OWNER);
+const sourceJobPermissions = snapshotSourceJobPermissions(job);
 
 const runDir = args["run-dir"]
   ? path.resolve(String(args["run-dir"]))
@@ -113,6 +114,7 @@ const plan = {
   mode: job.frontmatter.mode,
   triage_policy: job.frontmatter.triage_policy ?? null,
   source_job: job.relativePath,
+  source_job_permissions: sourceJobPermissions,
   generated_at: new Date().toISOString(),
   offline,
   main: branch,
@@ -477,6 +479,15 @@ function buildFixArtifact(plan, job) {
       "if replacing a contributor PR, include source PR credit and the exact close comment that says Clownfish will preserve attribution",
       "include full GitHub URLs in closure rationale",
     ],
+  };
+}
+
+function snapshotSourceJobPermissions(job) {
+  return {
+    allowed_actions: [...job.frontmatter.allowed_actions],
+    blocked_actions: [...(job.frontmatter.blocked_actions ?? [])],
+    allow_fix_pr: job.frontmatter.allow_fix_pr === true,
+    allow_merge: job.frontmatter.allow_merge === true,
   };
 }
 

--- a/scripts/plan-cluster.mjs
+++ b/scripts/plan-cluster.mjs
@@ -41,7 +41,7 @@ if (errors.length > 0) {
 }
 
 assertAllowedOwner(job.frontmatter.repo, process.env.CLOWNFISH_ALLOWED_OWNER);
-const sourceJobPermissions = snapshotSourceJobPermissions(job);
+const sourceJobPolicy = snapshotSourceJobPolicy(job);
 
 const runDir = args["run-dir"]
   ? path.resolve(String(args["run-dir"]))
@@ -114,7 +114,7 @@ const plan = {
   mode: job.frontmatter.mode,
   triage_policy: job.frontmatter.triage_policy ?? null,
   source_job: job.relativePath,
-  source_job_permissions: sourceJobPermissions,
+  source_job_permissions: sourceJobPolicy,
   generated_at: new Date().toISOString(),
   offline,
   main: branch,
@@ -482,12 +482,15 @@ function buildFixArtifact(plan, job) {
   };
 }
 
-function snapshotSourceJobPermissions(job) {
+function snapshotSourceJobPolicy(job) {
   return {
     allowed_actions: [...job.frontmatter.allowed_actions],
     blocked_actions: [...(job.frontmatter.blocked_actions ?? [])],
     allow_fix_pr: job.frontmatter.allow_fix_pr === true,
     allow_merge: job.frontmatter.allow_merge === true,
+    maintainer_calibration: Array.isArray(job.frontmatter.maintainer_calibration)
+      ? [...job.frontmatter.maintainer_calibration]
+      : [],
   };
 }
 

--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -84,7 +84,7 @@ function reviewResult(resultPath) {
   const result = JSON.parse(fs.readFileSync(resultPath, "utf8"));
   const plan = readSiblingJson(runDir, "cluster-plan.json");
   const sourceJob = readSourceJob(plan);
-  const sourceJobPermissions = sourceJob?.frontmatter ?? readSourceJobPermissionSnapshot(plan);
+  const sourceJobPolicy = sourceJob?.frontmatter ?? readSourceJobPolicySnapshot(plan);
   const failures = [];
   const warnings = [];
   const itemByRef = buildItemMap(plan, result.repo);
@@ -257,7 +257,7 @@ function reviewResult(resultPath) {
   }
 
   if (fixActions.length > 0) {
-    validateFixActionPermissions(sourceJobPermissions, fixActions, failures);
+    validateFixActionPermissions(sourceJobPolicy, fixActions, failures);
     validateFixArtifact(result.fix_artifact, failures);
   }
   const plannedMergeActions = mergeActions.filter((action) => action.status === "planned");
@@ -265,7 +265,7 @@ function reviewResult(resultPath) {
     validateMergePreflight(result.merge_preflight, plannedMergeActions, failures);
   }
   validateCalibratedPrFinalization({
-    job: sourceJob,
+    sourceJobPolicy,
     result,
     itemByRef,
     fixActions,
@@ -308,8 +308,8 @@ function reviewResult(resultPath) {
   };
 }
 
-function validateCalibratedPrFinalization({ job, result, itemByRef, fixActions, mergeActions, failures }) {
-  if (!Array.isArray(job?.frontmatter?.maintainer_calibration) || job.frontmatter.maintainer_calibration.length === 0) {
+function validateCalibratedPrFinalization({ sourceJobPolicy, result, itemByRef, fixActions, mergeActions, failures }) {
+  if (!Array.isArray(sourceJobPolicy?.maintainer_calibration) || sourceJobPolicy.maintainer_calibration.length === 0) {
     return;
   }
   const canonicalPrRef = normalizeRef(result.canonical_pr ?? result.canonical);
@@ -633,7 +633,7 @@ function readSourceJob(plan) {
   }
 }
 
-function readSourceJobPermissionSnapshot(plan) {
+function readSourceJobPolicySnapshot(plan) {
   const permissions = plan?.source_job_permissions;
   if (!permissions || typeof permissions !== "object" || Array.isArray(permissions)) return null;
   if (
@@ -642,7 +642,9 @@ function readSourceJobPermissionSnapshot(plan) {
     !Array.isArray(permissions.blocked_actions) ||
     !permissions.blocked_actions.every((action) => typeof action === "string") ||
     typeof permissions.allow_fix_pr !== "boolean" ||
-    typeof permissions.allow_merge !== "boolean"
+    typeof permissions.allow_merge !== "boolean" ||
+    !Array.isArray(permissions.maintainer_calibration) ||
+    !permissions.maintainer_calibration.every((entry) => typeof entry === "string")
   ) {
     return null;
   }

--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -84,6 +84,7 @@ function reviewResult(resultPath) {
   const result = JSON.parse(fs.readFileSync(resultPath, "utf8"));
   const plan = readSiblingJson(runDir, "cluster-plan.json");
   const sourceJob = readSourceJob(plan);
+  const sourceJobPermissions = sourceJob?.frontmatter ?? readSourceJobPermissionSnapshot(plan);
   const failures = [];
   const warnings = [];
   const itemByRef = buildItemMap(plan, result.repo);
@@ -256,7 +257,7 @@ function reviewResult(resultPath) {
   }
 
   if (fixActions.length > 0) {
-    validateFixActionPermissions(sourceJob, fixActions, failures);
+    validateFixActionPermissions(sourceJobPermissions, fixActions, failures);
     validateFixArtifact(result.fix_artifact, failures);
   }
   const plannedMergeActions = mergeActions.filter((action) => action.status === "planned");
@@ -464,21 +465,21 @@ function allowsSelfCanonicalCurrentMainCloseout(action) {
   return /\b(current main|already fixed|already covered|fixed-by-current-main|main already)\b/i.test(text);
 }
 
-function validateFixActionPermissions(job, fixActions, failures) {
+function validateFixActionPermissions(permissions, fixActions, failures) {
   if (fixActions.length === 0) return;
-  if (!job) {
+  if (!permissions) {
     failures.push("fix actions require source job permissions");
     return;
   }
 
-  const allowedActions = new Set(job.frontmatter.allowed_actions ?? []);
-  const blockedActions = new Set(job.frontmatter.blocked_actions ?? []);
+  const allowedActions = new Set(permissions.allowed_actions);
+  const blockedActions = new Set(permissions.blocked_actions);
   const blockers = [];
   if (!allowedActions.has("fix")) blockers.push("allowed_actions lacks fix");
   if (!allowedActions.has("raise_pr")) blockers.push("allowed_actions lacks raise_pr");
   if (blockedActions.has("fix")) blockers.push("blocked_actions includes fix");
   if (blockedActions.has("raise_pr")) blockers.push("blocked_actions includes raise_pr");
-  if (job.frontmatter.allow_fix_pr !== true) blockers.push("allow_fix_pr is not true");
+  if (permissions.allow_fix_pr !== true) blockers.push("allow_fix_pr is not true");
   if (blockers.length === 0) return;
 
   const actionList = fixActions
@@ -630,6 +631,22 @@ function readSourceJob(plan) {
   } catch {
     return null;
   }
+}
+
+function readSourceJobPermissionSnapshot(plan) {
+  const permissions = plan?.source_job_permissions;
+  if (!permissions || typeof permissions !== "object" || Array.isArray(permissions)) return null;
+  if (
+    !Array.isArray(permissions.allowed_actions) ||
+    !permissions.allowed_actions.every((action) => typeof action === "string") ||
+    !Array.isArray(permissions.blocked_actions) ||
+    !permissions.blocked_actions.every((action) => typeof action === "string") ||
+    typeof permissions.allow_fix_pr !== "boolean" ||
+    typeof permissions.allow_merge !== "boolean"
+  ) {
+    return null;
+  }
+  return permissions;
 }
 
 function buildItemMap(plan, repo) {

--- a/test/plan-cluster.test.mjs
+++ b/test/plan-cluster.test.mjs
@@ -74,6 +74,8 @@ cluster_id: test-pr-hydration
 mode: plan
 allowed_actions:
   - comment
+maintainer_calibration:
+  - "Require a planned fix or merge for an open canonical PR."
 candidates:
   - "#2"
 canonical:
@@ -102,6 +104,7 @@ canonical:
     blocked_actions: [],
     allow_fix_pr: false,
     allow_merge: false,
+    maintainer_calibration: ["Require a planned fix or merge for an open canonical PR."],
   });
   assert.equal(candidate.kind, "pull_request");
   assert.match(candidate.hydration_error, /pull request #2: unexpected end of JSON input/);

--- a/test/plan-cluster.test.mjs
+++ b/test/plan-cluster.test.mjs
@@ -97,6 +97,12 @@ canonical:
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const plan = JSON.parse(fs.readFileSync(path.join(runDir, "cluster-plan.json"), "utf8"));
   const candidate = plan.items.find((item) => item.ref === "#2");
+  assert.deepEqual(plan.source_job_permissions, {
+    allowed_actions: ["comment"],
+    blocked_actions: [],
+    allow_fix_pr: false,
+    allow_merge: false,
+  });
   assert.equal(candidate.kind, "pull_request");
   assert.match(candidate.hydration_error, /pull request #2: unexpected end of JSON input/);
   assert.match(candidate.pull_request.hydration_error, /pull request #2: unexpected end of JSON input/);

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -743,6 +743,97 @@ test("review-results rejects fix artifacts when source job disallows fix PRs", (
   assert.match(result.stdout, /allow_fix_pr is not true/);
 });
 
+test("review-results verifies fix artifacts with a permission snapshot after source job removal", () => {
+  const dir = makeResultDir(
+    {
+      mode: "autonomous",
+      actions: [
+        {
+          target: "cluster:cluster-test",
+          action: "build_fix_artifact",
+          status: "planned",
+          idempotency_key: "projectclownfish:cluster-test:build-fix-artifact:v1",
+          evidence: ["The archived plan proves this job permits a narrow fix PR."],
+        },
+      ],
+      fix_artifact: {
+        summary: "build a narrow credited fix",
+        affected_surfaces: ["control ui"],
+        likely_files: ["ui/src/ui/chat/build-chat-items.ts"],
+        linked_refs: ["#1"],
+        validation_commands: ["pnpm check:changed"],
+        changelog_required: false,
+        credit_notes: ["credit source PR"],
+        pr_title: "fix: narrow issue",
+        pr_body: "## Summary\n- fix the issue",
+        repair_strategy: "new_fix_pr",
+      },
+    },
+    {
+      job: fixEnabledJob(),
+      plan: {
+        source_job_permissions: {
+          allowed_actions: ["comment", "label", "close", "fix", "raise_pr"],
+          blocked_actions: ["force_push"],
+          allow_fix_pr: true,
+          allow_merge: false,
+        },
+      },
+    },
+  );
+  fs.rmSync(path.join(dir, "job.md"));
+
+  const result = review(dir);
+
+  assert.equal(result.status, 0, result.stdout || result.stderr);
+  assert.match(result.stdout, /"status": "passed"/);
+});
+
+test("review-results rejects incomplete permission snapshots after source job removal", () => {
+  const dir = makeResultDir(
+    {
+      mode: "autonomous",
+      actions: [
+        {
+          target: "cluster:cluster-test",
+          action: "build_fix_artifact",
+          status: "planned",
+          idempotency_key: "projectclownfish:cluster-test:build-fix-artifact:v1",
+          evidence: ["The permission snapshot is incomplete."],
+        },
+      ],
+      fix_artifact: {
+        summary: "build a narrow credited fix",
+        affected_surfaces: ["control ui"],
+        likely_files: ["ui/src/ui/chat/build-chat-items.ts"],
+        linked_refs: ["#1"],
+        validation_commands: ["pnpm check:changed"],
+        changelog_required: false,
+        credit_notes: ["credit source PR"],
+        pr_title: "fix: narrow issue",
+        pr_body: "## Summary\n- fix the issue",
+        repair_strategy: "new_fix_pr",
+      },
+    },
+    {
+      job: fixEnabledJob(),
+      plan: {
+        source_job_permissions: {
+          allowed_actions: ["comment", "label", "close", "fix", "raise_pr"],
+          blocked_actions: ["force_push"],
+          allow_fix_pr: true,
+        },
+      },
+    },
+  );
+  fs.rmSync(path.join(dir, "job.md"));
+
+  const result = review(dir);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /fix actions require source job permissions/);
+});
+
 function makeResultDir(overrides, options = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-review-"));
   const result = {

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -777,6 +777,7 @@ test("review-results verifies fix artifacts with a permission snapshot after sou
           blocked_actions: ["force_push"],
           allow_fix_pr: true,
           allow_merge: false,
+          maintainer_calibration: [],
         },
       },
     },
@@ -822,6 +823,7 @@ test("review-results rejects incomplete permission snapshots after source job re
           allowed_actions: ["comment", "label", "close", "fix", "raise_pr"],
           blocked_actions: ["force_push"],
           allow_fix_pr: true,
+          maintainer_calibration: [],
         },
       },
     },
@@ -832,6 +834,42 @@ test("review-results rejects incomplete permission snapshots after source job re
 
   assert.notEqual(result.status, 0);
   assert.match(result.stdout, /fix actions require source job permissions/);
+});
+
+test("review-results enforces calibrated canonical finalization after source job removal", () => {
+  const dir = makeResultDir(
+    {
+      mode: "autonomous",
+      canonical_pr: "#1",
+    },
+    {
+      job: calibratedFixEnabledJob(),
+      plan: {
+        source_job_permissions: {
+          allowed_actions: ["comment", "label", "close", "fix", "raise_pr"],
+          blocked_actions: ["force_push"],
+          allow_fix_pr: true,
+          allow_merge: false,
+          maintainer_calibration: ["Require a planned fix or merge for an open canonical PR."],
+        },
+        items: [
+          {
+            ref: "#1",
+            kind: "pull_request",
+            state: "open",
+            updated_at: "2026-06-18T00:00:00Z",
+            security_sensitive: false,
+          },
+        ],
+      },
+    },
+  );
+  fs.rmSync(path.join(dir, "job.md"));
+
+  const result = review(dir);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /#1 calibrated canonical PR requires either a planned merge action with merge_preflight or a planned fix action/);
 });
 
 function makeResultDir(overrides, options = {}) {
@@ -916,5 +954,29 @@ allow_fix_pr: true
 ---
 
 # Fix-enabled job
+`;
+}
+
+function calibratedFixEnabledJob() {
+  return `---
+repo: openclaw/openclaw
+cluster_id: cluster-test
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - close
+  - fix
+  - raise_pr
+blocked_actions:
+  - force_push
+maintainer_calibration:
+  - "Require a planned fix or merge for an open canonical PR."
+candidates:
+  - "#1"
+allow_fix_pr: true
+---
+
+# Calibrated fix-enabled job
 `;
 }


### PR DESCRIPTION
## Summary
- snapshot fix and merge permissions in each cluster plan
- keep artifact review fail-closed when the original generated job is unavailable
- preserve calibrated PR finalization checks in portable artifacts

## Verification
- `node --test test/plan-cluster.test.mjs test/review-results.test.mjs`
- `node --check scripts/plan-cluster.mjs`
- `node --check scripts/review-results.mjs`
- `git diff --check`