### PR TITLE
fix(executor): allow review artifact validation

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2965,6 +2965,7 @@ function parseAllowedValidationCommand(command) {
   const parts = stripAllowedValidationEnvPrefixes(rawParts, text);
   if (isAllowedAutoreviewValidation(parts)) return parts;
   if (rawParts.length === parts.length && isAllowedShellSyntaxValidation(parts)) return parts;
+  if (rawParts.length === parts.length && isAllowedPullRequestArtifactReviewValidation(parts)) return parts;
   if (!["pnpm", "npm", "node", "git"].includes(parts[0])) {
     throw new Error(`unsupported validation command: ${text}`);
   }
@@ -2984,6 +2985,15 @@ function isAllowedAutoreviewValidation(parts) {
 
 function isAllowedShellSyntaxValidation(parts) {
   return parts.length === 3 && parts[0] === "bash" && parts[1] === "-n" && isSafeRelativeShellScriptPath(parts[2]);
+}
+
+function isAllowedPullRequestArtifactReviewValidation(parts) {
+  return (
+    parts.length === 3 &&
+    parts[0] === "scripts/pr" &&
+    parts[1] === "review-validate-artifacts" &&
+    /^[1-9][0-9]*$/.test(parts[2])
+  );
 }
 
 function isSafeRelativeShellScriptPath(value) {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -610,6 +610,34 @@ test("execute-fix-artifact accepts a bounded shell syntax validation", () => {
   assert.equal(run.report.status, "planned");
 });
 
+test("execute-fix-artifact accepts bounded OpenClaw PR review artifact validation", () => {
+  const run = runBaselineChangedGateFixture({
+    clusterId: "pr-review-artifact-validation-cluster",
+    baselineOutput: "",
+    postOutput: "",
+    strict: true,
+    validationCommands: ["scripts/pr review-validate-artifacts 94022"],
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "planned");
+});
+
+test("execute-fix-artifact rejects non-bounded OpenClaw PR validation commands", () => {
+  for (const validationCommand of ["scripts/pr review-validate-artifacts 0", "scripts/pr prepare-run 94022"]) {
+    const run = runBaselineChangedGateFixture({
+      clusterId: `rejected-pr-review-validation-${validationCommand.split(" ")[1]}`,
+      baselineOutput: "",
+      postOutput: "",
+      validationCommands: [validationCommand],
+    });
+
+    assert.equal(run.child.status, 1, run.child.stderr || run.child.stdout);
+    assert.match(run.child.stderr, /unsupported validation command/);
+    assert.equal(run.report.status, "failed");
+  }
+});
+
 test("execute-fix-artifact rejects shell execution validation commands", () => {
   const run = runBaselineChangedGateFixture({
     clusterId: "shell-execution-validation-cluster",
@@ -885,6 +913,14 @@ function makeFixture() {
   fs.writeFileSync(path.join(seedDir, "src", "app.js"), "export const value = 1;\n");
   fs.mkdirSync(path.join(seedDir, "scripts"), { recursive: true });
   fs.writeFileSync(path.join(seedDir, "scripts", "setup-auth-system.sh"), "#!/usr/bin/env bash\nset -euo pipefail\n");
+  writeExecutable(
+    path.join(seedDir, "scripts", "pr"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+test "$1" = "review-validate-artifacts"
+test "$2" = "94022"
+`,
+  );
   git(["add", "."], { cwd: seedDir });
   git(["commit", "-m", "initial"], { cwd: seedDir });
   git(["remote", "add", "origin", originDir], { cwd: seedDir });


### PR DESCRIPTION
## Summary
- allow only the bounded scripts/pr review-validate-artifacts with a positive PR number
- cover the accepted command and rejected lookalikes

## Verification
- node --test test/execute-fix-artifact.test.mjs
- npm test
- npm run validate