### PR TITLE
fix(review): ignore negated security item evidence

### DIFF
--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -415,7 +415,7 @@ function nonSecurityAssertionStrippedText(value) {
       "non-security classification",
     )
     .replace(
-      /\b(?:no|without|absent)\s+(?:deterministic\s+|live\s+|preflight\s+)?security[-_\s]?sensitive\s+(?:signal|signals|refs?|items?|target|targets)\b/gi,
+      /\b(?:no|without|absent)\s+(?:(?:deterministic|live|preflight|hydrated)\s+)?security[-_\s]?sensitive\s+(?:(?:hydrated|live|preflight|linked|related)\s+)?(?:signal|signals|refs?|items?|target|targets)\b/gi,
       "non-security classification",
     )
     .replace(

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -141,7 +141,7 @@ test("review-results ignores security-boundary no-signal prose in mutating actio
           target_kind: "pull_request",
           target_updated_at: "2026-06-15T14:15:01Z",
           comment: "Rebase review is required before finalization.",
-          evidence: ["Security boundary preflight reports no security-sensitive items."],
+          evidence: ["No security-sensitive hydrated item is present."],
           reason: "The contributor branch needs a fresh review before finalization.",
         },
       ],


### PR DESCRIPTION
## Summary
- recognize negated hydrated security-item evidence as non-security context
- cover the exact false-positive phrase from the #94022 worker artifact

## Verification
- node --test test/review-results.test.mjs
- node scripts/review-results.mjs /tmp/clownfish-review-27715612319-initial
- npm test
- npm run validate