### PR TITLE
fix(executor): expose eligible baseline diagnostics

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -1136,6 +1136,7 @@ function editValidatePrepareMerge({
         previousNoDiff: attempt > 1,
         previousSummary,
         repositoryContext,
+        changedGateBaseline,
       });
       const summaryPath = path.join(workRoot, `${mode}-codex-summary-${attempt}.md`);
       const timeoutMs = boundedCodexTimeoutMs("Codex fix worker");
@@ -1276,7 +1277,17 @@ function buildFixPrompt({
   previousNoDiff,
   previousSummary,
   repositoryContext,
+  changedGateBaseline,
 }) {
+  const baselineDiagnostics =
+    changedGateBaseline?.status === "failed" && changedGateBaseline.report?.eligible
+      ? changedGateBaseline.diagnostics.items
+          .map(
+            (diagnostic) =>
+              `${normalizeDiagnosticFile(diagnostic.file)}(${diagnostic.line},${diagnostic.column}): ${diagnostic.code} ${diagnostic.message}`,
+          )
+          .join("\n")
+      : "";
   return [
     "You are editing the target repository for ProjectClownfish.",
     "",
@@ -1310,6 +1321,16 @@ function buildFixPrompt({
     "```text",
     repositoryContext,
     "```",
+    baselineDiagnostics
+      ? [
+          "",
+          "Existing changed-gate baseline diagnostics:",
+          "These failures already exist on the contributor branch. Do not weaken validation; repair them when they are in the affected surface.",
+          "```text",
+          baselineDiagnostics,
+          "```",
+        ].join("\n")
+      : "",
     "",
     "Fix artifact:",
     "```json",

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -544,6 +544,20 @@ test("execute-fix-artifact tolerates unchanged baseline changed-gate diagnostics
   assert.equal(baselineDebug.exit_code, 1);
 });
 
+test("execute-fix-artifact gives eligible baseline diagnostics to the initial repair worker", () => {
+  const output = "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.";
+  const run = runBaselineChangedGateFixture({
+    clusterId: "baseline-diagnostic-prompt-cluster",
+    baselineOutput: output,
+    postOutput: output,
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  const prompt = fs.readFileSync(run.initialPrompt, "utf8");
+  assert.match(prompt, /Existing changed-gate baseline diagnostics:/);
+  assert.match(prompt, /src\/web-search\/runtime\.ts\(374,10\): TS6133/);
+});
+
 test("execute-fix-artifact tolerates unchanged baseline changed-gate diagnostics for source-only repairs", () => {
   const run = runBaselineChangedGateFixture({
     clusterId: "baseline-source-only-cluster",
@@ -790,6 +804,7 @@ function runBaselineChangedGateFixture({
   const reportPath = path.join(fixture.runDir, "fix-execution-report.json");
   const targetedTestMarker = path.join(fixture.root, "targeted-test-command");
   const changedGateMarker = path.join(fixture.root, "check-changed-calls");
+  const initialPrompt = path.join(fixture.root, "initial-codex-prompt");
 
   fs.writeFileSync(fixture.jobPath, jobFile(clusterId));
   const result = resultFile(clusterId);
@@ -812,6 +827,9 @@ if (args.includes("--output-schema")) {
     evidence: ["fixture review passed"],
   }));
   process.exit(0);
+}
+if (!fs.existsSync(${JSON.stringify(initialPrompt)})) {
+  fs.writeFileSync(${JSON.stringify(initialPrompt)}, fs.readFileSync(0, "utf8"));
 }
 fs.writeFileSync(path.join(cd, ${JSON.stringify(editedFile)}), "export const fixture = true;\\n");
 fs.writeFileSync(path.join(cd, ".clownfish-edited"), "true\\n");
@@ -885,6 +903,7 @@ process.exit(0);
     report: JSON.parse(fs.readFileSync(reportPath, "utf8")),
     targetedTestMarker,
     changedGateMarker,
+    initialPrompt,
   };
 }
 


### PR DESCRIPTION
## Summary
- pass eligible contributor-branch changed-gate diagnostics to the initial repair worker
- preserve validation strictness and add coverage for the handoff

## Verification
- `node --test test/execute-fix-artifact.test.mjs`
- `npm run validate`