### PR TITLE
fix(executor): parse bracketed pnpm failure summaries

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2818,7 +2818,7 @@ function isPotentialFailureLine(line) {
 }
 
 function isKnownChangedGateFailureSummary(line) {
-  return /^(?:[>\u2713\u2714]|\s)*(?:ELIFECYCLE|ERR_PNPM_|command failed with exit code|found \d+ errors?|failed with exit code)/i.test(
+  return /^(?:[>\u2713\u2714]|\s)*(?:\[(?:ELIFECYCLE|ERR_PNPM_[^\]]*)\]|ELIFECYCLE|ERR_PNPM_|command failed with exit code|found \d+ errors?|failed with exit code)/i.test(
     line,
   );
 }

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -545,7 +545,10 @@ test("execute-fix-artifact tolerates unchanged baseline changed-gate diagnostics
 });
 
 test("execute-fix-artifact gives eligible baseline diagnostics to the initial repair worker", () => {
-  const output = "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.";
+  const output = [
+    "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+    "[ELIFECYCLE] Command failed with exit code 2.",
+  ].join("\n");
   const run = runBaselineChangedGateFixture({
     clusterId: "baseline-diagnostic-prompt-cluster",
     baselineOutput: output,


### PR DESCRIPTION
## Summary
- recognize pnpm bracketed lifecycle failure summaries as known changed-gate wrappers
- preserve real diagnostics for eligible baseline repair prompts

## Validation
- node --test test/execute-fix-artifact.test.mjs
- npm run validate
