### PR TITLE
chore(jobs): permit scoped repair for #94022

### DIFF
--- a/jobs/openclaw/inbox/repair-94022-live-pr-inventory-20260617t082059-005-repair-wave-20260617.md
+++ b/jobs/openclaw/inbox/repair-94022-live-pr-inventory-20260617t082059-005-repair-wave-20260617.md
@@ -33,6 +33,7 @@ cluster_refs:
 allow_instant_close: false
 allow_fix_pr: true
 allow_merge: false
+allow_broad_fix_artifacts: true
 allow_unmerged_fix_close: false
 allow_post_merge_close: false
 require_fix_before_close: true


### PR DESCRIPTION
## Summary
- permit the existing #94022 cron repair job to execute its reviewed cross-caller implementation and regression-test plan
- keep target merge, close, label, and automerge actions disabled
- scope the exception to this job only; no repository-wide broad-fix gate changes

## Validation
- `npm run validate`
- `npm run render -- jobs/openclaw/inbox/repair-94022-live-pr-inventory-20260617t082059-005-repair-wave-20260617.md --mode plan`