### PR TITLE
fix(executor): parse changed-gate summary failures

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2818,7 +2818,7 @@ function isPotentialFailureLine(line) {
 }
 
 function isKnownChangedGateFailureSummary(line) {
-  return /^(?:[>\u2713\u2714]|\s)*(?:\[(?:ELIFECYCLE|ERR_PNPM_[^\]]*)\]|ELIFECYCLE|ERR_PNPM_|command failed with exit code|found \d+ errors?|failed with exit code)/i.test(
+  return /^(?:[>\u2713\u2714]|\s)*(?:\[(?:ELIFECYCLE|ERR_PNPM_[^\]]*)\]|ELIFECYCLE|ERR_PNPM_|command failed with exit code|found \d+ errors?|failed with exit code|\d+(?:\.\d+)?(?:ms|s)\s+failed(?::\d+)?\b)/i.test(
     line,
   );
 }

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -548,6 +548,7 @@ test("execute-fix-artifact gives eligible baseline diagnostics to the initial re
   const output = [
     "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
     "[ELIFECYCLE] Command failed with exit code 2.",
+    "5.81s  failed:2   typecheck core",
   ].join("\n");
   const run = runBaselineChangedGateFixture({
     clusterId: "baseline-diagnostic-prompt-cluster",


### PR DESCRIPTION
## Summary
- recognize the `check:changed` duration summary (`failed:N`) as a known failure summary rather than an unknown error
- preserve eligible baseline diagnostics so the validation-repair worker can address newly introduced TypeScript errors

## Validation
- `node --test test/execute-fix-artifact.test.mjs`
- `npm run validate`