### PR TITLE
fix(executor): retry eslint validation failures

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2850,7 +2850,7 @@ function isPotentialFailureLine(line) {
 }
 
 function isKnownChangedGateFailureSummary(line) {
-  return /^(?:[>\u2713\u2714]|\s)*(?:\[(?:ELIFECYCLE|ERR_PNPM_[^\]]*)\]|ELIFECYCLE|ERR_PNPM_|command failed with exit code|found \d+ errors?|failed with exit code|\d+(?:\.\d+)?(?:ms|s)\s+failed(?::\d+)?\b)/i.test(
+  return /^(?:[>\u2713\u2714]|\s)*(?:\[(?:ELIFECYCLE|ERR_PNPM_[^\]]*)\]|ELIFECYCLE|ERR_PNPM_|command failed with exit code|found \d+ errors?|failed with exit code|\d+(?:\.\d+)?(?:ms|s)\s+failed(?::\d+)?\b|\u2716\s+\d+\s+problems?\s+\(\d+\s+errors?(?:,\s*\d+\s+warnings?)?\))/i.test(
     line,
   );
 }

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -468,6 +468,8 @@ const source = fs.readFileSync(path.join(process.cwd(), "src", "app.js"), "utf8"
 if (source.includes("invalid")) {
   console.error("\\u001b[4m" + path.join(process.cwd(), "src", "app.js") + "\\u001b[0m");
   console.error("  \\u001b[2m1:24\\u001b[0m  \\u001b[31merror\\u001b[0m  Expected { after 'if' condition.  \\u001b[2meslint(curly)\\u001b[0m");
+  console.error("\\u001b[31m✖ 1 problem (1 error, 0 warnings)\\u001b[0m");
+  console.error("[ELIFECYCLE] Command failed with exit code 1.");
   process.exit(1);
 }
 process.exit(0);


### PR DESCRIPTION
## Summary
- recognize ESLint problem-count summaries as known changed-gate output
- preserve the bounded validation-repair loop for colored ESLint diagnostics
- cover the exact real executor output shape

## Verification
- `node --test test/execute-fix-artifact.test.mjs`
- `npm run validate`