### PR TITLE
fix(review): accept explicit non-security boundary assertions

### DIFF
--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -368,7 +368,11 @@ function isSkippedClosedContextAction(action, item) {
 
 function nonSecurityAssertionStrippedText(value) {
   return String(value ?? "")
-    .replace(/\bsecurity-sensitive-guard(?:-detect)?\b/gi, "routine CI guard")
+    .replace(
+      /\bsecurity[-_\s]?boundary\s*:\s*preflight\s+security[-_\s]?sensitive\s*=\s*(?:false|0|no)(?:\s+and\s+security[-_\s]?sensitive[-_\s]?guard(?:[-_\s]?detect)?\s+passed)?(?:\s*;\s*no\s+route_security\s+action\s+needed)?\.?/gi,
+      "non-security classification",
+    )
+    .replace(/\bsecurity[-_\s]?sensitive[-_\s]?guard(?:[-_\s]?detect)?\b/gi, "routine CI guard")
     .replace(/\bsecurity[-_\s]?sensitive\s*[=:]\s*(?:false|0|no)\b/gi, "non-security classification")
     .replace(/\bsecuritySensitive\s*[=:]\s*(?:false|0|no)\b/g, "non-security classification")
     .replace(

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -604,6 +604,64 @@ test("review-results does not treat the security-sensitive CI guard as a target 
   assert.match(result.stdout, /"status": "passed"/);
 });
 
+test("review-results ignores an explicit non-security boundary assertion in fix evidence", () => {
+  const dir = makeResultDir(
+    {
+      mode: "autonomous",
+      actions: [
+        {
+          target: "#81410",
+          action: "fix_needed",
+          status: "planned",
+          idempotency_key: "cluster-test:fix-needed:81410:security-boundary",
+          classification: "canonical",
+          target_kind: "issue",
+          target_updated_at: "2026-06-15T10:00:00Z",
+          evidence: [
+            "#81410 still needs the narrow gateway lifecycle repair.",
+            "Security boundary: preflight security_sensitive=false and security-sensitive guard passed; no route_security action needed.",
+          ],
+          reason: "A narrow new fix PR is appropriate for #81410.",
+        },
+      ],
+      fix_artifact: {
+        summary: "Repair stale SUDO_USER user-scope resolution for root gateway lifecycle commands.",
+        affected_surfaces: ["gateway", "systemd"],
+        likely_files: ["src/daemon/systemd.ts", "src/daemon/systemd.test.ts"],
+        linked_refs: ["#81410"],
+        validation_commands: ["pnpm check:changed"],
+        changelog_required: true,
+        credit_notes: ["Preserve contributor attribution for the source report."],
+        pr_title: "fix(gateway): ignore stale sudo scope for root systemd commands",
+        pr_body: "## Summary\n- fix stale root systemd user scope resolution\n\n## Test plan\n- pnpm check:changed",
+        repair_strategy: "new_fix_pr",
+        allow_no_pr: false,
+      },
+    },
+    {
+      job: fixEnabledJob(),
+      plan: {
+        items: [
+          {
+            ref: "#81410",
+            kind: "issue",
+            state: "open",
+            title: "Gateway lifecycle commands target stale SUDO_USER scope from root shell",
+            labels: ["bug", "systemd"],
+            updated_at: "2026-06-15T10:00:00Z",
+            security_sensitive: false,
+          },
+        ],
+      },
+    },
+  );
+
+  const result = review(dir);
+
+  assert.equal(result.status, 0, result.stdout || result.stderr);
+  assert.match(result.stdout, /"status": "passed"/);
+});
+
 test("review-results allows unavailable non-mutating plan classifications", () => {
   const dir = makeResultDir(
     {


### PR DESCRIPTION
## Summary
- normalize explicit preflight non-security boundary assertions before security review
- recognize spaced and hyphenated security guard check names
- cover the production artifact shape that blocked a safe repair plan

## Verification
- `node --test test/review-results.test.mjs`
- `npm test`
- `npm run validate`
- replayed the #42637 worker artifact through `npm run review-results`