### PR TITLE
fix(executor): clear failed clone before auth retry

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2379,6 +2379,7 @@ function ensureTargetCheckout(repo, targetDir) {
       });
     } catch (error) {
       if (readGhEnv().GH_TOKEN === ghEnv().GH_TOKEN) throw error;
+      removeIncompleteTargetCheckout(targetDir);
       run("gh", ["repo", "clone", repo, targetDir, "--", "--depth=1", "--filter=blob:none"], {
         cwd: repoRoot(),
         env: ghEnv(),
@@ -2391,6 +2392,11 @@ function ensureTargetCheckout(repo, targetDir) {
   }
   const status = run("git", ["status", "--porcelain"], { cwd: targetDir }).trim();
   if (status) throw new Error(`target checkout has uncommitted changes: ${targetDir}`);
+}
+
+function removeIncompleteTargetCheckout(targetDir) {
+  if (!fs.existsSync(targetDir)) return;
+  fs.rmSync(targetDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 }
 
 function prepareTargetToolchain(cwd) {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -33,6 +33,19 @@ test("execute-fix-artifact bounds auxiliary GitHub and git subprocesses by the f
   );
 });
 
+test("execute-fix-artifact clears a partial clone before retrying with the write token", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "execute-fix-artifact.mjs"), "utf8");
+
+  assert.match(
+    source,
+    /function ensureTargetCheckout\([\s\S]*?catch \(error\) \{[\s\S]*?removeIncompleteTargetCheckout\(targetDir\);[\s\S]*?run\("gh", \["repo", "clone", repo, targetDir/,
+  );
+  assert.match(
+    source,
+    /function removeIncompleteTargetCheckout\(targetDir\) \{[\s\S]*?fs\.rmSync\(targetDir, \{ recursive: true, force: true, maxRetries: 3, retryDelay: 100 \}\);/,
+  );
+});
+
 test("execute-fix-artifact skips blocked worker results before invoking Codex or mutating", () => {
   const fixture = makeFixture();
   const resultPath = path.join(fixture.runDir, "result.json");


### PR DESCRIPTION
Fixes the executor failure observed in workflow run 27748392914.

When the read-token clone leaves a partial destination and the write-token fallback retries, remove that known-incomplete checkout before cloning again. Adds a regression contract for the retry path.

Validation:
- node --check scripts/execute-fix-artifact.mjs
- node --test test/execute-fix-artifact.test.mjs
- npm run validate