### PR TITLE
fix(review): accept empty non-security proof fields

### DIFF
--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -374,7 +374,12 @@ function nonSecurityAssertionStrippedText(value) {
     )
     .replace(/\bsecurity[-_\s]?sensitive[-_\s]?guard(?:[-_\s]?detect)?\b/gi, "routine CI guard")
     .replace(/\bsecurity[-_\s]?sensitive\s*[=:]\s*(?:false|0|no)\b/gi, "non-security classification")
+    .replace(/\bsecurity[-_\s]?sensitive\s+(?:false|0|no)\b/gi, "non-security classification")
     .replace(/\bsecuritySensitive\s*[=:]\s*(?:false|0|no)\b/g, "non-security classification")
+    .replace(
+      /\bsecurity[-_\s]?boundary\.security[-_\s]?sensitive[-_\s]?(?:items?|refs?|targets?)\s+(?:is|are)\s+(?:empty|absent|clear)\b/gi,
+      "non-security classification",
+    )
     .replace(
       /\bsecurity[-_\s]?boundary(?:\s+(?:preflight|review|artifact|policy|check)){0,4}\s+(?:reports?|reported|shows?|showed|found|finds|has|had)\s+(?:no|zero)\s+security[-_\s]?sensitive\s+(?:signal|signals|refs?|items?|target|targets)\b/gi,
       "non-security classification",

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -127,6 +127,51 @@ test("review-results ignores false security_sensitive field echoes", () => {
   assert.match(result.stdout, /"status": "passed"/);
 });
 
+test("review-results ignores empty security boundary item collections in mutating evidence", () => {
+  const dir = makeResultDir(
+    {
+      mode: "execute",
+      actions: [
+        {
+          target: "#90672",
+          action: "comment",
+          status: "planned",
+          idempotency_key: "cluster-test:comment:90672:empty-security-items",
+          classification: "canonical",
+          target_kind: "pull_request",
+          target_updated_at: "2026-06-15T14:15:01Z",
+          comment: "The closeout remains pending maintainer review.",
+          evidence: [
+            "Preflight item_matrix marks #90672 security_sensitive false.",
+            "security_boundary.security_sensitive_items is empty, so route_security is not allowed for this run.",
+          ],
+          reason: "The target remains a non-security maintainer workflow item.",
+        },
+      ],
+    },
+    {
+      plan: {
+        items: [
+          {
+            ref: "#90672",
+            kind: "pull_request",
+            state: "open",
+            title: "fix(telegram): report blocked group ingress in /status",
+            labels: ["channel: telegram", "proof: sufficient"],
+            updated_at: "2026-06-15T14:15:01Z",
+            security_sensitive: false,
+          },
+        ],
+      },
+    },
+  );
+
+  const result = review(dir);
+
+  assert.equal(result.status, 0, result.stdout || result.stderr);
+  assert.match(result.stdout, /"status": "passed"/);
+});
+
 test("review-results ignores security-boundary no-signal prose in mutating action evidence", () => {
   const dir = makeResultDir(
     {


### PR DESCRIPTION
## Summary
- accept explicit `security_sensitive false` and empty `security_boundary.security_sensitive_items` evidence as non-security context
- cover the mutating-action review path that blocked PR #90754

## Verification
- `node --test test/review-results.test.mjs`
- `npm run review-results -- /tmp/clownfish-90754-failed`
- `npm run validate`