### PR TITLE
chore(intake): add fresh live PR plan wave

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-001.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T094823-001
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#94024"
+  - "#94023"
+  - "#94038"
+  - "#94027"
+  - "#94061"
+  - "#94060"
+  - "#94041"
+  - "#94097"
+  - "#94091"
+  - "#94111"
+  - "#94069"
+  - "#94088"
+  - "#94128"
+  - "#94046"
+  - "#94122"
+  - "#94121"
+  - "#94118"
+  - "#94109"
+  - "#94103"
+  - "#94137"
+  - "#94139"
+  - "#94112"
+  - "#94072"
+  - "#94151"
+  - "#94149"
+  - "#94136"
+  - "#94154"
+  - "#94134"
+  - "#94049"
+  - "#94116"
+  - "#94169"
+  - "#94185"
+  - "#94182"
+  - "#94195"
+  - "#94172"
+  - "#94193"
+  - "#94204"
+  - "#94216"
+  - "#94213"
+  - "#94214"
+cluster_refs:
+  - "#94024"
+  - "#94023"
+  - "#94038"
+  - "#94027"
+  - "#94061"
+  - "#94060"
+  - "#94041"
+  - "#94097"
+  - "#94091"
+  - "#94111"
+  - "#94069"
+  - "#94088"
+  - "#94128"
+  - "#94046"
+  - "#94122"
+  - "#94121"
+  - "#94118"
+  - "#94109"
+  - "#94103"
+  - "#94137"
+  - "#94139"
+  - "#94112"
+  - "#94072"
+  - "#94151"
+  - "#94149"
+  - "#94136"
+  - "#94154"
+  - "#94134"
+  - "#94049"
+  - "#94116"
+  - "#94169"
+  - "#94185"
+  - "#94182"
+  - "#94195"
+  - "#94172"
+  - "#94193"
+  - "#94204"
+  - "#94216"
+  - "#94213"
+  - "#94214"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T09:48:23.455Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 1
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #94024 fix(gateway): clear stale tailscale serve entries before setting up new ones
+
+- bucket: recent_active
+- author: xydttsw
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, proof: supplied
+- live updated: 2026-06-17T08:27:27Z
+- live url: https://github.com/openclaw/openclaw/pull/94024
+
+### #94023 docs: add agent runtime boundary documentation
+
+- bucket: recent_active
+- author: sheyanmin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: XS, proof: supplied
+- live updated: 2026-06-17T08:30:18Z
+- live url: https://github.com/openclaw/openclaw/pull/94023
+
+### #94038 fix(matrix): recognize MiniMax mm: namespaced reasoning tags in monitor replies
+
+- bucket: recent_active
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: matrix, size: XS, proof: supplied
+- live updated: 2026-06-17T08:47:16Z
+- live url: https://github.com/openclaw/openclaw/pull/94038
+
+### #94027 feat(llm): forward run context to model as opt-in request headers
+
+- bucket: recent_active
+- author: Jah-xy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-17T08:52:01Z
+- live url: https://github.com/openclaw/openclaw/pull/94027
+
+### #94061 fix(agent-runner): suppress stale tool-failed warning when Discord reply delivered via message tool
+
+- bucket: recent_active
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-17T09:24:49Z
+- live url: https://github.com/openclaw/openclaw/pull/94061
+
+### #94060 fix(agents): keep lane timeout alive during long tool execution
+
+- bucket: recent_active
+- author: LiLan0125
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-17T09:25:51Z
+- live url: https://github.com/openclaw/openclaw/pull/94060
+
+### #94041 fix(usage): improve footer fallback resilience and add Telegram surface
+
+- bucket: recent_active
+- author: zhangqueping
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-17T09:52:24Z
+- live url: https://github.com/openclaw/openclaw/pull/94041
+
+### #94097 fix(heartbeat): suppress raw text delivery to channel when visibleReplies is message_tool
+
+- bucket: recent_active
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-17T10:34:09Z
+- live url: https://github.com/openclaw/openclaw/pull/94097
+
+### #94091 fix(cron): persist startup overflow deferral ids in service state
+
+- bucket: recent_active
+- author: ruomuxydt
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied
+- live updated: 2026-06-17T11:21:04Z
+- live url: https://github.com/openclaw/openclaw/pull/94091
+
+### #94111 fix(heartbeat): suppress raw reply delivery in message_tool_only mode
+
+- bucket: recent_active
+- author: LiLan0125
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-17T11:35:47Z
+- live url: https://github.com/openclaw/openclaw/pull/94111
+
+### #94069 feat(commands): switch gemini default model to gemini-3-flash-preview
+
+- bucket: needs_proof
+- author: woyzeck1978
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, extensions: google, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-17T11:38:15Z
+- live url: https://github.com/openclaw/openclaw/pull/94069
+
+### #94088 fix(heartbeat): keep private final reply off-channel in message_tool mode
+
+- bucket: recent_active
+- author: Bartok9
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied
+- live updated: 2026-06-17T11:58:57Z
+- live url: https://github.com/openclaw/openclaw/pull/94088
+
+### #94128 fix(telegram): drop unsupported local markdown link hrefs in rich HTML (fixes #94117)
+
+- bucket: recent_active
+- author: Pick-cat
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, proof: supplied
+- live updated: 2026-06-17T12:04:27Z
+- live url: https://github.com/openclaw/openclaw/pull/94128
+
+### #94046 Force manual compaction past empty kept-tail cuts
+
+- bucket: maintainer_owned
+- author: amknight
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: agents, maintainer, size: M
+- live updated: 2026-06-17T12:24:15Z
+- live url: https://github.com/openclaw/openclaw/pull/94046
+
+### #94122 feat(discord): send up to 10 file attachments per message (#24196)
+
+- bucket: needs_proof
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: discord, size: M, triage: mock-only-proof
+- live updated: 2026-06-17T12:29:20Z
+- live url: https://github.com/openclaw/openclaw/pull/94122
+
+### #94121 fix(heartbeat): prevent message_tool_only text leak when model skips the response tool (#94053)
+
+- bucket: needs_proof
+- author: wendy-chsy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: mock-only-proof
+- live updated: 2026-06-17T12:34:53Z
+- live url: https://github.com/openclaw/openclaw/pull/94121
+
+### #94118 [codex] Fix Telegram rich local Markdown link hrefs
+
+- bucket: recent_active
+- author: dankarization
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, proof: supplied
+- live updated: 2026-06-17T12:43:34Z
+- live url: https://github.com/openclaw/openclaw/pull/94118
+
+### #94109 perf(infra): skip tsdown cleanup when CI=true [AI]
+
+- bucket: needs_proof
+- author: mpz4life
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: automation, status: needs proof
+- live updated: 2026-06-17T12:46:34Z
+- live url: https://github.com/openclaw/openclaw/pull/94109
+
+### #94103 fix(tailscale): pre-clean stale serve entries on gateway startup
+
+- bucket: needs_proof
+- author: fsdwen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, triage: mock-only-proof
+- live updated: 2026-06-17T12:59:08Z
+- live url: https://github.com/openclaw/openclaw/pull/94103
+
+### #94137 fix(codex): backoff startup connection-close retries and surface exhaustion (#83959) [AI-assisted]
+
+- bucket: recent_active
+- author: ml12580
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: codex, proof: supplied
+- live updated: 2026-06-17T13:02:46Z
+- live url: https://github.com/openclaw/openclaw/pull/94137
+
+### #94139 fix(auto-reply): preserve partial image results when some attachments fail to resolve
+
+- bucket: recent_active
+- author: fsdwen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-17T13:07:52Z
+- live url: https://github.com/openclaw/openclaw/pull/94139
+
+### #94112 fix(reply): strip leaked current-message scaffolding and (no output) placeholders
+
+- bucket: recent_active
+- author: SnowSky1
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied
+- live updated: 2026-06-17T13:09:37Z
+- live url: https://github.com/openclaw/openclaw/pull/94112
+
+### #94072 fix(agents): count message-tool source reply as user-facing reply for tool error warnings
+
+- bucket: recent_active
+- author: chenyangjun-xy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-17T13:13:37Z
+- live url: https://github.com/openclaw/openclaw/pull/94072
+
+### #94151 fix(slack): preserve custom identity on message edits
+
+- bucket: recent_active
+- author: dwc1997
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: slack, size: L, proof: supplied
+- live updated: 2026-06-17T13:28:53Z
+- live url: https://github.com/openclaw/openclaw/pull/94151
+
+### #94149 fix(status): bound systemd service probes so status cannot hang on a wedged systemctl (#84698)
+
+- bucket: recent_active
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, commands, size: S, proof: supplied
+- live updated: 2026-06-17T13:29:46Z
+- live url: https://github.com/openclaw/openclaw/pull/94149
+
+### #94136 fix(zai): expose GLM-5.2 reasoning levels [AI-assisted]
+
+- bucket: needs_proof
+- author: BorClaw
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: S, triage: needs-real-behavior-proof, extensions: zai, P2, rating: unranked krab, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-17T13:37:25Z
+- live url: https://github.com/openclaw/openclaw/pull/94136
+
+### #94154 fix(gateway): resolve plugin-registered gateway methods through live registry
+
+- bucket: recent_active
+- author: Pick-cat
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: supplied
+- live updated: 2026-06-17T13:44:06Z
+- live url: https://github.com/openclaw/openclaw/pull/94154
+
+### #94134 feat(ios): auto-connect nearby gateways during onboarding
+
+- bucket: needs_proof
+- author: zats
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: ios, size: L, proof: supplied, P2, rating: silver shellfish, merge-risk: compatibility, status: needs proof, proof: video
+- live updated: 2026-06-17T13:52:30Z
+- live url: https://github.com/openclaw/openclaw/pull/94134
+
+### #94049 fix(whatsapp): propagate steered inbound audio metadata for TTS dispatch
+
+- bucket: needs_proof
+- author: xialonglee
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P2, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-17T14:15:36Z
+- live url: https://github.com/openclaw/openclaw/pull/94049
+
+### #94116 fix(cron): preserve isolated success on delivery failure
+
+- bucket: draft
+- author: yu-xin-c
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: size: S, proof: supplied
+- live updated: 2026-06-17T14:17:49Z
+- live url: https://github.com/openclaw/openclaw/pull/94116
+
+### #94169 fix(control-ui): serve manifest.webmanifest inline via bootstrap config to avoid 403 behind auth proxies
+
+- bucket: recent_active
+- author: xydttsw
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: S, proof: supplied
+- live updated: 2026-06-17T14:26:06Z
+- live url: https://github.com/openclaw/openclaw/pull/94169
+
+### #94185 fix(doctor): recover sibling moltbot.json config dropped on upgrade (#54200) [AI-assisted]
+
+- bucket: recent_active
+- author: ml12580
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, commands, size: M, proof: supplied
+- live updated: 2026-06-17T14:52:37Z
+- live url: https://github.com/openclaw/openclaw/pull/94185
+
+### #94182 fix(cron): persist startup overflow deferral in service state to prevent read-RPC clobbering
+
+- bucket: recent_active
+- author: xydttsw
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied
+- live updated: 2026-06-17T15:11:58Z
+- live url: https://github.com/openclaw/openclaw/pull/94182
+
+### #94195 fix(telegram): avoid HTML parse_mode for plain text to respect iOS font size
+
+- bucket: recent_active
+- author: xydttsw
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-17T15:18:49Z
+- live url: https://github.com/openclaw/openclaw/pull/94195
+
+### #94172 fix(agents): expose fs discovery tools to codex
+
+- bucket: recent_active
+- author: tayoun
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docker, agents, size: S, proof: supplied
+- live updated: 2026-06-17T15:18:56Z
+- live url: https://github.com/openclaw/openclaw/pull/94172
+
+### #94193 fix(cron): prevent lane timeout expiry during long tool execution in isolated cron jobs
+
+- bucket: needs_proof
+- author: xydttsw
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, P1, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-17T15:35:47Z
+- live url: https://github.com/openclaw/openclaw/pull/94193
+
+### #94204 fix(control-ui): rewrite manifest hrefs for configured base path
+
+- bucket: recent_active
+- author: hugenshen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: S, proof: supplied
+- live updated: 2026-06-17T15:38:10Z
+- live url: https://github.com/openclaw/openclaw/pull/94204
+
+### #94216 fix(streaming): preserve paragraph separators across block-chunk deliveries [AI-assisted]
+
+- bucket: recent_active
+- author: eldar702
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied
+- live updated: 2026-06-17T16:04:18Z
+- live url: https://github.com/openclaw/openclaw/pull/94216
+
+### #94213 fix: populate persisted threadId for system events in reply route
+
+- bucket: recent_active
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: S, proof: supplied
+- live updated: 2026-06-17T16:04:19Z
+- live url: https://github.com/openclaw/openclaw/pull/94213
+
+### #94214 fix(ollama): resolve thinking profile for live-discovered models
+
+- bucket: recent_active
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, extensions: ollama
+- live updated: 2026-06-17T16:04:24Z
+- live url: https://github.com/openclaw/openclaw/pull/94214

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-002.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T094823-002
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#94217"
+  - "#94199"
+  - "#94212"
+  - "#94130"
+  - "#94237"
+  - "#94271"
+  - "#94230"
+  - "#94099"
+  - "#94215"
+  - "#94281"
+  - "#94192"
+  - "#94233"
+  - "#94284"
+  - "#94300"
+  - "#94301"
+  - "#94305"
+  - "#94090"
+  - "#94170"
+  - "#94207"
+  - "#94260"
+  - "#94310"
+  - "#94051"
+  - "#94319"
+  - "#94323"
+  - "#94143"
+  - "#94086"
+  - "#94331"
+  - "#94321"
+  - "#94094"
+  - "#94256"
+  - "#94180"
+  - "#94066"
+  - "#94045"
+  - "#94238"
+  - "#94339"
+  - "#94079"
+  - "#94115"
+  - "#94029"
+  - "#94035"
+  - "#94031"
+cluster_refs:
+  - "#94217"
+  - "#94199"
+  - "#94212"
+  - "#94130"
+  - "#94237"
+  - "#94271"
+  - "#94230"
+  - "#94099"
+  - "#94215"
+  - "#94281"
+  - "#94192"
+  - "#94233"
+  - "#94284"
+  - "#94300"
+  - "#94301"
+  - "#94305"
+  - "#94090"
+  - "#94170"
+  - "#94207"
+  - "#94260"
+  - "#94310"
+  - "#94051"
+  - "#94319"
+  - "#94323"
+  - "#94143"
+  - "#94086"
+  - "#94331"
+  - "#94321"
+  - "#94094"
+  - "#94256"
+  - "#94180"
+  - "#94066"
+  - "#94045"
+  - "#94238"
+  - "#94339"
+  - "#94079"
+  - "#94115"
+  - "#94029"
+  - "#94035"
+  - "#94031"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T09:48:23.456Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 2
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #94217 fix(agents): thread image attachments through embedded-agent steer queue [AI-assisted]
+
+- bucket: recent_active
+- author: eldar702
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied
+- live updated: 2026-06-17T16:04:56Z
+- live url: https://github.com/openclaw/openclaw/pull/94217
+
+### #94199 fix(cron): retry isolated setup timeouts
+
+- bucket: ready_for_maintainer
+- author: aaroneden
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: blank-template, proof: supplied, proof: sufficient, P1, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-17T16:09:36Z
+- live url: https://github.com/openclaw/openclaw/pull/94199
+
+### #94212 fix(cron): always emit before_agent_reply phase for cron triggers to prevent watchdog false-positive
+
+- bucket: recent_active
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-17T16:48:40Z
+- live url: https://github.com/openclaw/openclaw/pull/94212
+
+### #94130 fix(anthropic): handle max_turns stop reason and surface retry-limit details to users
+
+- bucket: recent_active
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, P2, merge-risk: session-state
+- live updated: 2026-06-17T17:06:30Z
+- live url: https://github.com/openclaw/openclaw/pull/94130
+
+### #94237 fix(cron): log cache tokens + cost and fix daily usage report totals
+
+- bucket: needs_proof
+- author: wyhgqxq-ship-it
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-17T17:32:40Z
+- live url: https://github.com/openclaw/openclaw/pull/94237
+
+### #94271 fix(agents): truncate oversized text content blocks in tool-result middleware instead of dropping
+
+- bucket: needs_proof
+- author: lzyyzznl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-17T20:59:54Z
+- live url: https://github.com/openclaw/openclaw/pull/94271
+
+### #94230 #94162: Performance: bundle-tools loading adds 6-7s latency on every agent request
+
+- bucket: recent_active
+- author: mmyzwl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied
+- live updated: 2026-06-17T21:10:24Z
+- live url: https://github.com/openclaw/openclaw/pull/94230
+
+### #94099 fix(tools): surface hidden-tool diagnostics via onHiddenDiagnostic callback
+
+- bucket: needs_proof
+- author: fsdwen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P2, rating: silver shellfish, status: needs proof, merge-risk: other
+- live updated: 2026-06-17T21:19:01Z
+- live url: https://github.com/openclaw/openclaw/pull/94099
+
+### #94215 fix(i18n): correct zh-CN theme/cron labels and translate Dreaming restart modal [AI-assisted]
+
+- bucket: needs_proof
+- author: eldar702
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, proof: sufficient, P3, rating: silver shellfish, status: waiting on author
+- live updated: 2026-06-17T21:35:49Z
+- live url: https://github.com/openclaw/openclaw/pull/94215
+
+### #94281 fix(nodes): sanitize large base64 payloads in invoke results
+
+- bucket: needs_proof
+- author: mateolatapia-code
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-17T21:48:36Z
+- live url: https://github.com/openclaw/openclaw/pull/94281
+
+### #94192 [codex] feat(sessions): add read-only diagnose command
+
+- bucket: ready_for_maintainer
+- author: zaidazmi
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: web-ui, gateway, cli, commands, agents, size: XL, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look, feature: showcase
+- live updated: 2026-06-17T22:24:22Z
+- live url: https://github.com/openclaw/openclaw/pull/94192
+
+### #94233 fix(model-fallback): coalesce auth decision logs
+
+- bucket: ready_for_maintainer
+- author: goutamadwant
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-17T23:11:31Z
+- live url: https://github.com/openclaw/openclaw/pull/94233
+
+### #94284 fix: preserve cross-agent subagent role context
+
+- bucket: draft
+- author: pjodoin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-17T23:14:40Z
+- live url: https://github.com/openclaw/openclaw/pull/94284
+
+### #94300 fix(gateway): include OAuth authorization URL in wizard prompts
+
+- bucket: needs_proof
+- author: bkudiess
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: msteams, commands, size: L, extensions: openai, triage: mock-only-proof, extensions: chutes, extensions: google, extensions: openrouter
+- live updated: 2026-06-17T23:36:42Z
+- live url: https://github.com/openclaw/openclaw/pull/94300
+
+### #94301 fix #86957: drain worker-spooled Telegram updates immediately
+
+- bucket: needs_proof
+- author: LiuwqGit
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-17T23:37:24Z
+- live url: https://github.com/openclaw/openclaw/pull/94301
+
+### #94305 fix(agents): use currentAttemptAssistant for incomplete-turn classification
+
+- bucket: needs_proof
+- author: LiuwqGit
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: mock-only-proof
+- live updated: 2026-06-17T23:54:03Z
+- live url: https://github.com/openclaw/openclaw/pull/94305
+
+### #94090 fix(cron): add lane progress heartbeat during embedded agent tool execution (fixes #94033)
+
+- bucket: recent_active
+- author: zenglingbiao
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-18T00:19:18Z
+- live url: https://github.com/openclaw/openclaw/pull/94090
+
+### #94170 fix(tools): cache fs.existsSync calls in plugin scan path
+
+- bucket: needs_proof
+- author: dwc1997
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T00:19:50Z
+- live url: https://github.com/openclaw/openclaw/pull/94170
+
+### #94207 fix(telegram): wake drain immediately after worker-spooled update write
+
+- bucket: needs_proof
+- author: dwc1997
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: L, triage: mock-only-proof
+- live updated: 2026-06-18T00:20:21Z
+- live url: https://github.com/openclaw/openclaw/pull/94207
+
+### #94260 fix(cron): allow empty assistant replies in cron lane (fixes #94224)
+
+- bucket: needs_proof
+- author: zenglingbiao
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T00:21:35Z
+- live url: https://github.com/openclaw/openclaw/pull/94260
+
+### #94310 [Feature]: Detect Containerized Environments and Disable Update Suggestions
+
+- bucket: recent_active
+- author: natecl
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, commands, size: XS, proof: supplied
+- live updated: 2026-06-18T00:30:40Z
+- live url: https://github.com/openclaw/openclaw/pull/94310
+
+### #94051 fix(telegram): strip trailing notify=false marker and send as silent
+
+- bucket: draft
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: channel: telegram, size: S, proof: supplied, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-18T00:35:43Z
+- live url: https://github.com/openclaw/openclaw/pull/94051
+
+### #94319 fix(cron): skip stored delivery context for delivery.mode=none sessions
+
+- bucket: needs_proof
+- author: LiLan0125
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T00:37:10Z
+- live url: https://github.com/openclaw/openclaw/pull/94319
+
+### #94323 fix(cron): stop add/remove from dropping a due recurring job's pending run
+
+- bucket: recent_active
+- author: yetval
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied
+- live updated: 2026-06-18T00:47:00Z
+- live url: https://github.com/openclaw/openclaw/pull/94323
+
+### #94143 fix(gateway): resolve plugin-registered gateway methods through live registry
+
+- bucket: needs_proof
+- author: zenglingbiao
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, proof: supplied, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-18T00:47:03Z
+- live url: https://github.com/openclaw/openclaw/pull/94143
+
+### #94086 fix(doctor): archive superseded plugin install indexes
+
+- bucket: ready_for_maintainer
+- author: ooiuuii
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-18T00:48:44Z
+- live url: https://github.com/openclaw/openclaw/pull/94086
+
+### #94331 fix: merge llm policy into plugin subagent override authorization
+
+- bucket: recent_active
+- author: sheyanmin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, proof: supplied
+- live updated: 2026-06-18T01:01:20Z
+- live url: https://github.com/openclaw/openclaw/pull/94331
+
+### #94321 fix(telegram): normalize all HTML tables before entity-escaping in rich messages
+
+- bucket: recent_active
+- author: zhangqueping
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, proof: supplied
+- live updated: 2026-06-18T01:03:23Z
+- live url: https://github.com/openclaw/openclaw/pull/94321
+
+### #94094 fix(agents): strip leaked truncation sentinels from final replies (#82121)
+
+- bucket: needs_proof
+- author: MoerAI
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T01:14:41Z
+- live url: https://github.com/openclaw/openclaw/pull/94094
+
+### #94256 fix(redact): stop over-masking kebab identifiers as Apple app-specific passwords
+
+- bucket: recent_active
+- author: Nas01010101
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied
+- live updated: 2026-06-18T01:15:07Z
+- live url: https://github.com/openclaw/openclaw/pull/94256
+
+### #94180 feat(memory-core): allow private network endpoints for memory embeddi
+
+- bucket: recent_active
+- author: SunnyShu0925
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: supplied
+- live updated: 2026-06-18T01:18:26Z
+- live url: https://github.com/openclaw/openclaw/pull/94180
+
+### #94066 fix(qwen): enable qwen3.6-plus on Coding Plan CN, correct reasoning flag
+
+- bucket: recent_active
+- author: zhanxingxin1998
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied
+- live updated: 2026-06-18T01:20:23Z
+- live url: https://github.com/openclaw/openclaw/pull/94066
+
+### #94045 Explain private-network exec failures
+
+- bucket: recent_active
+- author: TurboTheTurtle
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied
+- live updated: 2026-06-18T01:20:40Z
+- live url: https://github.com/openclaw/openclaw/pull/94045
+
+### #94238 fix(config): fail closed when configure runs without an interactive TTY (#93953)
+
+- bucket: recent_active
+- author: ruomuxydt
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: S, proof: supplied
+- live updated: 2026-06-18T01:21:35Z
+- live url: https://github.com/openclaw/openclaw/pull/94238
+
+### #94339 fix(codex): keep root MEMORY.md in prompt context when memory tools are available
+
+- bucket: recent_active
+- author: zhangqueping
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, extensions: codex, proof: supplied
+- live updated: 2026-06-18T01:21:40Z
+- live url: https://github.com/openclaw/openclaw/pull/94339
+
+### #94079 docs(gateway): document host agent runtime boundary policy
+
+- bucket: recent_active
+- author: Monkey-wusky
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: XS, proof: supplied
+- live updated: 2026-06-18T01:25:20Z
+- live url: https://github.com/openclaw/openclaw/pull/94079
+
+### #94115 fix(nodes): add actionable hint for 'unknown requestId' pairing error
+
+- bucket: needs_proof
+- author: Monkey-wusky
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T01:25:24Z
+- live url: https://github.com/openclaw/openclaw/pull/94115
+
+### #94029 fix(setup): correct health failure hint to point at 'openclaw onboard' flags
+
+- bucket: recent_active
+- author: Monkey-wusky
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: supplied
+- live updated: 2026-06-18T01:26:30Z
+- live url: https://github.com/openclaw/openclaw/pull/94029
+
+### #94035 fix(tailscale): reset serve entries before setup to prevent duplicates on restart
+
+- bucket: recent_active
+- author: Monkey-wusky
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, proof: supplied
+- live updated: 2026-06-18T01:26:44Z
+- live url: https://github.com/openclaw/openclaw/pull/94035
+
+### #94031 fix(discord): prevent stale tool-failed warning after successful message_tool_only reply
+
+- bucket: recent_active
+- author: Monkey-wusky
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-18T01:26:45Z
+- live url: https://github.com/openclaw/openclaw/pull/94031

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-003.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T094823-003
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#94315"
+  - "#94257"
+  - "#94252"
+  - "#94250"
+  - "#94308"
+  - "#94042"
+  - "#94328"
+  - "#94335"
+  - "#94221"
+  - "#94231"
+  - "#94232"
+  - "#94181"
+  - "#94173"
+  - "#94161"
+  - "#94140"
+  - "#94247"
+  - "#94110"
+  - "#94096"
+  - "#94349"
+  - "#94299"
+  - "#94087"
+  - "#94291"
+  - "#94357"
+  - "#94361"
+  - "#94374"
+  - "#94065"
+  - "#94073"
+  - "#94294"
+  - "#94119"
+  - "#94067"
+  - "#94381"
+  - "#94320"
+  - "#94384"
+  - "#94197"
+  - "#94306"
+  - "#94386"
+  - "#94359"
+  - "#94084"
+  - "#94407"
+  - "#94409"
+cluster_refs:
+  - "#94315"
+  - "#94257"
+  - "#94252"
+  - "#94250"
+  - "#94308"
+  - "#94042"
+  - "#94328"
+  - "#94335"
+  - "#94221"
+  - "#94231"
+  - "#94232"
+  - "#94181"
+  - "#94173"
+  - "#94161"
+  - "#94140"
+  - "#94247"
+  - "#94110"
+  - "#94096"
+  - "#94349"
+  - "#94299"
+  - "#94087"
+  - "#94291"
+  - "#94357"
+  - "#94361"
+  - "#94374"
+  - "#94065"
+  - "#94073"
+  - "#94294"
+  - "#94119"
+  - "#94067"
+  - "#94381"
+  - "#94320"
+  - "#94384"
+  - "#94197"
+  - "#94306"
+  - "#94386"
+  - "#94359"
+  - "#94084"
+  - "#94407"
+  - "#94409"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T09:48:23.456Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 3
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #94315 #94249: skill_workshop apply times out on large proposals (~28KB)
+
+- bucket: recent_active
+- author: mmyzwl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-18T01:35:23Z
+- live url: https://github.com/openclaw/openclaw/pull/94315
+
+### #94257 fix(sessions): preserve Media* index alignment when reading user-turn fields
+
+- bucket: ready_for_maintainer
+- author: Nas01010101
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-18T01:45:48Z
+- live url: https://github.com/openclaw/openclaw/pull/94257
+
+### #94252 fix(memory): scrub stale dreaming sessions on startup
+
+- bucket: needs_proof
+- author: bennewell35
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: supplied, P2, rating: silver shellfish, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-18T01:48:35Z
+- live url: https://github.com/openclaw/openclaw/pull/94252
+
+### #94250 fix(feishu): send blocks as independent messages when blockStreaming is enabled
+
+- bucket: needs_proof
+- author: xialonglee
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: S, proof: supplied, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-18T01:49:15Z
+- live url: https://github.com/openclaw/openclaw/pull/94250
+
+### #94308 feat(status): show session costs
+
+- bucket: recent_active
+- author: mraleko
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, commands, size: S, proof: supplied
+- live updated: 2026-06-18T01:49:35Z
+- live url: https://github.com/openclaw/openclaw/pull/94308
+
+### #94042 fix(feishu): paginate drive list/info to resolve files beyond first page
+
+- bucket: recent_active
+- author: xzh-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: M, proof: supplied
+- live updated: 2026-06-18T01:56:00Z
+- live url: https://github.com/openclaw/openclaw/pull/94042
+
+### #94328 fix(agents): keep post-compaction user re-issue of a kept-tail prompt during compaction rotation
+
+- bucket: ready_for_maintainer
+- author: yetval
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-18T01:56:47Z
+- live url: https://github.com/openclaw/openclaw/pull/94328
+
+### #94335 fix(subagent): reconcile child output before lost-context sweep
+
+- bucket: needs_proof
+- author: dwc1997
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-18T02:01:47Z
+- live url: https://github.com/openclaw/openclaw/pull/94335
+
+### #94221 fix(skills): preserve skillKey in SkillSnapshot for env override resolution
+
+- bucket: recent_active
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-18T02:08:31Z
+- live url: https://github.com/openclaw/openclaw/pull/94221
+
+### #94231 fix(telegram): strip local/relative markdown link hrefs that cause RICH_MESSAGE_URL_INVALID
+
+- bucket: recent_active
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, proof: supplied
+- live updated: 2026-06-18T02:08:51Z
+- live url: https://github.com/openclaw/openclaw/pull/94231
+
+### #94232 fix(ui): make raw config textarea scrollable in settings view
+
+- bucket: recent_active
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, proof: supplied
+- live updated: 2026-06-18T02:08:54Z
+- live url: https://github.com/openclaw/openclaw/pull/94232
+
+### #94181 fix(feishu): paginate message reaction listing
+
+- bucket: needs_proof
+- author: Alix-007
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T02:12:14Z
+- live url: https://github.com/openclaw/openclaw/pull/94181
+
+### #94173 fix(feishu): paginate document block listing when clearing a document
+
+- bucket: needs_proof
+- author: Alix-007
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T02:12:27Z
+- live url: https://github.com/openclaw/openclaw/pull/94173
+
+### #94161 fix(feishu): paginate bitable table and field listings
+
+- bucket: needs_proof
+- author: Alix-007
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T02:12:55Z
+- live url: https://github.com/openclaw/openclaw/pull/94161
+
+### #94140 fix(agents): require a letter before treating an uppercase line as a tool doc-block header
+
+- bucket: needs_proof
+- author: Alix-007
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T02:13:13Z
+- live url: https://github.com/openclaw/openclaw/pull/94140
+
+### #94247 fix(streaming): preserve paragraph separators across block-streamed deliveries [AI-assisted]
+
+- bucket: needs_proof
+- author: ml12580
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-18T02:13:16Z
+- live url: https://github.com/openclaw/openclaw/pull/94247
+
+### #94110 fix(plugins): surface empty availability groups at plugin tool registration
+
+- bucket: needs_proof
+- author: Alix-007
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T02:13:25Z
+- live url: https://github.com/openclaw/openclaw/pull/94110
+
+### #94096 fix(usage): reject inverted startDate-endDate range in usage.cost and sessions.usage
+
+- bucket: needs_proof
+- author: Alix-007
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T02:13:33Z
+- live url: https://github.com/openclaw/openclaw/pull/94096
+
+### #94349 fix(agents): preserve pending subagent completion announces
+
+- bucket: maintainer_owned
+- author: sallyom
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: agents, maintainer, size: S
+- live updated: 2026-06-18T02:17:21Z
+- live url: https://github.com/openclaw/openclaw/pull/94349
+
+### #94299 fix(codex): keep root memory in bootstrap context
+
+- bucket: recent_active
+- author: nicknmorty
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: codex, proof: supplied
+- live updated: 2026-06-18T02:24:21Z
+- live url: https://github.com/openclaw/openclaw/pull/94299
+
+### #94087 fix: prevent heartbeat runner from leaking private replies in message_tool_only mode
+
+- bucket: recent_active
+- author: sheyanmin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-18T02:28:21Z
+- live url: https://github.com/openclaw/openclaw/pull/94087
+
+### #94291 ci: draft QA Lab smoke profile dispatch wiring
+
+- bucket: draft
+- author: Solvely-Colin
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: size: S, proof: supplied, P3, rating: silver shellfish, merge-risk: automation, status: needs proof
+- live updated: 2026-06-18T02:28:45Z
+- live url: https://github.com/openclaw/openclaw/pull/94291
+
+### #94357 Allow WhatsApp observe-only message hooks
+
+- bucket: recent_active
+- author: fluffychaichai
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: whatsapp-web, size: M, proof: supplied
+- live updated: 2026-06-18T02:30:07Z
+- live url: https://github.com/openclaw/openclaw/pull/94357
+
+### #94361 fix(ui): scroll to cron run history
+
+- bucket: needs_proof
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T02:31:41Z
+- live url: https://github.com/openclaw/openclaw/pull/94361
+
+### #94374 fix: suppress exec stderr warnings from covering channel replies (#94360)
+
+- bucket: needs_proof
+- author: joelnishanth
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: mock-only-proof
+- live updated: 2026-06-18T02:34:29Z
+- live url: https://github.com/openclaw/openclaw/pull/94374
+
+### #94065 feat(bonjour): add instanceName plugin config to override mDNS service name [AI-assisted]
+
+- bucket: needs_proof
+- author: zhanxingxin1998
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: S, plugin: bonjour, triage: mock-only-proof
+- live updated: 2026-06-18T02:37:05Z
+- live url: https://github.com/openclaw/openclaw/pull/94065
+
+### #94073 fix(config): allow historyLimit: 0 in GroupChatSchema
+
+- bucket: needs_proof
+- author: zhanxingxin1998
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, triage: mock-only-proof
+- live updated: 2026-06-18T02:37:10Z
+- live url: https://github.com/openclaw/openclaw/pull/94073
+
+### #94294 fix: dedupe duplicate non-streaming final replies
+
+- bucket: needs_proof
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-18T02:42:45Z
+- live url: https://github.com/openclaw/openclaw/pull/94294
+
+### #94119 fix(update): warn about stale gateway when version changes
+
+- bucket: needs_proof
+- author: Monkey-wusky
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied, P1, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T02:44:12Z
+- live url: https://github.com/openclaw/openclaw/pull/94119
+
+### #94067 fix(channels): resolve native /think menu levels via runtime catalog for live-discovered models
+
+- bucket: maintainer_owned
+- author: openperf
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: channel: discord, channel: slack, channel: telegram, size: S, mantis: telegram-visible-proof, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-18T02:46:17Z
+- live url: https://github.com/openclaw/openclaw/pull/94067
+
+### #94381 #94360: Feishu - exec stderr output sent as user-visible reply
+
+- bucket: recent_active
+- author: mmyzwl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-18T02:47:57Z
+- live url: https://github.com/openclaw/openclaw/pull/94381
+
+### #94320 feat(discord): drain pending deliveries on gateway reconnect
+
+- bucket: needs_proof
+- author: bladin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-18T02:49:09Z
+- live url: https://github.com/openclaw/openclaw/pull/94320
+
+### #94384 feat(telegram): send voice typing cue before transcription
+
+- bucket: needs_proof
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T02:55:11Z
+- live url: https://github.com/openclaw/openclaw/pull/94384
+
+### #94197 fix(sandbox): translate Docker bind-mount host paths for DooD deployments
+
+- bucket: recent_active
+- author: xydttsw
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-18T03:00:18Z
+- live url: https://github.com/openclaw/openclaw/pull/94197
+
+### #94306 test: add QA Lab UX Matrix evidence scenario
+
+- bucket: recent_active
+- author: Solvely-Colin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: XL, extensions: qa-lab, proof: supplied
+- live updated: 2026-06-18T03:00:55Z
+- live url: https://github.com/openclaw/openclaw/pull/94306
+
+### #94386 feat(whatsapp): notify sender after pairing approval
+
+- bucket: needs_proof
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: whatsapp-web, size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T03:02:44Z
+- live url: https://github.com/openclaw/openclaw/pull/94386
+
+### #94359 fix(sessions): use account names for direct display
+
+- bucket: needs_proof
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T03:05:51Z
+- live url: https://github.com/openclaw/openclaw/pull/94359
+
+### #94084 fix(cli): sync official plugins during update --all
+
+- bucket: ready_for_maintainer
+- author: ooiuuii
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-18T03:10:45Z
+- live url: https://github.com/openclaw/openclaw/pull/94084
+
+### #94407 fix(agents): use configured compaction timeout for aggregate retry deadline
+
+- bucket: recent_active
+- author: zhangqueping
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-18T03:35:15Z
+- live url: https://github.com/openclaw/openclaw/pull/94407
+
+### #94409 fix(sessions_send): derive delivery channel from resolved session entry
+
+- bucket: recent_active
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-18T03:35:37Z
+- live url: https://github.com/openclaw/openclaw/pull/94409

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-004.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T094823-004
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#94410"
+  - "#94165"
+  - "#94363"
+  - "#94028"
+  - "#94304"
+  - "#94352"
+  - "#94078"
+  - "#94346"
+  - "#94387"
+  - "#94420"
+  - "#94223"
+  - "#94402"
+  - "#94424"
+  - "#94163"
+  - "#94404"
+  - "#94235"
+  - "#94430"
+  - "#94431"
+  - "#94054"
+  - "#94348"
+  - "#94392"
+  - "#94412"
+  - "#94436"
+  - "#94437"
+  - "#94423"
+  - "#94376"
+  - "#94415"
+  - "#94427"
+  - "#94373"
+  - "#94106"
+  - "#94405"
+  - "#94393"
+  - "#94227"
+  - "#94314"
+  - "#94446"
+  - "#94210"
+  - "#94341"
+  - "#94342"
+  - "#94428"
+  - "#94219"
+cluster_refs:
+  - "#94410"
+  - "#94165"
+  - "#94363"
+  - "#94028"
+  - "#94304"
+  - "#94352"
+  - "#94078"
+  - "#94346"
+  - "#94387"
+  - "#94420"
+  - "#94223"
+  - "#94402"
+  - "#94424"
+  - "#94163"
+  - "#94404"
+  - "#94235"
+  - "#94430"
+  - "#94431"
+  - "#94054"
+  - "#94348"
+  - "#94392"
+  - "#94412"
+  - "#94436"
+  - "#94437"
+  - "#94423"
+  - "#94376"
+  - "#94415"
+  - "#94427"
+  - "#94373"
+  - "#94106"
+  - "#94405"
+  - "#94393"
+  - "#94227"
+  - "#94314"
+  - "#94446"
+  - "#94210"
+  - "#94341"
+  - "#94342"
+  - "#94428"
+  - "#94219"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T09:48:23.456Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 4
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #94410 fix(cron): apply defaultAgentId in normalizeCronJobInput applyDefaults
+
+- bucket: recent_active
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, proof: supplied
+- live updated: 2026-06-18T03:35:54Z
+- live url: https://github.com/openclaw/openclaw/pull/94410
+
+### #94165 fix(control-ui): recognize namespaced reasoning tags in thinking extraction
+
+- bucket: needs_proof
+- author: Alix-007
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, triage: needs-real-behavior-proof, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-18T03:41:34Z
+- live url: https://github.com/openclaw/openclaw/pull/94165
+
+### #94363 fix(logging): narrow app-specific password field detection to Apple/iCloud contexts
+
+- bucket: needs_proof
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T03:47:47Z
+- live url: https://github.com/openclaw/openclaw/pull/94363
+
+### #94028 fix(config): close configure wizard on non-TTY with clear error message
+
+- bucket: needs_proof
+- author: Monkey-wusky
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T03:49:24Z
+- live url: https://github.com/openclaw/openclaw/pull/94028
+
+### #94304 fix: split taxonomy coverage id features
+
+- bucket: maintainer_owned
+- author: RomneyDa
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: maintainer, size: XL, extensions: qa-lab, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-18T03:49:47Z
+- live url: https://github.com/openclaw/openclaw/pull/94304
+
+### #94352 feat: scaffold provider plugins from init
+
+- bucket: maintainer_owned
+- author: Patrick-Erichsen
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: docs, cli, scripts, maintainer, size: L
+- live updated: 2026-06-18T03:49:51Z
+- live url: https://github.com/openclaw/openclaw/pull/94352
+
+### #94078 fix(agents): isolate RTL lines on outbound assistant text
+
+- bucket: needs_proof
+- author: zhanxingxin1998
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: mock-only-proof, mantis: telegram-visible-proof, P2, rating: silver shellfish, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-18T03:53:07Z
+- live url: https://github.com/openclaw/openclaw/pull/94078
+
+### #94346 fix(cron): persist startup overflow deferral in service state to prevent silent drop
+
+- bucket: needs_proof
+- author: xydttsw
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-18T03:55:21Z
+- live url: https://github.com/openclaw/openclaw/pull/94346
+
+### #94387 fix(plugin-sdk): export approval handler runtime event types
+
+- bucket: maintainer_owned
+- author: amknight
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: maintainer, size: XS, P3, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-18T04:01:12Z
+- live url: https://github.com/openclaw/openclaw/pull/94387
+
+### #94420 fix(subagent): recover terminal transcript before lost context
+
+- bucket: draft
+- author: yu-xin-c
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: agents, size: M, proof: supplied
+- live updated: 2026-06-18T04:02:53Z
+- live url: https://github.com/openclaw/openclaw/pull/94420
+
+### #94223 fix(codex): prefer recovered replies over stale failure banners
+
+- bucket: recent_active
+- author: arthurfantaci
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, extensions: codex, proof: supplied
+- live updated: 2026-06-18T04:06:03Z
+- live url: https://github.com/openclaw/openclaw/pull/94223
+
+### #94402 fix: handle object-format data and URL-safe base64 from OpenAI-compatible proxy responses
+
+- bucket: recent_active
+- author: Jah-xy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-18T04:06:35Z
+- live url: https://github.com/openclaw/openclaw/pull/94402
+
+### #94424 fix(claude-cli): route native tool use through operator approver when ask is configured
+
+- bucket: recent_active
+- author: LiLan0125
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied
+- live updated: 2026-06-18T04:16:05Z
+- live url: https://github.com/openclaw/openclaw/pull/94424
+
+### #94163 fix(skills): persist skillKey in SkillSnapshot for snapshot env override resolution (fixes #94146)
+
+- bucket: needs_proof
+- author: zenglingbiao
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T04:18:01Z
+- live url: https://github.com/openclaw/openclaw/pull/94163
+
+### #94404 fix(zai): fall back to default baseUrl when template lacks one for catalog models
+
+- bucket: needs_proof
+- author: xydttsw
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, extensions: zai, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T04:18:58Z
+- live url: https://github.com/openclaw/openclaw/pull/94404
+
+### #94235 fix: #94224 cron lane FailoverError
+
+- bucket: needs_proof
+- author: zhiqiang26
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P1, rating: silver shellfish, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T04:19:54Z
+- live url: https://github.com/openclaw/openclaw/pull/94235
+
+### #94430 fix(errors): recognize content policy / new_sensitive errors as rate_limit for fallback
+
+- bucket: needs_proof
+- author: xiongxiaoyang-cell
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T04:36:26Z
+- live url: https://github.com/openclaw/openclaw/pull/94430
+
+### #94431 fix(cli): accept parent options placed after lazy subcommands (#55563 regression 1) [AI-assisted]
+
+- bucket: recent_active
+- author: ml12580
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: M, proof: supplied
+- live updated: 2026-06-18T04:41:14Z
+- live url: https://github.com/openclaw/openclaw/pull/94431
+
+### #94054 fix(gateway.tls): reject empty/whitespace certPath and keyPath
+
+- bucket: needs_proof
+- author: miorbnli
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-18T04:48:51Z
+- live url: https://github.com/openclaw/openclaw/pull/94054
+
+### #94348 fix(msteams): keep attachment replies in channel threads
+
+- bucket: needs_proof
+- author: arkyu2077
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: msteams, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-18T04:49:42Z
+- live url: https://github.com/openclaw/openclaw/pull/94348
+
+### #94392 fix(gateway): strip oversized config payload from config.get tool result details
+
+- bucket: needs_proof
+- author: xydttsw
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-18T04:58:09Z
+- live url: https://github.com/openclaw/openclaw/pull/94392
+
+### #94412 fix(agent-core): stop loop after aborted tool run
+
+- bucket: needs_proof
+- author: szsip239
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P1, rating: gold shrimp, status: needs proof
+- live updated: 2026-06-18T05:05:50Z
+- live url: https://github.com/openclaw/openclaw/pull/94412
+
+### #94436 docs(media): clarify legacy MEDIA line formatting
+
+- bucket: needs_proof
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T05:14:26Z
+- live url: https://github.com/openclaw/openclaw/pull/94436
+
+### #94437 fix(agents): render identity name in runtime prompt
+
+- bucket: needs_proof
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T05:22:21Z
+- live url: https://github.com/openclaw/openclaw/pull/94437
+
+### #94423 Add stdin and file message inputs to agent CLI
+
+- bucket: needs_proof
+- author: mcampsall
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, commands, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T05:41:23Z
+- live url: https://github.com/openclaw/openclaw/pull/94423
+
+### #94376 feat(qqbot): add actionable setup error guidance
+
+- bucket: needs_proof
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, channel: qqbot, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-18T05:43:41Z
+- live url: https://github.com/openclaw/openclaw/pull/94376
+
+### #94415 fix(ports): probe all address families in ensurePortAvailable
+
+- bucket: needs_proof
+- author: wangwllu
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-18T05:49:30Z
+- live url: https://github.com/openclaw/openclaw/pull/94415
+
+### #94427 fix(feishu): render streaming card footer
+
+- bucket: recent_active
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: M, proof: supplied
+- live updated: 2026-06-18T05:51:18Z
+- live url: https://github.com/openclaw/openclaw/pull/94427
+
+### #94373 fix(parallel): prevent parallel-free from being auto-detected as default web search provider
+
+- bucket: recent_active
+- author: yuxuan-7814
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: matrix, cli, agents, size: M, proof: supplied, extensions: parallel
+- live updated: 2026-06-18T05:52:58Z
+- live url: https://github.com/openclaw/openclaw/pull/94373
+
+### #94106 fix(secrets): scope env scrub to migrated providers' vars
+
+- bucket: ready_for_maintainer
+- author: yetval
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-18T05:55:12Z
+- live url: https://github.com/openclaw/openclaw/pull/94106
+
+### #94405 fix(telegram): fall back to sendMessage when sendRichMessage unsupported by client
+
+- bucket: recent_active
+- author: zw-xysk
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: M, proof: supplied
+- live updated: 2026-06-18T05:55:57Z
+- live url: https://github.com/openclaw/openclaw/pull/94405
+
+### #94393 fix(gateway): enable Ctrl+C signal handling on Windows
+
+- bucket: recent_active
+- author: yuxuan-7814
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: matrix, cli, agents, size: M, proof: supplied, extensions: parallel
+- live updated: 2026-06-18T05:58:15Z
+- live url: https://github.com/openclaw/openclaw/pull/94393
+
+### #94227 fix(reply): preserve routed transcript mirror metadata
+
+- bucket: needs_proof
+- author: hugenshen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, P1, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-18T05:58:16Z
+- live url: https://github.com/openclaw/openclaw/pull/94227
+
+### #94314 refactor(policy): split doctor modules
+
+- bucket: maintainer_owned
+- author: giodl73-repo
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: maintainer, size: XL, P3, rating: unranked krab, status: actively grinding, extensions: policy
+- live updated: 2026-06-18T05:58:25Z
+- live url: https://github.com/openclaw/openclaw/pull/94314
+
+### #94446 fix(context-engine): eagerly resolve plugin LLM policy from config for model override authority
+
+- bucket: recent_active
+- author: xydttsw
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-18T06:06:00Z
+- live url: https://github.com/openclaw/openclaw/pull/94446
+
+### #94210 fix(cli): resolve 200K context window fallback in status command
+
+- bucket: needs_proof
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: supplied, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T06:06:15Z
+- live url: https://github.com/openclaw/openclaw/pull/94210
+
+### #94341 fix(agents): load bootstrap files from agentDir alongside workspace
+
+- bucket: recent_active
+- author: mazhuima
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-18T06:06:49Z
+- live url: https://github.com/openclaw/openclaw/pull/94341
+
+### #94342 fix(hooks): wire message:sending internal hook to user-defined hooks
+
+- bucket: recent_active
+- author: mazhuima
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied
+- live updated: 2026-06-18T06:06:54Z
+- live url: https://github.com/openclaw/openclaw/pull/94342
+
+### #94428 fix(feishu): preserve replies before error finals
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: steipete
+- labels: maintainer, channel: feishu, size: S
+- live updated: 2026-06-18T06:07:45Z
+- live url: https://github.com/openclaw/openclaw/pull/94428
+
+### #94219 fix(control-ui): restore provider usage quota pill in sidebar session switcher (fixes #93041)
+
+- bucket: ready_for_maintainer
+- author: Pick-cat
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-18T06:10:48Z
+- live url: https://github.com/openclaw/openclaw/pull/94219

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-005.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T094823-005
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#94450"
+  - "#94451"
+  - "#94422"
+  - "#94456"
+  - "#94445"
+  - "#94150"
+  - "#94218"
+  - "#94338"
+  - "#94463"
+  - "#94044"
+  - "#94467"
+  - "#94048"
+  - "#94050"
+  - "#94135"
+  - "#94459"
+  - "#94107"
+  - "#94441"
+  - "#94461"
+  - "#94253"
+  - "#94477"
+  - "#94462"
+  - "#94198"
+  - "#94240"
+  - "#94438"
+  - "#94472"
+  - "#94070"
+  - "#94485"
+  - "#94487"
+  - "#94211"
+  - "#94362"
+  - "#94388"
+  - "#94394"
+  - "#94492"
+  - "#94474"
+  - "#94433"
+  - "#94480"
+  - "#94488"
+  - "#94494"
+  - "#94496"
+  - "#94497"
+cluster_refs:
+  - "#94450"
+  - "#94451"
+  - "#94422"
+  - "#94456"
+  - "#94445"
+  - "#94150"
+  - "#94218"
+  - "#94338"
+  - "#94463"
+  - "#94044"
+  - "#94467"
+  - "#94048"
+  - "#94050"
+  - "#94135"
+  - "#94459"
+  - "#94107"
+  - "#94441"
+  - "#94461"
+  - "#94253"
+  - "#94477"
+  - "#94462"
+  - "#94198"
+  - "#94240"
+  - "#94438"
+  - "#94472"
+  - "#94070"
+  - "#94485"
+  - "#94487"
+  - "#94211"
+  - "#94362"
+  - "#94388"
+  - "#94394"
+  - "#94492"
+  - "#94474"
+  - "#94433"
+  - "#94480"
+  - "#94488"
+  - "#94494"
+  - "#94496"
+  - "#94497"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T09:48:23.456Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 5
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #94450 fix(agents): expand leading tilde in exec workdir
+
+- bucket: recent_active
+- author: bowenluo718
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied
+- live updated: 2026-06-18T06:13:59Z
+- live url: https://github.com/openclaw/openclaw/pull/94450
+
+### #94451 Add ARD core discovery primitives
+
+- bucket: draft
+- author: jason-allen-oneal
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: docs, size: L, proof: supplied
+- live updated: 2026-06-18T06:15:35Z
+- live url: https://github.com/openclaw/openclaw/pull/94451
+
+### #94422 fix(channels): drop reasoning deltas that are a sub-string of the current buffer
+
+- bucket: needs_proof
+- author: miorbnli
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P2, rating: gold shrimp, status: waiting on author
+- live updated: 2026-06-18T06:15:42Z
+- live url: https://github.com/openclaw/openclaw/pull/94422
+
+### #94456 fix(cli): route isPortBusy through checkPortInUse to detect IPv4-only occupants
+
+- bucket: recent_active
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied
+- live updated: 2026-06-18T06:16:19Z
+- live url: https://github.com/openclaw/openclaw/pull/94456
+
+### #94445 fix(agents): keep cron cloud idle watchdog enabled
+
+- bucket: maintainer_owned
+- author: bek91
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: agents, maintainer, size: XS
+- live updated: 2026-06-18T06:19:39Z
+- live url: https://github.com/openclaw/openclaw/pull/94445
+
+### #94150 fix(gateway): deliver replies stranded in pendingFinalDelivery (#93625)
+
+- bucket: maintainer_owned
+- author: ai-hpc
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: gateway, size: M, P1, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-18T06:24:36Z
+- live url: https://github.com/openclaw/openclaw/pull/94150
+
+### #94218 fix(telegram): fall back to plain text when sendRichMessage fails on Telegram Web
+
+- bucket: needs_proof
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: S, proof: supplied, mantis: telegram-visible-proof, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T06:30:26Z
+- live url: https://github.com/openclaw/openclaw/pull/94218
+
+### #94338 fix(whatsapp): wire missing Baileys retry/cache hooks for group message reliability
+
+- bucket: needs_proof
+- author: xialonglee
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: whatsapp-web, size: S, proof: supplied, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-18T06:33:36Z
+- live url: https://github.com/openclaw/openclaw/pull/94338
+
+### #94463 fix: isPortBusy preflight misses IPv4-only occupant
+
+- bucket: recent_active
+- author: Jah-xy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied
+- live updated: 2026-06-18T06:38:12Z
+- live url: https://github.com/openclaw/openclaw/pull/94463
+
+### #94044 fix(matrix): prevent gateway stop on Megolm missing-key decryption failures
+
+- bucket: needs_proof
+- author: yuxuan-7814
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: matrix, size: S, proof: supplied, P1, rating: unranked krab, merge-risk: message-delivery, merge-risk: availability, status: needs proof
+- live updated: 2026-06-18T06:40:17Z
+- live url: https://github.com/openclaw/openclaw/pull/94044
+
+### #94467 [codex] Prove Workboard dispatch lifecycle starts
+
+- bucket: draft
+- author: akeshr
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: docs, channel: discord, channel: googlechat, channel: imessage, channel: line, channel: matrix, channel: mattermost, channel: msteams, channel: nextcloud-talk, channel: nostr, channel: signal, channel: slack, channel: telegram, channel: tlon, channel: voice-call, channel: whatsapp-web, channel: zalo, channel: zalouser, app: android, app: ios, app: macos, app: web-ui, gateway, extensions: copilot-proxy, extensions: diagnostics-otel, extensions: llm-task, extensions: lobster, extensions: memory-core, extensions: memory-lancedb, extensions: open-prose
+- live updated: 2026-06-18T06:45:06Z
+- live url: https://github.com/openclaw/openclaw/pull/94467
+
+### #94048 fix(telegram): set richMessages default to false explicitly in schema
+
+- bucket: recent_active
+- author: Monkey-wusky
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, mantis: telegram-visible-proof, P1, rating: unranked krab, merge-risk: compatibility, status: actively grinding
+- live updated: 2026-06-18T06:47:12Z
+- live url: https://github.com/openclaw/openclaw/pull/94048
+
+### #94050 fix: strip volatile output from exec result hash to fix no-progress detection (#93917)
+
+- bucket: needs_proof
+- author: sunlit-deng
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: availability, status: needs proof
+- live updated: 2026-06-18T06:48:22Z
+- live url: https://github.com/openclaw/openclaw/pull/94050
+
+### #94135 fix(memory-core): index memory path in FTS text for filename queries (fixes #94102)
+
+- bucket: needs_proof
+- author: Pick-cat
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: M, proof: supplied, proof: sufficient, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-18T06:53:51Z
+- live url: https://github.com/openclaw/openclaw/pull/94135
+
+### #94459 fix: add OTel reply latency decomposition
+
+- bucket: maintainer_owned
+- author: bek91
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: docs, gateway, extensions: diagnostics-otel, agents, maintainer, size: XL, extensions: qa-lab
+- live updated: 2026-06-18T06:54:04Z
+- live url: https://github.com/openclaw/openclaw/pull/94459
+
+### #94107 fix(outbound): reject reserved Telegram targets before directory/default fallback
+
+- bucket: needs_proof
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, gateway, size: M, proof: supplied, mantis: telegram-visible-proof, P1, rating: silver shellfish, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-18T06:58:23Z
+- live url: https://github.com/openclaw/openclaw/pull/94107
+
+### #94441 fix(exec): fail invalid explicit workdir before running
+
+- bucket: recent_active
+- author: renaudcerrato
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied
+- live updated: 2026-06-18T07:02:05Z
+- live url: https://github.com/openclaw/openclaw/pull/94441
+
+### #94461 fix(zai): fall back to manifest baseUrl for synthesized GLM-5 models
+
+- bucket: recent_active
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, extensions: zai
+- live updated: 2026-06-18T07:19:41Z
+- live url: https://github.com/openclaw/openclaw/pull/94461
+
+### #94253 feat(doctor): add doctor --explain diagnostics
+
+- bucket: recent_active
+- author: zaidazmi
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, cli, commands, size: M, proof: supplied, P3, merge-risk: compatibility
+- live updated: 2026-06-18T07:21:24Z
+- live url: https://github.com/openclaw/openclaw/pull/94253
+
+### #94477 [AI] fix(session): add session.restartContinuation config to preserve sessionId across Gateway restart
+
+- bucket: recent_active
+- author: xydt-tanshanshan
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, agents, size: XS, proof: supplied
+- live updated: 2026-06-18T07:28:12Z
+- live url: https://github.com/openclaw/openclaw/pull/94477
+
+### #94462 fix: expand leading tilde in exec workdir paths
+
+- bucket: recent_active
+- author: sheyanmin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-18T07:29:04Z
+- live url: https://github.com/openclaw/openclaw/pull/94462
+
+### #94198 test(telegram): add markdown edge case regression coverage
+
+- bucket: needs_proof
+- author: Ayushdevo
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T07:30:39Z
+- live url: https://github.com/openclaw/openclaw/pull/94198
+
+### #94240 fix(memory-core): degrade non-local embedding provider on persistent failure
+
+- bucket: needs_proof
+- author: SunnyShu0925
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-18T07:30:40Z
+- live url: https://github.com/openclaw/openclaw/pull/94240
+
+### #94438 fix(gateway): expose idempotencyKey in chat history metadata
+
+- bucket: needs_proof
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T07:31:15Z
+- live url: https://github.com/openclaw/openclaw/pull/94438
+
+### #94472 fix(tools): emit process warning for empty allOf/anyOf availability groups
+
+- bucket: recent_active
+- author: qingminglong
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-18T07:31:22Z
+- live url: https://github.com/openclaw/openclaw/pull/94472
+
+### #94070 fix(tui): normalize WSL2 backspace (^?/0x7f) to standard backspace (^H/0x08)
+
+- bucket: needs_proof
+- author: Monkey-wusky
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P1, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T07:37:05Z
+- live url: https://github.com/openclaw/openclaw/pull/94070
+
+### #94485 fix(heartbeat): keep private-text final replies from leaking to channel in message_tool_only mode
+
+- bucket: recent_active
+- author: qingminglong
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-18T07:43:53Z
+- live url: https://github.com/openclaw/openclaw/pull/94485
+
+### #94487 fix: #94482 normalize cacheRetention 'standard' to 'short'
+
+- bucket: recent_active
+- author: zhiqiang26
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-18T07:50:14Z
+- live url: https://github.com/openclaw/openclaw/pull/94487
+
+### #94211 fix(session-memory): deduplicate assistant messages when thinking is stripped
+
+- bucket: needs_proof
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-18T07:53:01Z
+- live url: https://github.com/openclaw/openclaw/pull/94211
+
+### #94362 fix: improve Ollama thinking profile resolution for live-discovered reasoning models using name heuristic
+
+- bucket: needs_proof
+- author: lizanle521
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, extensions: ollama, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T07:54:10Z
+- live url: https://github.com/openclaw/openclaw/pull/94362
+
+### #94388 feat(reply): annotate recent history images with thread context
+
+- bucket: needs_proof
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: actively grinding
+- live updated: 2026-06-18T07:54:33Z
+- live url: https://github.com/openclaw/openclaw/pull/94388
+
+### #94394 fix(infra): probe 127.0.0.1 in ensurePortAvailable to detect IPv4-only occupants
+
+- bucket: maintainer_owned
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: steipete
+- labels: size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T07:54:54Z
+- live url: https://github.com/openclaw/openclaw/pull/94394
+
+### #94492 fix(macos): prevent PortGuardian from killing launchd-managed gateway
+
+- bucket: recent_active
+- author: bowenluo718
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: macos, size: XS, proof: supplied
+- live updated: 2026-06-18T08:00:21Z
+- live url: https://github.com/openclaw/openclaw/pull/94492
+
+### #94474 fix: gateway config.get result exceeds middleware validation limits
+
+- bucket: needs_proof
+- author: Jah-xy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: needs-real-behavior-proof, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T08:02:43Z
+- live url: https://github.com/openclaw/openclaw/pull/94474
+
+### #94433 fix(sandbox): create skills dirs before first container launch
+
+- bucket: needs_proof
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: needs-real-behavior-proof, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T08:04:19Z
+- live url: https://github.com/openclaw/openclaw/pull/94433
+
+### #94480 fix(line): prevent silent message loss from reply token expiry and push quota exhaustion
+
+- bucket: needs_proof
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: line, size: M, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T08:04:36Z
+- live url: https://github.com/openclaw/openclaw/pull/94480
+
+### #94488 fix(macos): allowlist Homebrew Node + git checkout gateway in PortGuardian
+
+- bucket: needs_proof
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: macos, size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T08:04:52Z
+- live url: https://github.com/openclaw/openclaw/pull/94488
+
+### #94494 fix(agents): map cacheRetention 'standard' to 'short' for Bedrock Claude models
+
+- bucket: recent_active
+- author: xialonglee
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied
+- live updated: 2026-06-18T08:05:56Z
+- live url: https://github.com/openclaw/openclaw/pull/94494
+
+### #94496 fix: Tailscale serve creates redundant entries on gateway startup
+
+- bucket: recent_active
+- author: sunlit-deng
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-18T08:08:16Z
+- live url: https://github.com/openclaw/openclaw/pull/94496
+
+### #94497 fix(control-ui): render user message immediately on send (#94479)
+
+- bucket: recent_active
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, proof: supplied
+- live updated: 2026-06-18T08:11:53Z
+- live url: https://github.com/openclaw/openclaw/pull/94497

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-006.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T094823-006
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#94325"
+  - "#94368"
+  - "#94133"
+  - "#94039"
+  - "#94114"
+  - "#94093"
+  - "#94457"
+  - "#94413"
+  - "#94375"
+  - "#94501"
+  - "#94502"
+  - "#94503"
+  - "#94447"
+  - "#94469"
+  - "#94408"
+  - "#94478"
+  - "#94419"
+  - "#94506"
+  - "#94399"
+  - "#94508"
+  - "#94444"
+  - "#94489"
+  - "#94490"
+  - "#94493"
+  - "#94495"
+  - "#94512"
+  - "#94453"
+  - "#94513"
+  - "#94515"
+  - "#94452"
+  - "#94082"
+  - "#94355"
+  - "#94378"
+  - "#94464"
+  - "#94401"
+  - "#94443"
+  - "#94481"
+  - "#94473"
+  - "#94454"
+  - "#94520"
+cluster_refs:
+  - "#94325"
+  - "#94368"
+  - "#94133"
+  - "#94039"
+  - "#94114"
+  - "#94093"
+  - "#94457"
+  - "#94413"
+  - "#94375"
+  - "#94501"
+  - "#94502"
+  - "#94503"
+  - "#94447"
+  - "#94469"
+  - "#94408"
+  - "#94478"
+  - "#94419"
+  - "#94506"
+  - "#94399"
+  - "#94508"
+  - "#94444"
+  - "#94489"
+  - "#94490"
+  - "#94493"
+  - "#94495"
+  - "#94512"
+  - "#94453"
+  - "#94513"
+  - "#94515"
+  - "#94452"
+  - "#94082"
+  - "#94355"
+  - "#94378"
+  - "#94464"
+  - "#94401"
+  - "#94443"
+  - "#94481"
+  - "#94473"
+  - "#94454"
+  - "#94520"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T09:48:23.456Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 6
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #94325 fix: UI glitch: config is not visible
+
+- bucket: needs_proof
+- author: sunlit-deng
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, proof: supplied, P2, rating: unranked krab, status: needs proof, proof: screenshot
+- live updated: 2026-06-18T08:12:08Z
+- live url: https://github.com/openclaw/openclaw/pull/94325
+
+### #94368 feat(ui): show cron job ids and running state
+
+- bucket: needs_proof
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: slack, app: web-ui, agents, size: M, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T08:12:25Z
+- live url: https://github.com/openclaw/openclaw/pull/94368
+
+### #94133 fix: refresh subagent idle timeout on successful tool calls
+
+- bucket: needs_proof
+- author: kumaxs
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T08:13:41Z
+- live url: https://github.com/openclaw/openclaw/pull/94133
+
+### #94039 fix(web-fetch): forward NO_PROXY to EnvHttpProxyAgent options so env proxy respects bypass entries
+
+- bucket: needs_proof
+- author: Monkey-wusky
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T08:15:39Z
+- live url: https://github.com/openclaw/openclaw/pull/94039
+
+### #94114 fix(memory-core): include path in FTS indexed text so filename tokens are searchable
+
+- bucket: needs_proof
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: L, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T08:15:53Z
+- live url: https://github.com/openclaw/openclaw/pull/94114
+
+### #94093 Prevent Codex thread rotation from losing next-step context
+
+- bucket: maintainer_owned
+- author: VACInc
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: jalehman
+- labels: size: M, extensions: codex, proof: supplied, P2, rating: silver shellfish, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-18T08:18:44Z
+- live url: https://github.com/openclaw/openclaw/pull/94093
+
+### #94457 fix: convert HTML tables to code blocks for Telegram delivery (#94317)
+
+- bucket: recent_active
+- author: jincheng-xydt
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied
+- live updated: 2026-06-18T08:20:51Z
+- live url: https://github.com/openclaw/openclaw/pull/94457
+
+### #94413 fix(compaction): wire aggregate retry timeout to compaction.timeoutSeconds (#94391)
+
+- bucket: needs_proof
+- author: SymbolStar
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-18T08:22:37Z
+- live url: https://github.com/openclaw/openclaw/pull/94413
+
+### #94375 fix(agents): add direct text delivery fallback for subagent completion
+
+- bucket: needs_proof
+- author: wangmiao0668000666
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, agents, size: M, proof: supplied, P1, rating: silver shellfish, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-18T08:22:43Z
+- live url: https://github.com/openclaw/openclaw/pull/94375
+
+### #94501 feat(devices): add paired device labels
+
+- bucket: recent_active
+- author: zaidazmi
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: web-ui, gateway, cli, size: L, proof: supplied
+- live updated: 2026-06-18T08:23:31Z
+- live url: https://github.com/openclaw/openclaw/pull/94501
+
+### #94502 fix(gateway): serve root-mounted public assets outside configured basePath
+
+- bucket: needs_proof
+- author: qingminglong
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T08:25:18Z
+- live url: https://github.com/openclaw/openclaw/pull/94502
+
+### #94503 fix(compaction): emit after_compaction hook even when compacted:false
+
+- bucket: needs_proof
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T08:25:29Z
+- live url: https://github.com/openclaw/openclaw/pull/94503
+
+### #94447 fix: exec workdir with leading ~ falls back and still executes command
+
+- bucket: needs_proof
+- author: sunlit-deng
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-18T08:30:11Z
+- live url: https://github.com/openclaw/openclaw/pull/94447
+
+### #94469 fix(cli): isPortBusy probes all 4 address families to catch IPv4-only listeners
+
+- bucket: needs_proof
+- author: qingminglong
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T08:30:31Z
+- live url: https://github.com/openclaw/openclaw/pull/94469
+
+### #94408 fix(sessions): accept sessionKey as alias for key in sessions.send RPC
+
+- bucket: needs_proof
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: XS, proof: supplied, P1, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T08:30:49Z
+- live url: https://github.com/openclaw/openclaw/pull/94408
+
+### #94478 fix(codex): restore openai-codex catalog alias
+
+- bucket: needs_proof
+- author: TurboTheTurtle
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, agents, size: S, extensions: codex, proof: supplied, proof: sufficient, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: waiting on author
+- live updated: 2026-06-18T08:30:57Z
+- live url: https://github.com/openclaw/openclaw/pull/94478
+
+### #94419 feat(qwen): add Token Plan (Team Edition) provider
+
+- bucket: ready_for_maintainer
+- author: Omee11
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: M, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: auth-provider, status: actively grinding
+- live updated: 2026-06-18T08:31:05Z
+- live url: https://github.com/openclaw/openclaw/pull/94419
+
+### #94506 fix(telegram): stop clearing registered webhook on channel restart
+
+- bucket: recent_active
+- author: xialonglee
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, proof: supplied
+- live updated: 2026-06-18T08:33:18Z
+- live url: https://github.com/openclaw/openclaw/pull/94506
+
+### #94399 fix(ports): specify IPv4 loopback host in ensurePortAvailable
+
+- bucket: needs_proof
+- author: ajwan8998
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: blank-template, proof: supplied, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T08:34:51Z
+- live url: https://github.com/openclaw/openclaw/pull/94399
+
+### #94508 build(deps): bump the android-deps group across 1 directory with 4 updates
+
+- bucket: recent_active
+- author: dependabot
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: dependencies, app: android, size: XS, java
+- live updated: 2026-06-18T08:35:02Z
+- live url: https://github.com/openclaw/openclaw/pull/94508
+
+### #94444 agents: contain relative path traversal on default host write/edit
+
+- bucket: recent_active
+- author: Jr61-star
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied
+- live updated: 2026-06-18T08:39:26Z
+- live url: https://github.com/openclaw/openclaw/pull/94444
+
+### #94489 fix(cron): default runMode to "due" instead of "force"
+
+- bucket: needs_proof
+- author: LZY3538
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: mock-only-proof
+- live updated: 2026-06-18T08:39:45Z
+- live url: https://github.com/openclaw/openclaw/pull/94489
+
+### #94490 fix(compaction): wire aggregate retry timeout through compaction.timeoutSeconds
+
+- bucket: needs_proof
+- author: LZY3538
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: mock-only-proof
+- live updated: 2026-06-18T08:39:57Z
+- live url: https://github.com/openclaw/openclaw/pull/94490
+
+### #94493 fix(anthropic): strip thinking blocks from completed prior assistant turns
+
+- bucket: needs_proof
+- author: LZY3538
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: mock-only-proof
+- live updated: 2026-06-18T08:40:14Z
+- live url: https://github.com/openclaw/openclaw/pull/94493
+
+### #94495 fix(ollama): add request timeout fallback for remote hosts
+
+- bucket: needs_proof
+- author: LZY3538
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: mock-only-proof, extensions: ollama
+- live updated: 2026-06-18T08:40:28Z
+- live url: https://github.com/openclaw/openclaw/pull/94495
+
+### #94512 fix(tui): map DEL (0x7f) as backspace in addition to BS (0x08)
+
+- bucket: needs_proof
+- author: qingminglong
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T08:42:46Z
+- live url: https://github.com/openclaw/openclaw/pull/94512
+
+### #94453 fix: default cron runMode to "due" instead of "force" (#94270)
+
+- bucket: recent_active
+- author: jincheng-xydt
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-18T08:42:53Z
+- live url: https://github.com/openclaw/openclaw/pull/94453
+
+### #94513 build(deps): bump the actions group across 1 directory with 3 updates
+
+- bucket: recent_active
+- author: dependabot
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: dependencies, size: S, github_actions
+- live updated: 2026-06-18T08:44:03Z
+- live url: https://github.com/openclaw/openclaw/pull/94513
+
+### #94515 fix(codex): omit idle PreToolUse hook relays
+
+- bucket: recent_active
+- author: mazmorra-oc
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, extensions: codex, proof: supplied
+- live updated: 2026-06-18T08:48:42Z
+- live url: https://github.com/openclaw/openclaw/pull/94515
+
+### #94452 fix #94040: [Bug]: nodes approve failed: GatewayClientRequestError: unknown requestId
+
+- bucket: recent_active
+- author: mushuiyu886
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, proof: supplied
+- live updated: 2026-06-18T08:54:16Z
+- live url: https://github.com/openclaw/openclaw/pull/94452
+
+### #94082 fix(cron): prevent lane timeout during long tool execution
+
+- bucket: recent_active
+- author: ajwan8998
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-18T08:57:18Z
+- live url: https://github.com/openclaw/openclaw/pull/94082
+
+### #94355 fix(agents): fall back to generic embedding provider registry in memory-search config resolution
+
+- bucket: recent_active
+- author: SunnyShu0925
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, P2, rating: unranked krab, status: actively grinding
+- live updated: 2026-06-18T08:57:54Z
+- live url: https://github.com/openclaw/openclaw/pull/94355
+
+### #94378 fix(image-gen): skip invalid entries in OpenAI-compatible image response parsing
+
+- bucket: needs_proof
+- author: zhiqiang26
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-18T08:58:06Z
+- live url: https://github.com/openclaw/openclaw/pull/94378
+
+### #94464 Stabilize OpenClaw frontier candidate checks
+
+- bucket: ready_for_maintainer
+- author: THESPRYGUY
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, scripts, agents, size: M, extensions: codex, triage: dirty-candidate, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-18T08:58:06Z
+- live url: https://github.com/openclaw/openclaw/pull/94464
+
+### #94401 fix(session-memory): skip transcript-only assistant messages in getRecentSessionContent
+
+- bucket: ready_for_maintainer
+- author: SunnyShu0925
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, rating: gold shrimp, status: actively grinding
+- live updated: 2026-06-18T08:58:37Z
+- live url: https://github.com/openclaw/openclaw/pull/94401
+
+### #94443 fix(memory-wiki): retry transient source-page rewrite race instead of aborting wiki_status
+
+- bucket: ready_for_maintainer
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, extensions: memory-wiki, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-18T08:58:58Z
+- live url: https://github.com/openclaw/openclaw/pull/94443
+
+### #94481 fix(edit): unwrap XML-RPC {item: {oldText, newText}} edit transport shape
+
+- bucket: needs_proof
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T08:59:10Z
+- live url: https://github.com/openclaw/openclaw/pull/94481
+
+### #94473 fix(provider-catalog): use apiKey fallback for self-hosted discovery when discoveryApiKey is undefined (fixes #83461)
+
+- bucket: needs_proof
+- author: LiuwqGit
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T09:02:27Z
+- live url: https://github.com/openclaw/openclaw/pull/94473
+
+### #94454 fix: separate exec stdout from stderr for user-facing output (#94360)
+
+- bucket: recent_active
+- author: jincheng-xydt
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied
+- live updated: 2026-06-18T09:03:38Z
+- live url: https://github.com/openclaw/openclaw/pull/94454
+
+### #94520 fix(xai): normalize grok web search tools
+
+- bucket: needs_proof
+- author: pedrosbraga
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, triage: mock-only-proof, extensions: xai
+- live updated: 2026-06-18T09:04:42Z
+- live url: https://github.com/openclaw/openclaw/pull/94520

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-007.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-007.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T094823-007
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#94510"
+  - "#94521"
+  - "#94465"
+  - "#94498"
+  - "#94519"
+  - "#94522"
+  - "#94442"
+  - "#94369"
+  - "#94491"
+  - "#94345"
+  - "#94523"
+  - "#94471"
+  - "#94440"
+  - "#94245"
+  - "#94351"
+  - "#94337"
+  - "#94187"
+  - "#94514"
+  - "#94525"
+  - "#94526"
+  - "#94062"
+  - "#94449"
+  - "#94527"
+  - "#94509"
+  - "#94528"
+  - "#94486"
+  - "#94517"
+  - "#94448"
+  - "#94326"
+  - "#94148"
+  - "#94470"
+  - "#94483"
+  - "#94531"
+  - "#94416"
+  - "#94532"
+  - "#94411"
+  - "#94535"
+  - "#94085"
+  - "#94056"
+  - "#94537"
+cluster_refs:
+  - "#94510"
+  - "#94521"
+  - "#94465"
+  - "#94498"
+  - "#94519"
+  - "#94522"
+  - "#94442"
+  - "#94369"
+  - "#94491"
+  - "#94345"
+  - "#94523"
+  - "#94471"
+  - "#94440"
+  - "#94245"
+  - "#94351"
+  - "#94337"
+  - "#94187"
+  - "#94514"
+  - "#94525"
+  - "#94526"
+  - "#94062"
+  - "#94449"
+  - "#94527"
+  - "#94509"
+  - "#94528"
+  - "#94486"
+  - "#94517"
+  - "#94448"
+  - "#94326"
+  - "#94148"
+  - "#94470"
+  - "#94483"
+  - "#94531"
+  - "#94416"
+  - "#94532"
+  - "#94411"
+  - "#94535"
+  - "#94085"
+  - "#94056"
+  - "#94537"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T09:48:23.457Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 7
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #94510 docs(onboarding): normalize inline Info callout to block form
+
+- bucket: recent_active
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied
+- live updated: 2026-06-18T09:05:49Z
+- live url: https://github.com/openclaw/openclaw/pull/94510
+
+### #94521 fix(docs-i18n): detect and retry Chinese mojibake output from AI translation
+
+- bucket: needs_proof
+- author: bowenluo718
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T09:07:49Z
+- live url: https://github.com/openclaw/openclaw/pull/94521
+
+### #94465 fix(agents): keep lane-task timeout alive during long-running tools (fixes #94033)
+
+- bucket: recent_active
+- author: wangmiao0668000666
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, agents, size: M, proof: supplied
+- live updated: 2026-06-18T09:10:26Z
+- live url: https://github.com/openclaw/openclaw/pull/94465
+
+### #94498 fix(secrets): commit auth-stores before config to prevent half-migrated credentials
+
+- bucket: recent_active
+- author: Feelw00
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied
+- live updated: 2026-06-18T09:10:29Z
+- live url: https://github.com/openclaw/openclaw/pull/94498
+
+### #94519 Fix/redact app password overmasking 94254
+
+- bucket: recent_active
+- author: zw-xysk
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied
+- live updated: 2026-06-18T09:10:31Z
+- live url: https://github.com/openclaw/openclaw/pull/94519
+
+### #94522 fix(msteams): route attachment proactive sends through channel threads (fixes #88836)
+
+- bucket: recent_active
+- author: zenglingbiao
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: none
+- live updated: 2026-06-18T09:12:19Z
+- live url: https://github.com/openclaw/openclaw/pull/94522
+
+### #94442 fix(imessage): strip leading echo corruption markers in the persisted echo cache
+
+- bucket: recent_active
+- author: ly-wang19
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: imessage, size: S, proof: supplied
+- live updated: 2026-06-18T09:12:36Z
+- live url: https://github.com/openclaw/openclaw/pull/94442
+
+### #94369 fix(memory-wiki): exclude durable reference pages from stale report
+
+- bucket: needs_proof
+- author: SunnyShu0925
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: memory-wiki, proof: supplied, P2, rating: silver shellfish, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T09:13:28Z
+- live url: https://github.com/openclaw/openclaw/pull/94369
+
+### #94491 fix(cron): allow empty assistant replies in cron lane
+
+- bucket: needs_proof
+- author: LZY3538
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: mock-only-proof, P1, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T09:15:37Z
+- live url: https://github.com/openclaw/openclaw/pull/94491
+
+### #94345 feat(slack): update assistant thread status text per tool during execution (fixes #33413)
+
+- bucket: recent_active
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: slack, size: XS, proof: supplied, P2, rating: unranked krab, status: actively grinding, merge-risk: other
+- live updated: 2026-06-18T09:15:44Z
+- live url: https://github.com/openclaw/openclaw/pull/94345
+
+### #94523 fix(macos): open native file picker for Control UI file inputs
+
+- bucket: needs_proof
+- author: Bartok9
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: macos, size: S, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T09:17:35Z
+- live url: https://github.com/openclaw/openclaw/pull/94523
+
+### #94471 fix: #94426 isPortBusy probes all address families via checkPortInUse
+
+- bucket: recent_active
+- author: lzyyzznl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied
+- live updated: 2026-06-18T09:18:18Z
+- live url: https://github.com/openclaw/openclaw/pull/94471
+
+### #94440 fix: #94432 classify Cloudflare challenge 403 as upstream_html instead of auth_html
+
+- bucket: needs_proof
+- author: lzyyzznl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T09:19:12Z
+- live url: https://github.com/openclaw/openclaw/pull/94440
+
+### #94245 fix: update health check hints to reference openclaw onboard instead of bare flags
+
+- bucket: needs_proof
+- author: lzyyzznl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: supplied, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T09:22:05Z
+- live url: https://github.com/openclaw/openclaw/pull/94245
+
+### #94351 fix: rewrite public asset hrefs to namespace path on index.html serve
+
+- bucket: needs_proof
+- author: Jah-xy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: S, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T09:22:51Z
+- live url: https://github.com/openclaw/openclaw/pull/94351
+
+### #94337 fix(tui): show 0 not ? for fresh-session context tokens in footer
+
+- bucket: needs_proof
+- author: mushuiyu886
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-18T09:22:53Z
+- live url: https://github.com/openclaw/openclaw/pull/94337
+
+### #94187 fix(agent): surface non_deliverable_terminal_turn with specific message instead of generic /new fallback
+
+- bucket: needs_proof
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P1
+- live updated: 2026-06-18T09:24:16Z
+- live url: https://github.com/openclaw/openclaw/pull/94187
+
+### #94514 docs: add Windows pnpm fallback for Corepack EPERM
+
+- bucket: needs_proof
+- author: africoding
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T09:24:41Z
+- live url: https://github.com/openclaw/openclaw/pull/94514
+
+### #94525 [codex] fix(copilot): tolerate missing runtime state API
+
+- bucket: draft
+- author: Pluviobyte
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: size: XS, triage: mock-only-proof, extensions: copilot
+- live updated: 2026-06-18T09:25:03Z
+- live url: https://github.com/openclaw/openclaw/pull/94525
+
+### #94526 test(telegram): add regression test for forum topic message_thread_id with streamed reasoning
+
+- bucket: needs_proof
+- author: xialonglee
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T09:25:58Z
+- live url: https://github.com/openclaw/openclaw/pull/94526
+
+### #94062 fix(agents): classify generic "LLM request failed." as transient time
+
+- bucket: ready_for_maintainer
+- author: hugenshen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-18T09:26:16Z
+- live url: https://github.com/openclaw/openclaw/pull/94062
+
+### #94449 fix(exec): expand leading ~ in workdir to home directory
+
+- bucket: maintainer_owned
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: agents, size: XS, proof: supplied
+- live updated: 2026-06-18T09:27:45Z
+- live url: https://github.com/openclaw/openclaw/pull/94449
+
+### #94527 fix(agents): warn when bootstrap files exist in agentDir but not work
+
+- bucket: recent_active
+- author: wenyi-xydigit
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: M, proof: supplied
+- live updated: 2026-06-18T09:28:17Z
+- live url: https://github.com/openclaw/openclaw/pull/94527
+
+### #94509 fix(memory-wiki): honor durable: true frontmatter in stale pages report
+
+- bucket: needs_proof
+- author: chenweicong736
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: S, extensions: memory-wiki, proof: supplied, P2, rating: silver shellfish, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T09:28:29Z
+- live url: https://github.com/openclaw/openclaw/pull/94509
+
+### #94528 fix: macOS embedded Control UI avatar image picker opens native file
+
+- bucket: needs_proof
+- author: xiaoping1988
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: macos, size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T09:29:05Z
+- live url: https://github.com/openclaw/openclaw/pull/94528
+
+### #94486 fix(heartbeat): prevent private text leak in message_tool_only mode
+
+- bucket: needs_proof
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T09:30:25Z
+- live url: https://github.com/openclaw/openclaw/pull/94486
+
+### #94517 feat(devices): add rename command for human-friendly device names
+
+- bucket: recent_active
+- author: bladin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, cli, size: S, proof: supplied
+- live updated: 2026-06-18T09:31:15Z
+- live url: https://github.com/openclaw/openclaw/pull/94517
+
+### #94448 fix(cli): add IPv4 loopback host to isPortBusy
+
+- bucket: needs_proof
+- author: ajwan8998
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: availability, status: needs proof
+- live updated: 2026-06-18T09:32:57Z
+- live url: https://github.com/openclaw/openclaw/pull/94448
+
+### #94326 fix(memory-wiki): reserve compiler-owned page stems (index, log) in slug layer
+
+- bucket: needs_proof
+- author: yetval
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: memory-wiki, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-18T09:35:29Z
+- live url: https://github.com/openclaw/openclaw/pull/94326
+
+### #94148 fix(doctor): prevent non-interactive --fix from auto-restarting gateway
+
+- bucket: recent_active
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: supplied
+- live updated: 2026-06-18T09:35:55Z
+- live url: https://github.com/openclaw/openclaw/pull/94148
+
+### #94470 chore: sync yuanbao plugin catalog to 2.15.0
+
+- bucket: needs_proof
+- author: jase-283
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: XS, proof: supplied, P3, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T09:36:10Z
+- live url: https://github.com/openclaw/openclaw/pull/94470
+
+### #94483 feat(gateway-cli): scope usage-cost by agent
+
+- bucket: recent_active
+- author: ly-wang19
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, proof: supplied
+- live updated: 2026-06-18T09:36:19Z
+- live url: https://github.com/openclaw/openclaw/pull/94483
+
+### #94531 fix: always show raw config in settings (fixes #94202)
+
+- bucket: needs_proof
+- author: xiaoping1988
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T09:36:57Z
+- live url: https://github.com/openclaw/openclaw/pull/94531
+
+### #94416 fix #93501: [Bug]: Matrix error decrypting event
+
+- bucket: recent_active
+- author: mushuiyu886
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: matrix, size: XS, proof: supplied
+- live updated: 2026-06-18T09:38:27Z
+- live url: https://github.com/openclaw/openclaw/pull/94416
+
+### #94532 feat: make node.pair.approve idempotent for already-paired nodes (fix
+
+- bucket: needs_proof
+- author: xiaoping1988
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T09:38:59Z
+- live url: https://github.com/openclaw/openclaw/pull/94532
+
+### #94411 fix(sandbox): use config-resolved workspace for skill sync fallback
+
+- bucket: recent_active
+- author: wangmiao0668000666
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docker, agents, size: S, proof: supplied, rating: silver shellfish, status: re-review loop
+- live updated: 2026-06-18T09:40:22Z
+- live url: https://github.com/openclaw/openclaw/pull/94411
+
+### #94535 fix: bypass authentication for manifest.webmanifest behind oauth2-pro
+
+- bucket: needs_proof
+- author: xiaoping1988
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T09:41:13Z
+- live url: https://github.com/openclaw/openclaw/pull/94535
+
+### #94085 fix: inbound metadata leakage missing sentinels and display gaps
+
+- bucket: needs_proof
+- author: ajwan8998
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, triage: blank-template, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T09:42:31Z
+- live url: https://github.com/openclaw/openclaw/pull/94085
+
+### #94056 fix(telegram): replace heading tags with <b> to fix text overlap on macOS desktop
+
+- bucket: needs_proof
+- author: ajwan8998
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T09:42:35Z
+- live url: https://github.com/openclaw/openclaw/pull/94056
+
+### #94537 fix(memory-core): harden dreaming daily-file writes and drain dangling recall refs
+
+- bucket: recent_active
+- author: SunnyShu0925
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: supplied
+- live updated: 2026-06-18T09:43:09Z
+- live url: https://github.com/openclaw/openclaw/pull/94537

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-008.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T094823-008.md
@@ -1,0 +1,200 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T094823-008
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#94105"
+  - "#94538"
+  - "#94421"
+  - "#94354"
+  - "#94312"
+  - "#94303"
+  - "#94286"
+  - "#94259"
+  - "#94239"
+  - "#94262"
+  - "#94524"
+  - "#94539"
+cluster_refs:
+  - "#94105"
+  - "#94538"
+  - "#94421"
+  - "#94354"
+  - "#94312"
+  - "#94303"
+  - "#94286"
+  - "#94259"
+  - "#94239"
+  - "#94262"
+  - "#94524"
+  - "#94539"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T09:48:23.457Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 8
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #94105 feat(channels): add system_event InboundEventKind for ambient direct-chat silence
+
+- bucket: needs_proof
+- author: mirasrael
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: web-ui, gateway, agents, size: M, proof: supplied, proof: sufficient, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-18T09:43:48Z
+- live url: https://github.com/openclaw/openclaw/pull/94105
+
+### #94538 fix: prevent heartbeat runner from leaking private replies when respo
+
+- bucket: needs_proof
+- author: xiaoping1988
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof
+- live updated: 2026-06-18T09:44:32Z
+- live url: https://github.com/openclaw/openclaw/pull/94538
+
+### #94421 fix(agents): preserve active compaction retries
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: steipete
+- labels: docs, channel: discord, channel: imessage, channel: msteams, channel: slack, channel: telegram, channel: whatsapp-web, channel: zalo, app: web-ui, gateway, extensions: memory-core, cli, scripts, commands, docker, agents, maintainer, size: XL, extensions: openai, channel: qqbot, extensions: qa-lab, extensions: codex, plugin: google-meet, proof: sufficient, dependencies-changed, P1, rating: platinum hermit, status: ready for maintainer look, extensions: gmi
+- live updated: 2026-06-18T09:46:48Z
+- live url: https://github.com/openclaw/openclaw/pull/94421
+
+### #94354 fix(tui): handle /status and /compact in local mode instead of falling through to model (fixes #71592)
+
+- bucket: needs_proof
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-18T09:47:16Z
+- live url: https://github.com/openclaw/openclaw/pull/94354
+
+### #94312 fix(channels): strip relevant-memories tags from outbound assistant text (#74364)
+
+- bucket: needs_proof
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T09:47:18Z
+- live url: https://github.com/openclaw/openclaw/pull/94312
+
+### #94303 feat(telegram): set ThreadLabel from topicName for forum session display (fixes #7406)
+
+- bucket: needs_proof
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, proof: supplied, mantis: telegram-visible-proof, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-18T09:47:20Z
+- live url: https://github.com/openclaw/openclaw/pull/94303
+
+### #94286 fix(macos): cache CLLocationManager to avoid repeated TCC permission requests (fixes #94147)
+
+- bucket: needs_proof
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: macos, size: XS, proof: supplied, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-18T09:47:22Z
+- live url: https://github.com/openclaw/openclaw/pull/94286
+
+### #94259 fix(telegram): export sender isBot field to agent context (fixes #40838)
+
+- bucket: needs_proof
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, proof: supplied, mantis: telegram-visible-proof, P2, rating: unranked krab, status: needs proof, merge-risk: other
+- live updated: 2026-06-18T09:47:24Z
+- live url: https://github.com/openclaw/openclaw/pull/94259
+
+### #94239 fix(memory): align session file counter denominator with indexer filter
+
+- bucket: needs_proof
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: XS, proof: supplied, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-18T09:47:26Z
+- live url: https://github.com/openclaw/openclaw/pull/94239
+
+### #94262 fix(feishu): detect card JSON in plain message param for proactive sends (fixes #53486)
+
+- bucket: recent_active
+- author: liuhao1024
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: S, proof: supplied
+- live updated: 2026-06-18T09:47:34Z
+- live url: https://github.com/openclaw/openclaw/pull/94262
+
+### #94524 fix: quarantine drained system events as untrusted context
+
+- bucket: recent_active
+- author: tianlangqin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied
+- live updated: 2026-06-18T09:47:53Z
+- live url: https://github.com/openclaw/openclaw/pull/94524
+
+### #94539 fix(android): group settings by intent
+
+- bucket: draft
+- author: Tosko4
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: app: android, size: S, proof: supplied
+- live updated: 2026-06-18T09:48:05Z
+- live url: https://github.com/openclaw/openclaw/pull/94539


### PR DESCRIPTION
## Summary
- add eight plan-only live PR inventory shards covering 292 currently unrepresented open PRs
- exclude refs already represented in the active inbox or published results
- keep execute, fix, and merge gates closed

## Verification
- `npm run validate`