### PR TITLE
fix(review): trust explicit non-security preflight evidence

### DIFF
--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -350,6 +350,7 @@ function isUnavailableSecurityRouteAction(action, item) {
 
 function isSecuritySensitiveActionContext(action, item) {
   if (item?.security_sensitive === true) return true;
+  if (item?.security_sensitive === false && hasExplicitNonSecurityPreflightAssertion(action)) return false;
   if (NON_MUTATING_KEEP_ACTIONS.has(String(action.action ?? ""))) {
     return hasSecuritySensitiveText(securityTextFromItem(item), action.classification);
   }
@@ -359,6 +360,13 @@ function isSecuritySensitiveActionContext(action, item) {
     nonSecurityAssertionStrippedText(action.reason),
     nonSecurityAssertionStrippedText(action.comment),
     (action.evidence ?? []).map(nonSecurityAssertionStrippedText),
+  );
+}
+
+function hasExplicitNonSecurityPreflightAssertion(action) {
+  const text = [action.reason, action.comment, ...(action.evidence ?? [])].join("\n");
+  return /\b(?:preflight|item[-_\s]?matrix|hydrated\s+preflight)[^.\n]{0,160}\bsecurity[-_\s]?sensitive\s*(?:[=:]\s*|\s+)(?:false|0|no)\b/i.test(
+    text,
   );
 }
 

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -127,6 +127,51 @@ test("review-results ignores false security_sensitive field echoes", () => {
   assert.match(result.stdout, /"status": "passed"/);
 });
 
+test("review-results trusts explicit false preflight classifications", () => {
+  const dir = makeResultDir(
+    {
+      actions: [
+        {
+          target: "#90672",
+          action: "needs_human",
+          status: "planned",
+          idempotency_key: "cluster-test:needs-human:90672",
+          classification: "needs_human",
+          target_kind: "pull_request",
+          target_updated_at: "2026-06-15T14:15:01Z",
+          evidence: [
+            "Preflight marks security_sensitive=false for this item.",
+            "Deterministic validation separately reported: #90672 security-sensitive target must use route_security.",
+          ],
+          reason:
+            "Validator and hydrated preflight disagree on the security routing boundary; route_security is not safe to emit.",
+        },
+      ],
+    },
+    {
+      plan: {
+        items: [
+          {
+            ref: "#90672",
+            kind: "pull_request",
+            state: "open",
+            title: "fix: prevent private replies leaking to public channels",
+            labels: ["channel: telegram", "proof: sufficient"],
+            updated_at: "2026-06-15T14:15:01Z",
+            security_sensitive: false,
+            body_excerpt: "The preflight reviewed a privacy leak but classified this target as non-security.",
+          },
+        ],
+      },
+    },
+  );
+
+  const result = review(dir);
+
+  assert.equal(result.status, 0, result.stdout || result.stderr);
+  assert.match(result.stdout, /"status": "passed"/);
+});
+
 test("review-results ignores empty security boundary item collections in mutating evidence", () => {
   const dir = makeResultDir(
     {


### PR DESCRIPTION
Fixes plan-result validation when a security-shaped PR body is explicitly classified non-security by hydrated preflight evidence.

The reviewer now requires both `security_sensitive=false` and an explicit preflight assertion before suppressing heuristic text signals. Explicit security-shaped targets without that evidence remain rejected.

Validation:
- `node --test test/review-results.test.mjs`
- `npm run validate`
- `npm run review-results -- /tmp/clownfish-batch-27751598998-artifacts/projectclownfish-27751598998-1-7`