### PR TITLE
fix(review): honor result-level preflight security evidence

### DIFF
--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -165,7 +165,7 @@ function reviewResult(resultPath) {
     if (
       !clusterScopedAction &&
       !isSkippedClosedContextAction(action, item) &&
-      isSecuritySensitiveActionContext(action, item) &&
+      isSecuritySensitiveActionContext(action, item, result) &&
       name !== "route_security"
     ) {
       failures.push(`${target} security-sensitive target must use route_security`);
@@ -348,9 +348,9 @@ function isUnavailableSecurityRouteAction(action, item) {
   return /\b(rate limit|HTTP 403|unavailable|could not hydrate|missing live|hydration failed)\b/i.test(text);
 }
 
-function isSecuritySensitiveActionContext(action, item) {
+function isSecuritySensitiveActionContext(action, item, result) {
   if (item?.security_sensitive === true) return true;
-  if (item?.security_sensitive === false && hasExplicitNonSecurityPreflightAssertion(action)) return false;
+  if (item?.security_sensitive === false && hasExplicitNonSecurityPreflightAssertion(action, result)) return false;
   if (NON_MUTATING_KEEP_ACTIONS.has(String(action.action ?? ""))) {
     return hasSecuritySensitiveText(securityTextFromItem(item), action.classification);
   }
@@ -363,10 +363,18 @@ function isSecuritySensitiveActionContext(action, item) {
   );
 }
 
-function hasExplicitNonSecurityPreflightAssertion(action) {
-  const text = [action.reason, action.comment, ...(action.evidence ?? [])].join("\n");
-  return /\b(?:preflight|item[-_\s]?matrix|hydrated\s+preflight)[^.\n]{0,160}\bsecurity[-_\s]?sensitive\s*(?:[=:]\s*|\s+)(?:false|0|no)\b/i.test(
-    text,
+function hasExplicitNonSecurityPreflightAssertion(action, result) {
+  const text = [result?.summary, action.reason, action.comment, ...(action.evidence ?? [])].join("\n");
+  return (
+    /\b(?:preflight|item[-_\s]?matrix|hydrated\s+preflight)[^.\n]{0,160}\bsecurity[-_\s]?sensitive\s*(?:[=:]\s*|\s+)(?:false|0|no)\b/i.test(
+      text,
+    ) ||
+    /\bno\s+security[-_\s]?sensitive\s+(?:refs?|items?|targets?|signals?|status)\s+(?:were|was|are|is)?\s*(?:detected|present|found)\b/i.test(
+      text,
+    ) ||
+    /\bno\b[^.\n]{0,160}\b(?:security[-_\s]?route|route_security)\s+action\s+(?:is|was)\s+(?:justified|required|needed|allowed)\b/i.test(
+      text,
+    )
   );
 }
 

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -130,6 +130,7 @@ test("review-results ignores false security_sensitive field echoes", () => {
 test("review-results trusts explicit false preflight classifications", () => {
   const dir = makeResultDir(
     {
+      summary: "Hydrated preflight marks every target in this inventory shard security_sensitive=false.",
       actions: [
         {
           target: "#90672",
@@ -140,7 +141,6 @@ test("review-results trusts explicit false preflight classifications", () => {
           target_kind: "pull_request",
           target_updated_at: "2026-06-15T14:15:01Z",
           evidence: [
-            "Preflight marks security_sensitive=false for this item.",
             "Deterministic validation separately reported: #90672 security-sensitive target must use route_security.",
           ],
           reason:
@@ -160,6 +160,49 @@ test("review-results trusts explicit false preflight classifications", () => {
             updated_at: "2026-06-15T14:15:01Z",
             security_sensitive: false,
             body_excerpt: "The preflight reviewed a privacy leak but classified this target as non-security.",
+          },
+        ],
+      },
+    },
+  );
+
+  const result = review(dir);
+
+  assert.equal(result.status, 0, result.stdout || result.stderr);
+  assert.match(result.stdout, /"status": "passed"/);
+});
+
+test("review-results honors plan-level no-security routing assertions", () => {
+  const dir = makeResultDir(
+    {
+      summary:
+        "This inventory shard has no shared canonical; no close, merge, fix, or security-route action is justified from preflight evidence.",
+      actions: [
+        {
+          target: "#90672",
+          action: "keep_independent",
+          status: "planned",
+          idempotency_key: "cluster-test:keep-independent:90672:no-security-route",
+          classification: "independent",
+          target_kind: "pull_request",
+          target_updated_at: "2026-06-15T14:15:01Z",
+          evidence: ["No duplicate or superseded target is hydrated for this inventory shard."],
+          reason: "Independent PR; keep open.",
+        },
+      ],
+    },
+    {
+      plan: {
+        items: [
+          {
+            ref: "#90672",
+            kind: "pull_request",
+            state: "open",
+            title: "fix(secrets): prevent half-migrated credentials",
+            labels: ["proof: sufficient"],
+            updated_at: "2026-06-15T14:15:01Z",
+            security_sensitive: false,
+            body_excerpt: "Credential migration now commits stores before the config file.",
           },
         ],
       },


### PR DESCRIPTION
Fixes validation of live inventory plans that record an explicit non-security preflight classification in the result summary rather than in each action.

The bypass still requires `item.security_sensitive=false`; true or unclassified security-shaped items retain the existing route guard.

Validation:
- `node --test test/review-results.test.mjs`
- `npm run validate`
- exact pre-repair artifact from batch `27752013168` shard `006`