### PR TITLE
fix(review): trust hydrated non-security plan summaries

### DIFF
--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -186,6 +186,7 @@ function reviewResult(resultPath) {
     if (
       !clusterScopedAction &&
       name === "needs_human" &&
+      !hasExplicitNonSecurityPreflightForItem(action, item, result) &&
       /security-sensitive|security boundary|central .*security|security triage/i.test(String(action.reason ?? ""))
     ) {
       failures.push(`${target} security routing must use route_security instead of needs_human`);
@@ -350,7 +351,7 @@ function isUnavailableSecurityRouteAction(action, item) {
 
 function isSecuritySensitiveActionContext(action, item, result) {
   if (item?.security_sensitive === true) return true;
-  if (item?.security_sensitive === false && hasExplicitNonSecurityPreflightAssertion(action, result)) return false;
+  if (hasExplicitNonSecurityPreflightForItem(action, item, result)) return false;
   if (NON_MUTATING_KEEP_ACTIONS.has(String(action.action ?? ""))) {
     return hasSecuritySensitiveText(securityTextFromItem(item), action.classification);
   }
@@ -363,6 +364,10 @@ function isSecuritySensitiveActionContext(action, item, result) {
   );
 }
 
+function hasExplicitNonSecurityPreflightForItem(action, item, result) {
+  return item?.security_sensitive === false && hasExplicitNonSecurityPreflightAssertion(action, result);
+}
+
 function hasExplicitNonSecurityPreflightAssertion(action, result) {
   const text = [result?.summary, action.reason, action.comment, ...(action.evidence ?? [])].join("\n");
   return (
@@ -370,6 +375,9 @@ function hasExplicitNonSecurityPreflightAssertion(action, result) {
       text,
     ) ||
     /\bno\s+security[-_\s]?sensitive\s+(?:refs?|items?|targets?|signals?|status)\s+(?:were|was|are|is)?\s*(?:detected|present|found)\b/i.test(
+      text,
+    ) ||
+    /\bno\s+hydrated\s+(?:preflight\s+)?(?:items?|refs?|targets?)\s+(?:(?:has|have|had|were|was|are|is)\s+)?(?:explicitly\s+)?(?:marked\s+)?security[-_\s]?sensitive(?:\s*(?:[=:]\s*|\s+)(?:true|1|yes))?\b/i.test(
       text,
     ) ||
     /\bno\b[^.\n]{0,160}\b(?:security[-_\s]?route|route_security)\s+action\s+(?:is|was)\s+(?:justified|required|needed|allowed)\b/i.test(

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -144,7 +144,7 @@ test("review-results trusts explicit false preflight classifications", () => {
             "Deterministic validation separately reported: #90672 security-sensitive target must use route_security.",
           ],
           reason:
-            "Validator and hydrated preflight disagree on the security routing boundary; route_security is not safe to emit.",
+            "Human review is required to reconcile the validator's security-sensitive classification with the authoritative hydrated preflight item before any routing or mutating action.",
         },
       ],
     },
@@ -160,6 +160,48 @@ test("review-results trusts explicit false preflight classifications", () => {
             updated_at: "2026-06-15T14:15:01Z",
             security_sensitive: false,
             body_excerpt: "The preflight reviewed a privacy leak but classified this target as non-security.",
+          },
+        ],
+      },
+    },
+  );
+
+  const result = review(dir);
+
+  assert.equal(result.status, 0, result.stdout || result.stderr);
+  assert.match(result.stdout, /"status": "passed"/);
+});
+
+test("review-results trusts plan summaries with no hydrated security-sensitive items", () => {
+  const dir = makeResultDir(
+    {
+      summary:
+        "Plan-only inventory shard. No hydrated item has security_sensitive=true; merge, fix, and raise_pr are blocked.",
+      actions: [
+        {
+          target: "#90672",
+          action: "keep_independent",
+          status: "planned",
+          idempotency_key: "cluster-test:keep-independent:90672:no-hydrated-security-items",
+          classification: "independent",
+          target_kind: "pull_request",
+          target_updated_at: "2026-06-15T14:15:01Z",
+          evidence: ["No hydrated duplicate or supersession evidence is available."],
+          reason: "Independent PR.",
+        },
+      ],
+    },
+    {
+      plan: {
+        items: [
+          {
+            ref: "#90672",
+            kind: "pull_request",
+            state: "open",
+            title: "fix(secrets): avoid false positives in credential redaction",
+            labels: ["proof: sufficient"],
+            updated_at: "2026-06-15T14:15:01Z",
+            security_sensitive: false,
           },
         ],
       },


### PR DESCRIPTION
## Summary
- accept explicit plan summaries that report no hydrated security-sensitive items when the matching preflight item is non-security
- keep non-mutating human escalation valid for the same confirmed non-security case
- retain the rejection of route_security for preflight false targets

## Verification
- node --test test/review-results.test.mjs
- npm run validate
- replayed failed plan artifacts 27752484229 shards 002 and 006 through review-results