### PR TITLE
fix(review): accept hydrated no-security summaries

### DIFF
--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -374,7 +374,7 @@ function hasExplicitNonSecurityPreflightAssertion(action, result) {
     /\b(?:preflight|item[-_\s]?matrix|hydrated\s+preflight)[^.\n]{0,160}\bsecurity[-_\s]?sensitive\s*(?:[=:]\s*|\s+)(?:false|0|no)\b/i.test(
       text,
     ) ||
-    /\bno\s+security[-_\s]?sensitive\s+(?:refs?|items?|targets?|signals?|status)\s+(?:were|was|are|is)?\s*(?:detected|present|found)\b/i.test(
+    /\bno\s+security[-_\s]?sensitive\s+(?:hydrated\s+)?(?:refs?|items?|targets?|signals?|status)\b(?:\s+(?:were|was|are|is)?\s*(?:detected|present|found))?/i.test(
       text,
     ) ||
     /\bno\s+hydrated\s+(?:preflight\s+)?(?:items?|refs?|targets?)\s+(?:(?:has|have|had|were|was|are|is)\s+)?(?:explicitly\s+)?(?:marked\s+)?security[-_\s]?sensitive(?:\s*(?:[=:]\s*|\s+)(?:true|1|yes))?\b/i.test(

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -172,11 +172,11 @@ test("review-results trusts explicit false preflight classifications", () => {
   assert.match(result.stdout, /"status": "passed"/);
 });
 
-test("review-results trusts plan summaries with no hydrated security-sensitive items", () => {
+test("review-results trusts plan summaries with no security-sensitive hydrated refs", () => {
   const dir = makeResultDir(
     {
       summary:
-        "Plan-only inventory shard. No hydrated item has security_sensitive=true; merge, fix, and raise_pr are blocked.",
+        "Plan-only inventory shard. The preflight artifact reports no security-sensitive hydrated refs; merge, fix, and raise_pr are blocked.",
       actions: [
         {
           target: "#90672",
@@ -198,7 +198,7 @@ test("review-results trusts plan summaries with no hydrated security-sensitive i
             ref: "#90672",
             kind: "pull_request",
             state: "open",
-            title: "fix(secrets): avoid false positives in credential redaction",
+            title: "fix(security): avoid false positives in credential redaction",
             labels: ["proof: sufficient"],
             updated_at: "2026-06-15T14:15:01Z",
             security_sensitive: false,


### PR DESCRIPTION
## Summary
- recognize plan summaries stating that no security-sensitive hydrated refs were found
- keep the exception scoped to hydrated items explicitly marked `security_sensitive: false`
- cover the exact failing plan summary wording with a security-shaped PR fixture

## Verification
- `node --test test/review-results.test.mjs`
- replayed the original shard 006 pre-repair result: 40 `keep_independent` actions pass
- `npm run validate`