### PR TITLE
fix(closeout): generate non-security close canaries

### DIFF
--- a/jobs/openclaw/inbox/pr-close-canary-94489-20260618a.md
+++ b/jobs/openclaw/inbox/pr-close-canary-94489-20260618a.md
@@ -1,0 +1,59 @@
+---
+repo: openclaw/openclaw
+cluster_id: pr-close-canary-94489-20260618a
+mode: execute
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#94453"
+candidates:
+  - "#94489"
+  - "#94453"
+cluster_refs:
+  - "#94489"
+  - "#94453"
+overlap_policy: "skip-any"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Close-only canary: #94489 was planned as superseded of open canonical #94453 in run 27753529347. Re-fetch live state and only close if #94489 remains open and #94453 remains open as the best canonical ref."
+notes: "Generated from ProjectClownfish result live-pr-inventory-20260618T094823-006 after live refetch on 2026-06-18."
+---
+
+# PR Close Canary #94489
+
+## Goal
+
+Run one live close-only cleanup pass. Hydrate #94489 and #94453, then emit at most one planned close action for #94489. Do not merge, fix, raise a PR, or close the merged candidate.
+
+## Live Refetch Baseline
+
+- target: #94489 fix(cron): default runMode to "due" instead of "force"
+- target live state at generation: OPEN
+- target updatedAt at generation: 2026-06-18T08:39:45Z
+- canonical/candidate: #94453 fix: default cron runMode to "due" instead of "force" (#94270)
+- canonical/candidate live state at generation: OPEN
+- canonical/candidate mergedAt at generation: unknown
+- source result: ProjectClownfish workflow run 27753529347
+
+## Instructions
+
+If #94489 is still open and #94453 is still open, prefer `close_superseded` with `canonical: "#94453"` for #94489. Do not use `candidate_fix` for open canonical refs. Mention both PR/issue URLs in the close comment and preserve contributor/user context. If either live state changed, keep the target open or mark the exact blocker with `needs_human`.

--- a/jobs/openclaw/inbox/pr-close-canary-94490-20260618a.md
+++ b/jobs/openclaw/inbox/pr-close-canary-94490-20260618a.md
@@ -1,0 +1,59 @@
+---
+repo: openclaw/openclaw
+cluster_id: pr-close-canary-94490-20260618a
+mode: execute
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#94413"
+candidates:
+  - "#94490"
+  - "#94413"
+cluster_refs:
+  - "#94490"
+  - "#94413"
+overlap_policy: "skip-any"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Close-only canary: #94490 was planned as superseded of open canonical #94413 in run 27753529347. Re-fetch live state and only close if #94490 remains open and #94413 remains open as the best canonical ref."
+notes: "Generated from ProjectClownfish result live-pr-inventory-20260618T094823-006 after live refetch on 2026-06-18."
+---
+
+# PR Close Canary #94490
+
+## Goal
+
+Run one live close-only cleanup pass. Hydrate #94490 and #94413, then emit at most one planned close action for #94490. Do not merge, fix, raise a PR, or close the merged candidate.
+
+## Live Refetch Baseline
+
+- target: #94490 fix(compaction): wire aggregate retry timeout through compaction.timeoutSeconds
+- target live state at generation: OPEN
+- target updatedAt at generation: 2026-06-18T08:39:57Z
+- canonical/candidate: #94413 fix(compaction): wire aggregate retry timeout to compaction.timeoutSeconds (#94391)
+- canonical/candidate live state at generation: OPEN
+- canonical/candidate mergedAt at generation: unknown
+- source result: ProjectClownfish workflow run 27753529347
+
+## Instructions
+
+If #94490 is still open and #94413 is still open, prefer `close_superseded` with `canonical: "#94413"` for #94490. Do not use `candidate_fix` for open canonical refs. Mention both PR/issue URLs in the close comment and preserve contributor/user context. If either live state changed, keep the target open or mark the exact blocker with `needs_human`.

--- a/scripts/import-close-canaries-from-results.mjs
+++ b/scripts/import-close-canaries-from-results.mjs
@@ -275,10 +275,19 @@ function securityDropReason(item, target, canonical) {
   const signals = [];
   if (isSecuritySensitive(target)) signals.push("target");
   if (isSecuritySensitive(canonical)) signals.push("canonical");
-  if (hasSecuritySensitiveText(item.classification, item.reason, item.comment, item.evidence)) {
+  if (hasSecuritySensitiveText(...actionSecurityContext(item))) {
     signals.push("planned close context");
   }
   return signals.length > 0 ? `security signal in ${signals.join(", ")}` : "";
+}
+
+function actionSecurityContext(item) {
+  return [item.classification, item.reason, item.comment, ...(item.evidence ?? [])].map((value) =>
+    String(value ?? "").replace(
+      /\bsecurity[-_\s]?sensitive\s*(?:[=:]\s*|\s+)(?:false|0|no)\b/gi,
+      "non-security classification",
+    ),
+  );
 }
 
 function writeJob(item) {
@@ -350,7 +359,7 @@ function writeJob(item) {
     `- canonical/candidate: ${item.canonical} ${item.canonicalLive.title}`,
     `- canonical/candidate live state at generation: ${item.canonicalLive.state}`,
     `- canonical/candidate mergedAt at generation: ${item.canonicalLive.mergedAt ?? "unknown"}`,
-    `- source result: ${item.resultFile}`,
+    `- source result: ProjectClownfish workflow run ${item.runId}`,
     "",
     "## Instructions",
     "",

--- a/test/import-close-canaries-from-results.test.mjs
+++ b/test/import-close-canaries-from-results.test.mjs
@@ -112,6 +112,61 @@ test("import-close-canaries writes open canonical duplicate closeouts", () => {
   assert.match(job, /Do not use `candidate_fix` for open canonical refs/);
 });
 
+test("import-close-canaries ignores explicit non-security action evidence", () => {
+  const fixture = makeFixture();
+  fs.writeFileSync(
+    path.join(fixture.results, "129.json"),
+    `${JSON.stringify(
+      {
+        cluster_id: "source-cluster-non-security",
+        actions: [
+          {
+            target: "#92164",
+            action: "close_duplicate",
+            status: "planned",
+            canonical: "#92341",
+            classification: "duplicate",
+            reason: "The target duplicates the open canonical issue.",
+            evidence: ["Hydrated artifact marks security_sensitive=false."],
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFakeGhx(fixture.bin);
+
+  const run = spawnSync(
+    process.execPath,
+    [
+      "scripts/import-close-canaries-from-results.mjs",
+      "--results-dir",
+      fixture.results,
+      "--out",
+      fixture.inbox,
+      "--existing-dir",
+      fixture.existing,
+      "--suffix",
+      "non-security",
+      "--limit",
+      "1",
+      "--json",
+    ],
+    {
+      cwd: repoRoot,
+      env: { ...process.env, PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}` },
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(run.status, 0, run.stderr || run.stdout);
+  assert.deepEqual(JSON.parse(run.stdout).candidates.map((candidate) => candidate.target), ["#92164"]);
+  const job = fs.readFileSync(path.join(fixture.inbox, "pr-close-canary-92164-non-security.md"), "utf8");
+  assert.match(job, /source result: ProjectClownfish workflow run 129/);
+  assert.doesNotMatch(job, /clownfish-close-canary-/);
+});
+
 test("import-close-canaries prioritizes newly published results before stale lexical run ids", () => {
   const fixture = makeFixture();
   for (let index = 1; index <= 5; index += 1) {


### PR DESCRIPTION
## Summary
- preserve explicit `security_sensitive=false` action evidence during close-canary generation
- add regression coverage for the false-negative guard
- add two fresh, close-only execute canaries for PRs #94489 and #94490

## Verification
- `npm run validate`
- `node --test test/import-close-canaries-from-results.test.mjs`