### PR TITLE
chore(queue): add refreshed PR plan wave

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-001.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T110752-001
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#59705"
+  - "#88487"
+  - "#88497"
+  - "#88639"
+  - "#90819"
+  - "#88479"
+  - "#87681"
+  - "#87691"
+  - "#87695"
+  - "#87702"
+  - "#87707"
+  - "#88121"
+  - "#88270"
+  - "#88292"
+  - "#88280"
+  - "#88442"
+  - "#88506"
+  - "#88507"
+  - "#88522"
+  - "#88533"
+  - "#88550"
+  - "#88551"
+  - "#88621"
+  - "#88649"
+  - "#88651"
+  - "#88668"
+  - "#88673"
+  - "#88684"
+  - "#88709"
+  - "#88713"
+  - "#88726"
+  - "#88754"
+  - "#88776"
+  - "#92070"
+  - "#88793"
+  - "#88823"
+  - "#88828"
+  - "#88835"
+  - "#88925"
+  - "#88841"
+cluster_refs:
+  - "#59705"
+  - "#88487"
+  - "#88497"
+  - "#88639"
+  - "#90819"
+  - "#88479"
+  - "#87681"
+  - "#87691"
+  - "#87695"
+  - "#87702"
+  - "#87707"
+  - "#88121"
+  - "#88270"
+  - "#88292"
+  - "#88280"
+  - "#88442"
+  - "#88506"
+  - "#88507"
+  - "#88522"
+  - "#88533"
+  - "#88550"
+  - "#88551"
+  - "#88621"
+  - "#88649"
+  - "#88651"
+  - "#88668"
+  - "#88673"
+  - "#88684"
+  - "#88709"
+  - "#88713"
+  - "#88726"
+  - "#88754"
+  - "#88776"
+  - "#92070"
+  - "#88793"
+  - "#88823"
+  - "#88828"
+  - "#88835"
+  - "#88925"
+  - "#88841"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T11:07:52.834Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 1
+
+This is a high-volume live inventory shard over open pull requests, including previously represented PRs being refreshed against live GitHub state.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #59705 [codex] improve parallels windows smoke logging
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: scripts, maintainer, size: M, P3, rating: unranked krab, merge-risk: automation, status: needs proof
+- live updated: 2026-05-24T19:10:39Z
+- live url: https://github.com/openclaw/openclaw/pull/59705
+
+### #88487 fix(build): externalize protobufjs from root bundle
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: XS, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-05-31T00:46:01Z
+- live url: https://github.com/openclaw/openclaw/pull/88487
+
+### #88497 fix(gateway): load auto-enabled channel plugins at startup
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P1, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-05-31T02:03:11Z
+- live url: https://github.com/openclaw/openclaw/pull/88497
+
+### #88639 docs: document gateway method types
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: gateway, commands, agents, maintainer, size: XL, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-05-31T16:52:52Z
+- live url: https://github.com/openclaw/openclaw/pull/88639
+
+### #90819 fix(gateway): pin plugin workspace dir during sessions.list to stop O(rows) metadata scans under concurrency
+
+- bucket: ready_for_maintainer
+- author: k-l-lambda
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-06T03:00:00Z
+- live url: https://github.com/openclaw/openclaw/pull/90819
+
+### #88479 feat(ui): inline rename in the in-chat session picker
+
+- bucket: ready_for_maintainer
+- author: BSG2000
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XL, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-08T07:59:21Z
+- live url: https://github.com/openclaw/openclaw/pull/88479
+
+### #87681 fix(exec): surface oom_score_adj raise when SIGKILLs hit broad find/grep on Linux (#69242)
+
+- bucket: ready_for_maintainer
+- author: sweetcornna
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-10T09:55:07Z
+- live url: https://github.com/openclaw/openclaw/pull/87681
+
+### #87691 fix(auto-reply): preserve post-compaction failure context in user-facing recovery message (#67750)
+
+- bucket: needs_proof
+- author: sweetcornna
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, triage: mock-only-proof, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-10T09:55:14Z
+- live url: https://github.com/openclaw/openclaw/pull/87691
+
+### #87695 fix(types): unblock changed gate checks
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: XS, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-10T09:55:27Z
+- live url: https://github.com/openclaw/openclaw/pull/87695
+
+### #87702 fix(coding-agent): strip Claude Code nesting env vars when spawning claude (#57858)
+
+- bucket: ready_for_maintainer
+- author: sweetcornna
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, extensions: anthropic, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-10T09:55:51Z
+- live url: https://github.com/openclaw/openclaw/pull/87702
+
+### #87707 fix(auto-reply): direct-send text-only block replies when streaming off (#57225)
+
+- bucket: needs_proof
+- author: sweetcornna
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-10T09:55:57Z
+- live url: https://github.com/openclaw/openclaw/pull/87707
+
+### #88121 Lower profile tool policy filter audit logs
+
+- bucket: maintainer_owned
+- author: sjf
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: agents, maintainer, size: XS, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-10T13:41:50Z
+- live url: https://github.com/openclaw/openclaw/pull/88121
+
+### #88270 fix: retry loopback probes without device identity after pairing repair
+
+- bucket: needs_proof
+- author: koatomic88
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: L, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-10T13:44:15Z
+- live url: https://github.com/openclaw/openclaw/pull/88270
+
+### #88292 fix(update): guard Windows task autostart during package updates
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: gateway, cli, maintainer, size: L, P2, rating: platinum hermit, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-10T14:13:11Z
+- live url: https://github.com/openclaw/openclaw/pull/88292
+
+### #88280 Guard media store error cause traversal
+
+- bucket: recent_active
+- author: iHYZ
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P2, rating: off-meta tidepool
+- live updated: 2026-06-10T14:51:19Z
+- live url: https://github.com/openclaw/openclaw/pull/88280
+
+### #88442 Add report-only agent safety regression gate
+
+- bucket: needs_proof
+- author: martins-oss
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: L, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: automation, status: waiting on author
+- live updated: 2026-06-10T14:59:53Z
+- live url: https://github.com/openclaw/openclaw/pull/88442
+
+### #88506 feat: add per-agent compaction overrides
+
+- bucket: draft
+- author: kklouzal
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: docs, app: macos, gateway, extensions: memory-core, commands, agents, size: XL, extensions: codex, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-10T16:19:36Z
+- live url: https://github.com/openclaw/openclaw/pull/88506
+
+### #88507 feat(plugins): accept slot owner records
+
+- bucket: draft
+- author: kklouzal
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: docs, gateway, cli, commands, agents, size: L, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: availability, status: needs proof
+- live updated: 2026-06-10T16:19:47Z
+- live url: https://github.com/openclaw/openclaw/pull/88507
+
+### #88522 Fix Telegram active-run ingress sequencing
+
+- bucket: draft
+- author: Hilo-Hilo
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: docs, channel: telegram, size: M, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-10T16:19:57Z
+- live url: https://github.com/openclaw/openclaw/pull/88522
+
+### #88533 test(core): align changed gate type fixtures
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: agents, maintainer, size: XS, P3, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-10T16:20:18Z
+- live url: https://github.com/openclaw/openclaw/pull/88533
+
+### #88550 fix(codex-supervisor): disable app-server websocket compression
+
+- bucket: needs_proof
+- author: imwyvern
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: sufficient, P2, rating: unranked krab, merge-risk: automation, merge-risk: compatibility, status: waiting on author, extensions: codex-supervisor
+- live updated: 2026-06-10T16:20:23Z
+- live url: https://github.com/openclaw/openclaw/pull/88550
+
+### #88551 fix(agents): skip auth gate for CLI-owned transport
+
+- bucket: ready_for_maintainer
+- author: yu-xin-c
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-10T16:20:27Z
+- live url: https://github.com/openclaw/openclaw/pull/88551
+
+### #88621 fix(types): restore current changed gate
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: no
+- assignees: vincentkoc
+- labels: agents, maintainer, size: XS, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-10T16:21:02Z
+- live url: https://github.com/openclaw/openclaw/pull/88621
+
+### #88649 test(agents): use neutral tool schema fixtures
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, commands, agents, maintainer, size: M, extensions: codex, proof: sufficient, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-10T16:21:49Z
+- live url: https://github.com/openclaw/openclaw/pull/88649
+
+### #88651 fix: add memory leak protection for steer rate limit map
+
+- bucket: needs_proof
+- author: jokemanfire
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: availability, status: needs proof
+- live updated: 2026-06-10T17:42:48Z
+- live url: https://github.com/openclaw/openclaw/pull/88651
+
+### #88668 [codex] Add per-DM active directive prompt
+
+- bucket: draft
+- author: molle-png
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: app: web-ui, gateway, agents, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-10T17:43:02Z
+- live url: https://github.com/openclaw/openclaw/pull/88668
+
+### #88673 test(outbound): align implicit source reply sink
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: no
+- assignees: vincentkoc
+- labels: maintainer, size: XS, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-10T17:43:07Z
+- live url: https://github.com/openclaw/openclaw/pull/88673
+
+### #88684 Keep agent web_search on runtime provider resolution
+
+- bucket: needs_proof
+- author: alexzhu0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, P1, rating: gold shrimp, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-10T17:43:27Z
+- live url: https://github.com/openclaw/openclaw/pull/88684
+
+### #88709 fix(auth): cooldown inline api key billing failures
+
+- bucket: ready_for_maintainer
+- author: MertBasar0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: L, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-10T17:43:48Z
+- live url: https://github.com/openclaw/openclaw/pull/88709
+
+### #88713 docs: document agent helper comments
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: cli, commands, docker, agents, maintainer, size: XL, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-10T17:43:57Z
+- live url: https://github.com/openclaw/openclaw/pull/88713
+
+### #88726 [codex] Read exact X posts via FxTwitter
+
+- bucket: needs_proof
+- author: SnowBelt
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, commands, size: L, extensions: qa-lab, proof: supplied, proof: sufficient, extensions: xai, P2, rating: gold shrimp, merge-risk: automation, merge-risk: compatibility, merge-risk: auth-provider, status: waiting on author
+- live updated: 2026-06-10T17:44:13Z
+- live url: https://github.com/openclaw/openclaw/pull/88726
+
+### #88754 fix(text): normalize CJK/fullwidth quotes in reasoning tag delimiters
+
+- bucket: needs_proof
+- author: Kailigithub
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-10T17:44:55Z
+- live url: https://github.com/openclaw/openclaw/pull/88754
+
+### #88776 fix: normalise wiki lint targets
+
+- bucket: draft
+- author: ishangodawatta
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: size: M, extensions: memory-wiki, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: actively grinding
+- live updated: 2026-06-10T17:45:04Z
+- live url: https://github.com/openclaw/openclaw/pull/88776
+
+### #92070 feat(anthropic): enforce --safe-mode on all claude-cli subprocess launches
+
+- bucket: recent_active
+- author: ElliotDrel
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: none
+- live updated: 2026-06-11T02:05:59Z
+- live url: https://github.com/openclaw/openclaw/pull/92070
+
+### #88793 docs: document cli command path helpers
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: cli, maintainer, size: XL, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-11T04:02:52Z
+- live url: https://github.com/openclaw/openclaw/pull/88793
+
+### #88823 fix(update): avoid zsh readonly status in macOS handoffs
+
+- bucket: needs_proof
+- author: charles-openclaw
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, cli, size: S, triage: mock-only-proof, P2, rating: silver shellfish, status: actively grinding
+- live updated: 2026-06-11T04:03:35Z
+- live url: https://github.com/openclaw/openclaw/pull/88823
+
+### #88828 fix(gateway): gate cron on channel readiness
+
+- bucket: needs_proof
+- author: samzong
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: L, proof: supplied, P1, rating: silver shellfish, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-11T04:03:40Z
+- live url: https://github.com/openclaw/openclaw/pull/88828
+
+### #88835 fix(gateway): guard node approval policy writes
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: gateway, maintainer, size: M, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-11T04:03:45Z
+- live url: https://github.com/openclaw/openclaw/pull/88835
+
+### #88925 Fix stuck-session recovery aborts for active reply runs
+
+- bucket: recent_active
+- author: SnowSky1
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, P2, rating: off-meta tidepool, merge-risk: session-state, merge-risk: message-delivery
+- live updated: 2026-06-11T04:58:05Z
+- live url: https://github.com/openclaw/openclaw/pull/88925
+
+### #88841 fix(discord): reconnect after abnormal gateway close
+
+- bucket: maintainer_owned
+- author: levineam
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: channel: discord, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-11T17:50:48Z
+- live url: https://github.com/openclaw/openclaw/pull/88841

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-002.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T110752-002
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#88898"
+  - "#88581"
+  - "#88180"
+  - "#88633"
+  - "#88885"
+  - "#88743"
+  - "#88192"
+  - "#88845"
+  - "#88850"
+  - "#88876"
+  - "#88883"
+  - "#88899"
+  - "#88905"
+  - "#88959"
+  - "#88681"
+  - "#88382"
+  - "#88884"
+  - "#88875"
+  - "#88878"
+  - "#88936"
+  - "#90998"
+  - "#90855"
+  - "#90864"
+  - "#90923"
+  - "#90963"
+  - "#66968"
+  - "#63456"
+  - "#59835"
+  - "#89717"
+  - "#76495"
+  - "#90885"
+  - "#90102"
+  - "#90105"
+  - "#90109"
+  - "#90112"
+  - "#90114"
+  - "#90117"
+  - "#90118"
+  - "#90120"
+  - "#90136"
+cluster_refs:
+  - "#88898"
+  - "#88581"
+  - "#88180"
+  - "#88633"
+  - "#88885"
+  - "#88743"
+  - "#88192"
+  - "#88845"
+  - "#88850"
+  - "#88876"
+  - "#88883"
+  - "#88899"
+  - "#88905"
+  - "#88959"
+  - "#88681"
+  - "#88382"
+  - "#88884"
+  - "#88875"
+  - "#88878"
+  - "#88936"
+  - "#90998"
+  - "#90855"
+  - "#90864"
+  - "#90923"
+  - "#90963"
+  - "#66968"
+  - "#63456"
+  - "#59835"
+  - "#89717"
+  - "#76495"
+  - "#90885"
+  - "#90102"
+  - "#90105"
+  - "#90109"
+  - "#90112"
+  - "#90114"
+  - "#90117"
+  - "#90118"
+  - "#90120"
+  - "#90136"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T11:07:52.836Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 2
+
+This is a high-volume live inventory shard over open pull requests, including previously represented PRs being refreshed against live GitHub state.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #88898 fix(reply): also drop tool-error progress payloads under messages.suppressToolErrors
+
+- bucket: recent_active
+- author: amittell
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P2, rating: off-meta tidepool
+- live updated: 2026-06-12T05:42:44Z
+- live url: https://github.com/openclaw/openclaw/pull/88898
+
+### #88581 feat(commands): add /name to rename the current session from chat
+
+- bucket: ready_for_maintainer
+- author: BSG2000
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: M, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look, proof: video
+- live updated: 2026-06-12T14:43:09Z
+- live url: https://github.com/openclaw/openclaw/pull/88581
+
+### #88180 fix(prompt): preserve IDENTITY defaults in system prompt
+
+- bucket: ready_for_maintainer
+- author: yozu
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-13T06:34:31Z
+- live url: https://github.com/openclaw/openclaw/pull/88180
+
+### #88633 fix(ci): restore cron run-log Kysely guard
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-13T06:34:53Z
+- live url: https://github.com/openclaw/openclaw/pull/88633
+
+### #88885 fix(infra): wire session-delivery drain recovery guard onto the shared SQLite recovery_state column
+
+- bucket: ready_for_maintainer
+- author: Feelw00
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-13T06:35:13Z
+- live url: https://github.com/openclaw/openclaw/pull/88885
+
+### #88743 docs(sms): add Twilio A2P delivery guidance
+
+- bucket: ready_for_maintainer
+- author: clawSean
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, triage: refactor-only, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look, channel: sms
+- live updated: 2026-06-13T08:46:30Z
+- live url: https://github.com/openclaw/openclaw/pull/88743
+
+### #88192 fix: recover stale diagnostic session lanes
+
+- bucket: needs_proof
+- author: lyvoraai
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: mock-only-proof, P2, rating: silver shellfish, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-14T00:54:16Z
+- live url: https://github.com/openclaw/openclaw/pull/88192
+
+### #88845 Require signed beta desktop distribution
+
+- bucket: recent_active
+- author: reidmcgill
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: discord, channel: googlechat, channel: imessage, channel: line, channel: matrix, channel: mattermost, channel: msteams, channel: nextcloud-talk, channel: nostr, channel: signal, channel: slack, channel: telegram, channel: tlon, channel: voice-call, channel: whatsapp-web, channel: zalo, channel: zalouser, gateway, extensions: copilot-proxy, extensions: diagnostics-otel, extensions: llm-task, extensions: lobster, extensions: memory-core, extensions: memory-lancedb, extensions: open-prose, scripts, agents, channel: feishu, channel: twitch
+- live updated: 2026-06-14T01:34:52Z
+- live url: https://github.com/openclaw/openclaw/pull/88845
+
+### #88850 fix(msteams): thread proactive file sends
+
+- bucket: needs_proof
+- author: charles-openclaw
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: msteams, size: S, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: silver shellfish, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-14T01:35:00Z
+- live url: https://github.com/openclaw/openclaw/pull/88850
+
+### #88876 fix(ci): restore cron schema snapshots
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: no
+- assignees: vincentkoc
+- labels: agents, maintainer, extensions: phone-control, size: L, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T01:35:31Z
+- live url: https://github.com/openclaw/openclaw/pull/88876
+
+### #88883 fix(ts): narrow type guard for api_key in oauth-manager
+
+- bucket: needs_proof
+- author: andrewwaites
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, agents, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T01:35:47Z
+- live url: https://github.com/openclaw/openclaw/pull/88883
+
+### #88899 fix(android): widen chat bubbles and render markdown consistently
+
+- bucket: needs_proof
+- author: Pluviobyte
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: android, app: web-ui, size: S, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: automation, status: waiting on author
+- live updated: 2026-06-14T01:36:15Z
+- live url: https://github.com/openclaw/openclaw/pull/88899
+
+### #88905 feat(dreaming): expose shadow-trial scoring in reports
+
+- bucket: ready_for_maintainer
+- author: iFiras-Max1
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, extensions: memory-core, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T02:31:49Z
+- live url: https://github.com/openclaw/openclaw/pull/88905
+
+### #88959 fix(plugins): ignore throwing provider runtime hooks
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T02:33:09Z
+- live url: https://github.com/openclaw/openclaw/pull/88959
+
+### #88681 Make runtime plugin startup stalls name in-flight plugins
+
+- bucket: ready_for_maintainer
+- author: alexzhu0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T03:09:42Z
+- live url: https://github.com/openclaw/openclaw/pull/88681
+
+### #88382 fix(config): compare size-drop guard against canonical config
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P1, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T04:01:11Z
+- live url: https://github.com/openclaw/openclaw/pull/88382
+
+### #88884 fix(agents): trim web tools in lean mode
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: no
+- assignees: vincentkoc
+- labels: docs, gateway, agents, maintainer, size: L, extensions: openai, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-14T04:50:36Z
+- live url: https://github.com/openclaw/openclaw/pull/88884
+
+### #88875 docs: document markdown and shared helpers
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, cli, commands, agents, maintainer, size: XL, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T06:05:50Z
+- live url: https://github.com/openclaw/openclaw/pull/88875
+
+### #88878 fix(agents): project cron tool schemas for providers
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: agents, maintainer, size: M, P2, rating: silver shellfish, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-14T07:17:03Z
+- live url: https://github.com/openclaw/openclaw/pull/88878
+
+### #88936 fix(plugins): skip broken web provider factories
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-14T07:17:31Z
+- live url: https://github.com/openclaw/openclaw/pull/88936
+
+### #90998 fix(sms): authorize text slash commands
+
+- bucket: ready_for_maintainer
+- author: clawSean
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look, channel: sms
+- live updated: 2026-06-14T08:13:43Z
+- live url: https://github.com/openclaw/openclaw/pull/90998
+
+### #90855 Recover stale pending final deliveries
+
+- bucket: needs_proof
+- author: jeremykraklist
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: L, proof: supplied, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-14T09:55:52Z
+- live url: https://github.com/openclaw/openclaw/pull/90855
+
+### #90864 fix(tasks): accept completion summaries with result markers
+
+- bucket: needs_proof
+- author: moeedahmed
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: unranked krab, merge-risk: session-state, status: waiting on author
+- live updated: 2026-06-14T09:56:07Z
+- live url: https://github.com/openclaw/openclaw/pull/90864
+
+### #90923 fix(daemon): write LaunchAgent plist to boot volume when home is on external APFS
+
+- bucket: needs_proof
+- author: 849261680
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, cli, size: M, proof: supplied, proof: sufficient, P1, rating: gold shrimp, merge-risk: compatibility, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-14T11:15:07Z
+- live url: https://github.com/openclaw/openclaw/pull/90923
+
+### #90963 fix(codex): strengthen agent soul adherence
+
+- bucket: maintainer_owned
+- author: hannesrudolph
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: size: XS, extensions: codex, P3, rating: diamond lobster, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-14T11:15:21Z
+- live url: https://github.com/openclaw/openclaw/pull/90963
+
+### #66968 style: apply oxfmt formatting to 16 files
+
+- bucket: maintainer_owned
+- author: visionik
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: docs, app: web-ui, docker, agents, maintainer, size: S, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T13:13:56Z
+- live url: https://github.com/openclaw/openclaw/pull/66968
+
+### #63456 Scope workspace guidance to coding contexts
+
+- bucket: needs_proof
+- author: ImLukeF
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, maintainer, size: XL, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T14:06:27Z
+- live url: https://github.com/openclaw/openclaw/pull/63456
+
+### #59835 fix(cron): validate custom session ids
+
+- bucket: maintainer_owned
+- author: eleqtrizit
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: gateway, maintainer, size: S, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-14T14:07:43Z
+- live url: https://github.com/openclaw/openclaw/pull/59835
+
+### #89717 fix(agents): avoid enumerating wrapped tool descriptors
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: gold shrimp, status: waiting on author
+- live updated: 2026-06-14T15:37:08Z
+- live url: https://github.com/openclaw/openclaw/pull/89717
+
+### #76495 fix(memory): load configured memory slot for runtime checks
+
+- bucket: needs_proof
+- author: jonathangu
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T16:38:39Z
+- live url: https://github.com/openclaw/openclaw/pull/76495
+
+### #90885 fix(agent): resolve compaction model alias to canonical model ref
+
+- bucket: ready_for_maintainer
+- author: Pick-cat
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: re-review loop
+- live updated: 2026-06-14T18:42:59Z
+- live url: https://github.com/openclaw/openclaw/pull/90885
+
+### #90102 fix(plugin-sdk): guard qa runner manifest rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-14T20:04:44Z
+- live url: https://github.com/openclaw/openclaw/pull/90102
+
+### #90105 fix(channels): guard read-only command metadata rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T20:04:48Z
+- live url: https://github.com/openclaw/openclaw/pull/90105
+
+### #90109 fix(commands): guard manifest catalog filters
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: commands, maintainer, size: XS, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T20:04:56Z
+- live url: https://github.com/openclaw/openclaw/pull/90109
+
+### #90112 fix(commands): guard provider catalog aliases
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: commands, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T20:05:02Z
+- live url: https://github.com/openclaw/openclaw/pull/90112
+
+### #90114 fix(telegram): suppress failure fallback when source delivery is message-tool-only
+
+- bucket: maintainer_owned
+- author: openperf
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-14T20:05:07Z
+- live url: https://github.com/openclaw/openclaw/pull/90114
+
+### #90117 fix: skip qmd zero-hit sync retry in memory_search
+
+- bucket: needs_proof
+- author: arkyu2077
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-14T20:05:32Z
+- live url: https://github.com/openclaw/openclaw/pull/90117
+
+### #90118 [codex] docs(wizard): clarify provider key update path
+
+- bucket: needs_proof
+- author: Pluviobyte
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, scripts, size: S, proof: supplied, proof: sufficient, P3, rating: gold shrimp, status: waiting on author
+- live updated: 2026-06-14T20:05:37Z
+- live url: https://github.com/openclaw/openclaw/pull/90118
+
+### #90120 fix(plugins): guard provider contract metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: gold shrimp, status: waiting on author
+- live updated: 2026-06-14T20:05:41Z
+- live url: https://github.com/openclaw/openclaw/pull/90120
+
+### #90136 fix(plugins): guard manifest activation planning
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T20:06:27Z
+- live url: https://github.com/openclaw/openclaw/pull/90136

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-003.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T110752-003
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#89816"
+  - "#90150"
+  - "#78631"
+  - "#90135"
+  - "#90153"
+  - "#90154"
+  - "#90160"
+  - "#90168"
+  - "#90172"
+  - "#90194"
+  - "#90202"
+  - "#90215"
+  - "#89997"
+  - "#89999"
+  - "#89983"
+  - "#80235"
+  - "#80414"
+  - "#80418"
+  - "#80455"
+  - "#80473"
+  - "#80499"
+  - "#80523"
+  - "#80529"
+  - "#80596"
+  - "#80604"
+  - "#80649"
+  - "#80658"
+  - "#80666"
+  - "#80670"
+  - "#80716"
+  - "#80726"
+  - "#80774"
+  - "#80778"
+  - "#80805"
+  - "#80818"
+  - "#80829"
+  - "#80889"
+  - "#80915"
+  - "#80916"
+  - "#80929"
+cluster_refs:
+  - "#89816"
+  - "#90150"
+  - "#78631"
+  - "#90135"
+  - "#90153"
+  - "#90154"
+  - "#90160"
+  - "#90168"
+  - "#90172"
+  - "#90194"
+  - "#90202"
+  - "#90215"
+  - "#89997"
+  - "#89999"
+  - "#89983"
+  - "#80235"
+  - "#80414"
+  - "#80418"
+  - "#80455"
+  - "#80473"
+  - "#80499"
+  - "#80523"
+  - "#80529"
+  - "#80596"
+  - "#80604"
+  - "#80649"
+  - "#80658"
+  - "#80666"
+  - "#80670"
+  - "#80716"
+  - "#80726"
+  - "#80774"
+  - "#80778"
+  - "#80805"
+  - "#80818"
+  - "#80829"
+  - "#80889"
+  - "#80915"
+  - "#80916"
+  - "#80929"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T11:07:52.836Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 3
+
+This is a high-volume live inventory shard over open pull requests, including previously represented PRs being refreshed against live GitHub state.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #89816 docs(gateway): add launchd supervisor loop troubleshooting
+
+- bucket: ready_for_maintainer
+- author: Pick-cat
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: macos, gateway, size: XS, proof: supplied, P3, rating: platinum hermit, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-14T20:06:49Z
+- live url: https://github.com/openclaw/openclaw/pull/89816
+
+### #90150 fix(doctor): guard tool allowlist manifest metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: commands, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T20:06:57Z
+- live url: https://github.com/openclaw/openclaw/pull/90150
+
+### #78631 test(plugins): cover stale OpenClaw peer repair during install
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: no
+- assignees: vincentkoc
+- labels: maintainer, size: S, P3, rating: gold shrimp, status: waiting on author
+- live updated: 2026-06-14T20:22:14Z
+- live url: https://github.com/openclaw/openclaw/pull/78631
+
+### #90135 fix(plugins): guard manifest owner metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T20:33:49Z
+- live url: https://github.com/openclaw/openclaw/pull/90135
+
+### #90153 fix(doctor): isolate channel doctor hook failures
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: cli, commands, maintainer, size: M, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T20:44:53Z
+- live url: https://github.com/openclaw/openclaw/pull/90153
+
+### #90154 fix(gateway): restrict backend self-pairing shared auth
+
+- bucket: ready_for_maintainer
+- author: coygeek
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-14T20:45:01Z
+- live url: https://github.com/openclaw/openclaw/pull/90154
+
+### #90160 fix(channels): guard pairing adapter metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T20:45:14Z
+- live url: https://github.com/openclaw/openclaw/pull/90160
+
+### #90168 fix(gateway): guard reload metadata descriptors
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: gateway, maintainer, size: M, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T20:45:34Z
+- live url: https://github.com/openclaw/openclaw/pull/90168
+
+### #90172 [codex] fix(ui): proxy inbound media previews
+
+- bucket: draft
+- author: sweetcornna
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-14T20:45:44Z
+- live url: https://github.com/openclaw/openclaw/pull/90172
+
+### #90194 fix(cron): sweep isolated-target base cron sessions under sessionRetention
+
+- bucket: maintainer_owned
+- author: openperf
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: size: M, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-14T20:46:13Z
+- live url: https://github.com/openclaw/openclaw/pull/90194
+
+### #90202 feat(memory-wiki): add managed local source imports
+
+- bucket: ready_for_maintainer
+- author: Sunjae-k
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: L, extensions: memory-wiki, proof: supplied, proof: sufficient, P2, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-14T20:46:38Z
+- live url: https://github.com/openclaw/openclaw/pull/90202
+
+### #90215 test: detect file symlink support dynamically in canvas tool test
+
+- bucket: needs_proof
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P3, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-14T20:47:01Z
+- live url: https://github.com/openclaw/openclaw/pull/90215
+
+### #89997 fix(cli): suppress mcp serve startup stdout
+
+- bucket: ready_for_maintainer
+- author: kenners22
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-14T20:49:10Z
+- live url: https://github.com/openclaw/openclaw/pull/89997
+
+### #89999 fix(plugins): isolate CLI descriptor rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T20:57:44Z
+- live url: https://github.com/openclaw/openclaw/pull/89999
+
+### #89983 fix(agents): isolate provider attribution manifest rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: M, P2, rating: platinum hermit, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-14T21:21:00Z
+- live url: https://github.com/openclaw/openclaw/pull/89983
+
+### #80235 feat(discord): add implicit reply mention policy
+
+- bucket: ready_for_maintainer
+- author: JiehoonKwak
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: discord, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T21:29:59Z
+- live url: https://github.com/openclaw/openclaw/pull/80235
+
+### #80414 refactor(auto-reply): drop dead /reset branches in fast-path session init
+
+- bucket: needs_proof
+- author: gllbrn
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T21:33:40Z
+- live url: https://github.com/openclaw/openclaw/pull/80414
+
+### #80418 fix(/v1/responses): accept text field on requests for OpenAI SDK 6.x parity
+
+- bucket: needs_proof
+- author: logicbridgedev
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, triage: needs-real-behavior-proof, P2, rating: silver shellfish, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-14T21:33:51Z
+- live url: https://github.com/openclaw/openclaw/pull/80418
+
+### #80455 fix(doctor): suppress --fix trailer when no pending config changes remain
+
+- bucket: ready_for_maintainer
+- author: KeWang0622
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T21:34:39Z
+- live url: https://github.com/openclaw/openclaw/pull/80455
+
+### #80473 fix(discord): resolve redundant type constituents in native-command-route
+
+- bucket: ready_for_maintainer
+- author: KhanCold
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T21:34:49Z
+- live url: https://github.com/openclaw/openclaw/pull/80473
+
+### #80499 Fix Claude ACP config controls
+
+- bucket: needs_proof
+- author: qianhaoq
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, extensions: acpx, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: auth-provider, status: waiting on author
+- live updated: 2026-06-14T21:34:56Z
+- live url: https://github.com/openclaw/openclaw/pull/80499
+
+### #80523 Harden ACP worker dispatch controls
+
+- bucket: needs_proof
+- author: imwalkinhere
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, extensions: acpx, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: auth-provider, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-14T21:35:44Z
+- live url: https://github.com/openclaw/openclaw/pull/80523
+
+### #80529 fix(telegram): make pre-connect network failures recoverable in send context
+
+- bucket: needs_proof
+- author: Kailigithub
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-14T21:35:48Z
+- live url: https://github.com/openclaw/openclaw/pull/80529
+
+### #80596 Expose transcript update emitter to plugins
+
+- bucket: needs_proof
+- author: WangBRen
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, plugin: file-transfer, proof: sufficient, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-14T21:37:26Z
+- live url: https://github.com/openclaw/openclaw/pull/80596
+
+### #80604 fix(message): show dry-run output for send/poll
+
+- bucket: needs_proof
+- author: alchip
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, triage: mock-only-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T21:37:36Z
+- live url: https://github.com/openclaw/openclaw/pull/80604
+
+### #80649 i18n: improve Indonesian Control UI labels
+
+- bucket: needs_proof
+- author: aqilaziz
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, agents, size: M, proof: supplied, P3, rating: silver shellfish, merge-risk: availability, status: needs proof
+- live updated: 2026-06-14T21:38:51Z
+- live url: https://github.com/openclaw/openclaw/pull/80649
+
+### #80658 docs: clarify backend client behavior with gateway.auth.mode 'none'
+
+- bucket: needs_proof
+- author: HouJian2020
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: XS, triage: low-signal-docs, triage: needs-real-behavior-proof, P3, rating: silver shellfish, status: waiting on author
+- live updated: 2026-06-14T21:39:03Z
+- live url: https://github.com/openclaw/openclaw/pull/80658
+
+### #80666 Filter assistant process chatter from Dreaming session corpus
+
+- bucket: needs_proof
+- author: ArthurNie
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: session-state, status: waiting on author
+- live updated: 2026-06-14T21:39:11Z
+- live url: https://github.com/openclaw/openclaw/pull/80666
+
+### #80670 fix(gateway): reduce WebChat ingress latency
+
+- bucket: needs_proof
+- author: AndyTane
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: web-ui, gateway, agents, size: XL, proof: supplied, proof: sufficient, P1, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-14T21:39:27Z
+- live url: https://github.com/openclaw/openclaw/pull/80670
+
+### #80716 docs: add Codex long-task reliability runbook
+
+- bucket: needs_proof
+- author: scarlettdetekelala
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, triage: needs-real-behavior-proof, P3, rating: gold shrimp, status: waiting on author
+- live updated: 2026-06-14T21:40:25Z
+- live url: https://github.com/openclaw/openclaw/pull/80716
+
+### #80726 fix(telegram): resolve DM topic thread ids
+
+- bucket: needs_proof
+- author: Audiofool934
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: S, triage: needs-real-behavior-proof, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-14T21:40:32Z
+- live url: https://github.com/openclaw/openclaw/pull/80726
+
+### #80774 [codex] Add manifest plugin auth requirements
+
+- bucket: maintainer_owned
+- author: scoootscooob
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: docs, maintainer, size: L, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T21:41:14Z
+- live url: https://github.com/openclaw/openclaw/pull/80774
+
+### #80778 feat(codex): surface pre-turn projection accounting (#80765)
+
+- bucket: needs_proof
+- author: aiZKP
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, extensions: codex, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T21:41:19Z
+- live url: https://github.com/openclaw/openclaw/pull/80778
+
+### #80805 SUP-1563 restore channel responsiveness health
+
+- bucket: needs_proof
+- author: levineam
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, channel: telegram, gateway, extensions: memory-core, scripts, commands, agents, size: M, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: silver shellfish, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-14T21:42:14Z
+- live url: https://github.com/openclaw/openclaw/pull/80805
+
+### #80818 googlechat: add appPrincipal setup input + docs
+
+- bucket: ready_for_maintainer
+- author: alexuser
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: googlechat, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T21:42:40Z
+- live url: https://github.com/openclaw/openclaw/pull/80818
+
+### #80829 fix(auto-reply/followup): surface billing/quota notice instead of silent drop (#80700)
+
+- bucket: needs_proof
+- author: Sanjays2402
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-14T21:43:08Z
+- live url: https://github.com/openclaw/openclaw/pull/80829
+
+### #80889 fix(compaction): make overflow tuning configurable
+
+- bucket: needs_proof
+- author: hyspacex
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-14T21:45:32Z
+- live url: https://github.com/openclaw/openclaw/pull/80889
+
+### #80915 fix(memory-wiki): accept title wikilink targets
+
+- bucket: needs_proof
+- author: levineam
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, extensions: memory-wiki, proof: supplied, P2, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-14T21:45:57Z
+- live url: https://github.com/openclaw/openclaw/pull/80915
+
+### #80916 fix(memory): skip empty dreaming placeholders
+
+- bucket: ready_for_maintainer
+- author: hyspacex
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-14T21:46:04Z
+- live url: https://github.com/openclaw/openclaw/pull/80916
+
+### #80929 fix(outbound): classify deterministic delivery errors
+
+- bucket: ready_for_maintainer
+- author: honor2030
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-14T21:46:51Z
+- live url: https://github.com/openclaw/openclaw/pull/80929

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-004.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T110752-004
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#80955"
+  - "#80957"
+  - "#80982"
+  - "#80985"
+  - "#81019"
+  - "#81027"
+  - "#81039"
+  - "#81046"
+  - "#81047"
+  - "#81054"
+  - "#81079"
+  - "#81136"
+  - "#81154"
+  - "#81157"
+  - "#81190"
+  - "#81198"
+  - "#90224"
+  - "#90227"
+  - "#90232"
+  - "#90841"
+  - "#90257"
+  - "#90258"
+  - "#90266"
+  - "#90274"
+  - "#80924"
+  - "#90026"
+  - "#92892"
+  - "#81243"
+  - "#81300"
+  - "#90144"
+  - "#90161"
+  - "#81641"
+  - "#81778"
+  - "#90298"
+  - "#86637"
+  - "#90332"
+  - "#90365"
+  - "#90401"
+  - "#90406"
+  - "#89517"
+cluster_refs:
+  - "#80955"
+  - "#80957"
+  - "#80982"
+  - "#80985"
+  - "#81019"
+  - "#81027"
+  - "#81039"
+  - "#81046"
+  - "#81047"
+  - "#81054"
+  - "#81079"
+  - "#81136"
+  - "#81154"
+  - "#81157"
+  - "#81190"
+  - "#81198"
+  - "#90224"
+  - "#90227"
+  - "#90232"
+  - "#90841"
+  - "#90257"
+  - "#90258"
+  - "#90266"
+  - "#90274"
+  - "#80924"
+  - "#90026"
+  - "#92892"
+  - "#81243"
+  - "#81300"
+  - "#90144"
+  - "#90161"
+  - "#81641"
+  - "#81778"
+  - "#90298"
+  - "#86637"
+  - "#90332"
+  - "#90365"
+  - "#90401"
+  - "#90406"
+  - "#89517"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T11:07:52.836Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 4
+
+This is a high-volume live inventory shard over open pull requests, including previously represented PRs being refreshed against live GitHub state.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #80955 ui(i18n): localize chat page slash commands and composer for zh-CN
+
+- bucket: needs_proof
+- author: git-jxj
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XL, proof: supplied, P2, rating: unranked krab, status: needs proof, proof: screenshot, merge-risk: other
+- live updated: 2026-06-14T21:47:40Z
+- live url: https://github.com/openclaw/openclaw/pull/80955
+
+### #80957 fix: refresh status context window after model switch
+
+- bucket: needs_proof
+- author: chenyanchen
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-14T21:47:43Z
+- live url: https://github.com/openclaw/openclaw/pull/80957
+
+### #80982 feat(plugin-sdk): registerChatStreamRenderer for plugin-owned inline UI
+
+- bucket: needs_proof
+- author: 100yenadmin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: web-ui, gateway, size: L, triage: dirty-candidate, triage: external-plugin-candidate, proof: supplied, P2, rating: silver shellfish, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-14T21:48:23Z
+- live url: https://github.com/openclaw/openclaw/pull/80982
+
+### #80985 fix(cron): reject announce->webchat at create time and runtime
+
+- bucket: ready_for_maintainer
+- author: esqandil
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T21:48:38Z
+- live url: https://github.com/openclaw/openclaw/pull/80985
+
+### #81019 fix: track systemd unit provenance
+
+- bucket: needs_proof
+- author: WT-WSL
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, commands, size: L, proof: supplied, proof: sufficient, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: auth-provider, status: waiting on author
+- live updated: 2026-06-14T21:49:07Z
+- live url: https://github.com/openclaw/openclaw/pull/81019
+
+### #81027 fix(gateway): enforce hard-kill socket teardown on abort to eliminate
+
+- bucket: needs_proof
+- author: doedewaldt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, scripts, commands, agents, size: M, extensions: codex, proof: supplied, P1, rating: silver shellfish, merge-risk: automation, merge-risk: availability, status: needs proof
+- live updated: 2026-06-14T21:49:12Z
+- live url: https://github.com/openclaw/openclaw/pull/81027
+
+### #81039 fix(cli-runner): emit trajectory events from CLI executor path
+
+- bucket: needs_proof
+- author: 0xghost42
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: L, proof: supplied, P2, rating: silver shellfish, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-14T21:49:17Z
+- live url: https://github.com/openclaw/openclaw/pull/81039
+
+### #81046 Persist model exhaustion cooldowns
+
+- bucket: needs_proof
+- author: prantikmedhi
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-14T21:49:40Z
+- live url: https://github.com/openclaw/openclaw/pull/81046
+
+### #81047 fix(cli-runner): drop volatile systemPromptHash from claude-cli live fingerprint
+
+- bucket: needs_proof
+- author: benjamin1492
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: waiting on author
+- live updated: 2026-06-14T21:49:44Z
+- live url: https://github.com/openclaw/openclaw/pull/81047
+
+### #81054 feat: persist model exhaustion cooldowns per session
+
+- bucket: needs_proof
+- author: prantikmedhi
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, agents, size: L, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-14T21:49:53Z
+- live url: https://github.com/openclaw/openclaw/pull/81054
+
+### #81079 [feat]: thread currentTokenCount into ContextEngine.assemble
+
+- bucket: needs_proof
+- author: DatPham-6996
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: S, extensions: codex, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-14T21:50:20Z
+- live url: https://github.com/openclaw/openclaw/pull/81079
+
+### #81136 fix(gateway): carry assistant mediaUrls through live chat deltas and finals
+
+- bucket: needs_proof
+- author: adone0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: M, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-14T21:52:13Z
+- live url: https://github.com/openclaw/openclaw/pull/81136
+
+### #81154 fix(installer): bypass onboard exec when existing config is present
+
+- bucket: needs_proof
+- author: adone0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: S, proof: supplied, P2, rating: silver shellfish, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-14T21:52:21Z
+- live url: https://github.com/openclaw/openclaw/pull/81154
+
+### #81157 fix(agents): reject invalid process.action at the tool invocation boundary
+
+- bucket: ready_for_maintainer
+- author: adone0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-14T21:52:34Z
+- live url: https://github.com/openclaw/openclaw/pull/81157
+
+### #81190 fix(agents): truncate tool results before overflow compaction
+
+- bucket: ready_for_maintainer
+- author: LLagoon3
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-14T21:53:49Z
+- live url: https://github.com/openclaw/openclaw/pull/81190
+
+### #81198 feat: add before_route_inbound_message plugin hook for channel bridging
+
+- bucket: needs_proof
+- author: DranboFieldston
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-14T21:53:53Z
+- live url: https://github.com/openclaw/openclaw/pull/81198
+
+### #90224 fix(agents): skip unreadable tool search catalog entries
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T21:58:04Z
+- live url: https://github.com/openclaw/openclaw/pull/90224
+
+### #90227 test: make zalo credentials tests compatible with Windows
+
+- bucket: ready_for_maintainer
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: zalouser, size: XS, proof: sufficient, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-14T21:58:19Z
+- live url: https://github.com/openclaw/openclaw/pull/90227
+
+### #90232 fix(plugin-sdk): guard provider tool schema helpers
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T21:58:41Z
+- live url: https://github.com/openclaw/openclaw/pull/90232
+
+### #90841 fix(control-ui): validate Telegram cron To against full target contract (#90467)
+
+- bucket: needs_proof
+- author: lonexreb
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: M, triage: mock-only-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: actively grinding
+- live updated: 2026-06-14T21:59:14Z
+- live url: https://github.com/openclaw/openclaw/pull/90841
+
+### #90257 fix(agents): lower fresh isolated cron loop warnings
+
+- bucket: needs_proof
+- author: sweetcornna
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T21:59:30Z
+- live url: https://github.com/openclaw/openclaw/pull/90257
+
+### #90258 fix(qr): stabilize terminal colors
+
+- bucket: maintainer_owned
+- author: sliverp
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: maintainer, size: XS, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-14T21:59:35Z
+- live url: https://github.com/openclaw/openclaw/pull/90258
+
+### #90266 test: detect file symlink support dynamically in json-file tests
+
+- bucket: needs_proof
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: sufficient, P3, rating: gold shrimp, merge-risk: automation, status: waiting on author
+- live updated: 2026-06-14T21:59:49Z
+- live url: https://github.com/openclaw/openclaw/pull/90266
+
+### #90274 fix(agents): preserve unreadable wrapped tool schemas
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:00:07Z
+- live url: https://github.com/openclaw/openclaw/pull/90274
+
+### #80924 feat(i18n): translate dreaming module UI strings to Simplified Chinese
+
+- bucket: recent_active
+- author: git-jxj
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: L, proof: supplied, P3, rating: off-meta tidepool
+- live updated: 2026-06-14T22:00:44Z
+- live url: https://github.com/openclaw/openclaw/pull/80924
+
+### #90026 fix(gateway): guard channel method descriptor projection
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: gateway, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:00:54Z
+- live url: https://github.com/openclaw/openclaw/pull/90026
+
+### #92892 fix(gateway): allow Gemini CLI image-capable models
+
+- bucket: ready_for_maintainer
+- author: YonganZhang
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:05:45Z
+- live url: https://github.com/openclaw/openclaw/pull/92892
+
+### #81243 feat(discord): add fetch action to retrieve a single message by ID or URL
+
+- bucket: ready_for_maintainer
+- author: yousan
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, scripts, agents, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-14T22:13:00Z
+- live url: https://github.com/openclaw/openclaw/pull/81243
+
+### #81300 codex: plumb session reasoningLevel into codex model_reasoning_summary
+
+- bucket: needs_proof
+- author: iYoungblood
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: codex, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-14T22:14:01Z
+- live url: https://github.com/openclaw/openclaw/pull/81300
+
+### #90144 fix(announce): durable in-process queue fallback for direct-pending handoffs
+
+- bucket: needs_proof
+- author: bradfreels
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-14T22:14:33Z
+- live url: https://github.com/openclaw/openclaw/pull/90144
+
+### #90161 fix(channels): guard loaded channel registry metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:14:37Z
+- live url: https://github.com/openclaw/openclaw/pull/90161
+
+### #81641 fix(cli): make `models aliases remove` honest about built-in aliases
+
+- bucket: ready_for_maintainer
+- author: ScientificProgrammer
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:17:50Z
+- live url: https://github.com/openclaw/openclaw/pull/81641
+
+### #81778 fix(status): detect shell-wrapped gateway services
+
+- bucket: ready_for_maintainer
+- author: liaoandi
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:19:09Z
+- live url: https://github.com/openclaw/openclaw/pull/81778
+
+### #90298 fix(qa-lab): guard parity stable hashes
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, extensions: qa-lab, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:24:10Z
+- live url: https://github.com/openclaw/openclaw/pull/90298
+
+### #86637 fix(agents): cap DSML recovery buffer to prevent unbounded memory growth
+
+- bucket: maintainer_owned
+- author: SebTardif
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: osolmaz
+- labels: agents, size: S, proof: supplied, P1, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-14T22:24:25Z
+- live url: https://github.com/openclaw/openclaw/pull/86637
+
+### #90332 fix(codex): guard trajectory tool schema capture
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, extensions: codex, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:25:18Z
+- live url: https://github.com/openclaw/openclaw/pull/90332
+
+### #90365 test(browser): replace broad win32 skip with dynamic directory symlink check
+
+- bucket: needs_proof
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: sufficient, P3, rating: gold shrimp, merge-risk: automation, status: waiting on author
+- live updated: 2026-06-14T22:25:48Z
+- live url: https://github.com/openclaw/openclaw/pull/90365
+
+### #90401 docs(local-models): add Atomic Chat as an OpenAI-compatible local server
+
+- bucket: needs_proof
+- author: danyurkin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: XS, triage: needs-real-behavior-proof, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:26:19Z
+- live url: https://github.com/openclaw/openclaw/pull/90401
+
+### #90406 fix(google): skip unreadable tool schemas
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: L, extensions: google, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T22:26:23Z
+- live url: https://github.com/openclaw/openclaw/pull/90406
+
+### #89517 [codex] fix gateway hot-mode restart reloads
+
+- bucket: needs_proof
+- author: amittell
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: M, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-14T22:26:48Z
+- live url: https://github.com/openclaw/openclaw/pull/89517

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-005.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T110752-005
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#90099"
+  - "#81417"
+  - "#81794"
+  - "#81825"
+  - "#81832"
+  - "#81864"
+  - "#81916"
+  - "#82079"
+  - "#82160"
+  - "#82179"
+  - "#82213"
+  - "#82240"
+  - "#82355"
+  - "#82373"
+  - "#82379"
+  - "#82386"
+  - "#82435"
+  - "#82495"
+  - "#82505"
+  - "#82514"
+  - "#82519"
+  - "#82520"
+  - "#82536"
+  - "#77559"
+  - "#82552"
+  - "#82562"
+  - "#82585"
+  - "#82587"
+  - "#82618"
+  - "#82665"
+  - "#80251"
+  - "#82734"
+  - "#81176"
+  - "#81388"
+  - "#82870"
+  - "#82894"
+  - "#82895"
+  - "#82906"
+  - "#82909"
+  - "#82966"
+cluster_refs:
+  - "#90099"
+  - "#81417"
+  - "#81794"
+  - "#81825"
+  - "#81832"
+  - "#81864"
+  - "#81916"
+  - "#82079"
+  - "#82160"
+  - "#82179"
+  - "#82213"
+  - "#82240"
+  - "#82355"
+  - "#82373"
+  - "#82379"
+  - "#82386"
+  - "#82435"
+  - "#82495"
+  - "#82505"
+  - "#82514"
+  - "#82519"
+  - "#82520"
+  - "#82536"
+  - "#77559"
+  - "#82552"
+  - "#82562"
+  - "#82585"
+  - "#82587"
+  - "#82618"
+  - "#82665"
+  - "#80251"
+  - "#82734"
+  - "#81176"
+  - "#81388"
+  - "#82870"
+  - "#82894"
+  - "#82895"
+  - "#82906"
+  - "#82909"
+  - "#82966"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T11:07:52.837Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 5
+
+This is a high-volume live inventory shard over open pull requests, including previously represented PRs being refreshed against live GitHub state.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #90099 fix(plugin-sdk): guard facade registry rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:26:56Z
+- live url: https://github.com/openclaw/openclaw/pull/90099
+
+### #81417 feat(memory-core): scale default softThresholdTokens with model context window
+
+- bucket: needs_proof
+- author: 22kyasue
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, triage: external-plugin-candidate, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-14T22:45:29Z
+- live url: https://github.com/openclaw/openclaw/pull/81417
+
+### #81794 feat(control-ui): compress static assets
+
+- bucket: needs_proof
+- author: jbetala7
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: M, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-14T22:45:43Z
+- live url: https://github.com/openclaw/openclaw/pull/81794
+
+### #81825 fix(skills/1password): stop forcing tmux for desktop app auth (#52540)
+
+- bucket: ready_for_maintainer
+- author: koshaji
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:46:17Z
+- live url: https://github.com/openclaw/openclaw/pull/81825
+
+### #81832 feat(whatsapp): add post-link 'next steps' note and hello-world docs (#75082)
+
+- bucket: needs_proof
+- author: koshaji
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: whatsapp-web, size: S, proof: supplied, P3, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-14T22:46:29Z
+- live url: https://github.com/openclaw/openclaw/pull/81832
+
+### #81864 feat(approvals): add plain-language plugin approvals
+
+- bucket: ready_for_maintainer
+- author: kennykankush
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: discord, channel: imessage, channel: matrix, channel: nostr, channel: signal, channel: slack, channel: telegram, channel: whatsapp-web, channel: zalo, app: web-ui, extensions: memory-core, scripts, docker, agents, stale, size: XL, extensions: qa-lab, extensions: memory-wiki, extensions: codex, extensions: diagnostics-prometheus, extensions: deepinfra, proof: supplied, proof: sufficient, extensions: oc-path, mantis: telegram-visible-proof, extensions: diffs, extensions: google, extensions: openrouter, P2
+- live updated: 2026-06-14T22:47:39Z
+- live url: https://github.com/openclaw/openclaw/pull/81864
+
+### #81916 fix(compaction): bound stale transcript usage
+
+- bucket: ready_for_maintainer
+- author: jbetala7
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-14T22:48:53Z
+- live url: https://github.com/openclaw/openclaw/pull/81916
+
+### #82079 fix(telegram): preserve bot-self reply target context under allowlist visibility (#82002)
+
+- bucket: needs_proof
+- author: 0xghost42
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: S, proof: supplied, mantis: telegram-visible-proof, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-14T22:52:34Z
+- live url: https://github.com/openclaw/openclaw/pull/82079
+
+### #82160 fix(codex): wait for migrated plugin inventory
+
+- bucket: maintainer_owned
+- author: rubencu
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: stale, size: M, extensions: codex, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T22:54:27Z
+- live url: https://github.com/openclaw/openclaw/pull/82160
+
+### #82179 fix(volcengine): send coding plan thinking object
+
+- bucket: needs_proof
+- author: xuruiray
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, agents, size: S, extensions: volcengine, proof: supplied, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T22:55:07Z
+- live url: https://github.com/openclaw/openclaw/pull/82179
+
+### #82213 plugin-sdk: add runtime.session.cancel and channel.outbound.sendToSession
+
+- bucket: needs_proof
+- author: satoy-bot
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: S, triage: dirty-candidate, plugin: file-transfer, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-14T22:56:12Z
+- live url: https://github.com/openclaw/openclaw/pull/82213
+
+### #82240 feat(plugin-sdk): add longDescription to plugin approval payload
+
+- bucket: needs_proof
+- author: Rene0422
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: discord, channel: matrix, app: web-ui, gateway, size: S, proof: supplied, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-14T22:56:45Z
+- live url: https://github.com/openclaw/openclaw/pull/82240
+
+### #82355 Fix streamed chat completions dropping leading less-than
+
+- bucket: needs_proof
+- author: honor2030
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, agents, size: S, proof: supplied, P2, rating: silver shellfish, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-14T22:59:46Z
+- live url: https://github.com/openclaw/openclaw/pull/82355
+
+### #82373 Feature/pr 21b normal mode startup channel backoff
+
+- bucket: needs_proof
+- author: software-dev12
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, cli, scripts, size: XL, proof: supplied, dependencies-changed, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, merge-risk: availability, status: needs proof
+- live updated: 2026-06-14T23:00:08Z
+- live url: https://github.com/openclaw/openclaw/pull/82373
+
+### #82379 docs(lobster): enumerate injected runtime env vars and clarify step-output access
+
+- bucket: needs_proof
+- author: Sanjays2402
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: needs-real-behavior-proof, P2, rating: silver shellfish, status: waiting on author
+- live updated: 2026-06-14T23:00:18Z
+- live url: https://github.com/openclaw/openclaw/pull/82379
+
+### #82386 docs: sync maintainer roster source
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: maintainer, size: S, P3, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-14T23:00:29Z
+- live url: https://github.com/openclaw/openclaw/pull/82386
+
+### #82435 fix: broadcast tool result transcript updates
+
+- bucket: needs_proof
+- author: papayachat
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, P2, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-14T23:00:51Z
+- live url: https://github.com/openclaw/openclaw/pull/82435
+
+### #82495 fix(doctor): scope state dir scan to current home
+
+- bucket: ready_for_maintainer
+- author: lidge-jun
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T23:01:56Z
+- live url: https://github.com/openclaw/openclaw/pull/82495
+
+### #82505 fix: Canvas WebSocket creation in browser context silently swallows...
+
+- bucket: needs_proof
+- author: coygeek
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: mock-only-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T23:02:18Z
+- live url: https://github.com/openclaw/openclaw/pull/82505
+
+### #82514 feat(ui-i18n): localize Settings toolbar chrome strings (#46217 partial)
+
+- bucket: ready_for_maintainer
+- author: ObliviateRickLin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XL, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-14T23:03:02Z
+- live url: https://github.com/openclaw/openclaw/pull/82514
+
+### #82519 fix(test): stabilize red CI tests
+
+- bucket: needs_proof
+- author: lidge-jun
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: M, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-14T23:03:12Z
+- live url: https://github.com/openclaw/openclaw/pull/82519
+
+### #82520 fix: inject compaction summary into post-compaction context for seamless task continuation
+
+- bucket: needs_proof
+- author: sunvember
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: session-state, merge-risk: availability, status: needs proof
+- live updated: 2026-06-14T23:03:24Z
+- live url: https://github.com/openclaw/openclaw/pull/82520
+
+### #82536 perf: skip packageManager.resolve() by loading extensionFactories directly
+
+- bucket: needs_proof
+- author: sunvember
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-14T23:04:13Z
+- live url: https://github.com/openclaw/openclaw/pull/82536
+
+### #77559 [codex] Fix missing channel plugin diagnostics
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: maintainer, size: S, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-14T23:04:30Z
+- live url: https://github.com/openclaw/openclaw/pull/77559
+
+### #82552 fix(doctor): migrate legacy dreaming.storage string config (#70407)
+
+- bucket: needs_proof
+- author: ObliviateRickLin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: S, proof: supplied, proof: sufficient, P1, rating: silver shellfish, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-14T23:05:03Z
+- live url: https://github.com/openclaw/openclaw/pull/82552
+
+### #82562 fix(plugins): retain plugin tool registry after replacement
+
+- bucket: ready_for_maintainer
+- author: luoyanglang
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T23:05:24Z
+- live url: https://github.com/openclaw/openclaw/pull/82562
+
+### #82585 feat(synology-chat): add configurable triggerWord to replace payload-based stripping
+
+- bucket: needs_proof
+- author: iA2HVjA7ghZWWl2q9aoZ53f
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: S, channel: synology-chat, triage: needs-real-behavior-proof, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T23:06:04Z
+- live url: https://github.com/openclaw/openclaw/pull/82585
+
+### #82587 fix(minimax): resolve portal catalog OAuth via resolveProviderAuth (#79731)
+
+- bucket: needs_proof
+- author: ObliviateRickLin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: minimax, proof: supplied, P2, rating: unranked krab, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-14T23:06:09Z
+- live url: https://github.com/openclaw/openclaw/pull/82587
+
+### #82618 feat(edit): populate details.diff so HTML export renders edit changes (#82015)
+
+- bucket: needs_proof
+- author: therahul-yo
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P2, rating: unranked krab, status: waiting on author
+- live updated: 2026-06-14T23:06:16Z
+- live url: https://github.com/openclaw/openclaw/pull/82618
+
+### #82665 docs(messages): clarify session key queue lanes
+
+- bucket: ready_for_maintainer
+- author: vingov
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-14T23:06:31Z
+- live url: https://github.com/openclaw/openclaw/pull/82665
+
+### #80251 fix(sessions): rotate reset transcripts and clear compaction state
+
+- bucket: needs_proof
+- author: fredrikmacmini
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: M, proof: supplied, P1, rating: silver shellfish, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-14T23:07:12Z
+- live url: https://github.com/openclaw/openclaw/pull/80251
+
+### #82734 Bound tool transcript payloads
+
+- bucket: needs_proof
+- author: TheeMoneyTree
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T23:07:54Z
+- live url: https://github.com/openclaw/openclaw/pull/82734
+
+### #81176 feat(agents): add context-window-relative compaction budget shares
+
+- bucket: needs_proof
+- author: adone0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-14T23:08:16Z
+- live url: https://github.com/openclaw/openclaw/pull/81176
+
+### #81388 fix(session-cost-usage): fall back to O_EXCL write when fs.link is unsupported (#81089)
+
+- bucket: needs_proof
+- author: 0xghost42
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P2, rating: silver shellfish, merge-risk: availability, status: needs proof
+- live updated: 2026-06-14T23:08:29Z
+- live url: https://github.com/openclaw/openclaw/pull/81388
+
+### #82870 fix(agent): keep tool media authoritative in replies
+
+- bucket: ready_for_maintainer
+- author: Merlinzy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P1, rating: gold shrimp, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-14T23:08:50Z
+- live url: https://github.com/openclaw/openclaw/pull/82870
+
+### #82894 fix(gateway): prewarm agent runtime before ready
+
+- bucket: needs_proof
+- author: hansolo949
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: supplied, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-14T23:09:21Z
+- live url: https://github.com/openclaw/openclaw/pull/82894
+
+### #82895 fix(slack): preserve interaction thread status
+
+- bucket: draft
+- author: WuKongAI-CMU
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: channel: slack, size: S, proof: supplied, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T23:09:31Z
+- live url: https://github.com/openclaw/openclaw/pull/82895
+
+### #82906 fix(codex): gate CLI session resume behind plugin approval
+
+- bucket: ready_for_maintainer
+- author: LaPhilosophie
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: M, extensions: codex, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-14T23:09:44Z
+- live url: https://github.com/openclaw/openclaw/pull/82906
+
+### #82909 fix(telegram): repair message cache reply types
+
+- bucket: ready_for_maintainer
+- author: lidge-jun
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T23:09:55Z
+- live url: https://github.com/openclaw/openclaw/pull/82909
+
+### #82966 fix: return preserved totalTokens from resolveFreshSessionTotalTokens when stale (fixes #82900)
+
+- bucket: needs_proof
+- author: njuboy11
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-14T23:11:07Z
+- live url: https://github.com/openclaw/openclaw/pull/82966

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-006.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T110752-006
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#82971"
+  - "#82972"
+  - "#82985"
+  - "#83010"
+  - "#83041"
+  - "#83048"
+  - "#83081"
+  - "#90419"
+  - "#90065"
+  - "#90477"
+  - "#90125"
+  - "#90155"
+  - "#90489"
+  - "#90156"
+  - "#90182"
+  - "#90204"
+  - "#78591"
+  - "#90537"
+  - "#90586"
+  - "#90611"
+  - "#83161"
+  - "#83178"
+  - "#83203"
+  - "#83227"
+  - "#83242"
+  - "#83254"
+  - "#83295"
+  - "#83296"
+  - "#83368"
+  - "#83383"
+  - "#93093"
+  - "#83391"
+  - "#83458"
+  - "#83489"
+  - "#83492"
+  - "#83573"
+  - "#83590"
+  - "#83611"
+  - "#83629"
+  - "#83630"
+cluster_refs:
+  - "#82971"
+  - "#82972"
+  - "#82985"
+  - "#83010"
+  - "#83041"
+  - "#83048"
+  - "#83081"
+  - "#90419"
+  - "#90065"
+  - "#90477"
+  - "#90125"
+  - "#90155"
+  - "#90489"
+  - "#90156"
+  - "#90182"
+  - "#90204"
+  - "#78591"
+  - "#90537"
+  - "#90586"
+  - "#90611"
+  - "#83161"
+  - "#83178"
+  - "#83203"
+  - "#83227"
+  - "#83242"
+  - "#83254"
+  - "#83295"
+  - "#83296"
+  - "#83368"
+  - "#83383"
+  - "#93093"
+  - "#83391"
+  - "#83458"
+  - "#83489"
+  - "#83492"
+  - "#83573"
+  - "#83590"
+  - "#83611"
+  - "#83629"
+  - "#83630"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T11:07:52.837Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 6
+
+This is a high-volume live inventory shard over open pull requests, including previously represented PRs being refreshed against live GitHub state.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #82971 [codex] Guard Control UI protocol in npm release check
+
+- bucket: needs_proof
+- author: lamkan0210
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: automation, status: needs proof
+- live updated: 2026-06-14T23:11:19Z
+- live url: https://github.com/openclaw/openclaw/pull/82971
+
+### #82972 fix(discord): scope message-tool schema groups to advertised actions
+
+- bucket: needs_proof
+- author: lonexreb
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, P1, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-14T23:11:23Z
+- live url: https://github.com/openclaw/openclaw/pull/82972
+
+### #82985 feat(plugins): pass engine candidates to MemoryCorpusSupplement.search
+
+- bucket: ready_for_maintainer
+- author: ubehera
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, extensions: memory-core, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T23:11:37Z
+- live url: https://github.com/openclaw/openclaw/pull/82985
+
+### #83010 gateway: standardize URL base to localhost in mcp-http and tools-invoke handlers
+
+- bucket: needs_proof
+- author: YonganZhang
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, proof: supplied, P3, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-14T23:12:17Z
+- live url: https://github.com/openclaw/openclaw/pull/83010
+
+### #83041 Fix config patch restart-required notices
+
+- bucket: ready_for_maintainer
+- author: xuruiray
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: supplied, proof: sufficient, P3, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-14T23:12:29Z
+- live url: https://github.com/openclaw/openclaw/pull/83041
+
+### #83048 fix(a2a): resolve direct/dm announce target from session-key fallback
+
+- bucket: ready_for_maintainer
+- author: avatasia
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T23:12:51Z
+- live url: https://github.com/openclaw/openclaw/pull/83048
+
+### #83081 fix(channels): protect channel config repair paths
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc, shakkernerd
+- labels: docs, channel: line, channel: matrix, channel: nextcloud-talk, channel: telegram, channel: whatsapp-web, gateway, cli, scripts, commands, docker, maintainer, channel: feishu, size: XL, channel: qqbot, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-14T23:13:14Z
+- live url: https://github.com/openclaw/openclaw/pull/83081
+
+### #90419 fix: force-release session lock on dispose to prevent orphan locks
+
+- bucket: needs_proof
+- author: longkunbetter
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: session-state, merge-risk: availability, status: needs proof
+- live updated: 2026-06-14T23:16:22Z
+- live url: https://github.com/openclaw/openclaw/pull/90419
+
+### #90065 fix(agents): bound abort-path session lock release; force-release on unsettled retained writes
+
+- bucket: needs_proof
+- author: matin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: session-state, merge-risk: availability, status: needs proof
+- live updated: 2026-06-14T23:17:32Z
+- live url: https://github.com/openclaw/openclaw/pull/90065
+
+### #90477 fix: defer WhatsApp visible-reply typing until send start
+
+- bucket: maintainer_owned
+- author: mcaxtr
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: docs, channel: whatsapp-web, maintainer, size: L, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-14T23:17:53Z
+- live url: https://github.com/openclaw/openclaw/pull/90477
+
+### #90125 fix(embedded-runner): distinguish model initialization errors from assistant execution errors
+
+- bucket: needs_proof
+- author: bladin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-14T23:17:59Z
+- live url: https://github.com/openclaw/openclaw/pull/90125
+
+### #90155 fix(channels): guard legacy config rule metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, P2, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-14T23:18:03Z
+- live url: https://github.com/openclaw/openclaw/pull/90155
+
+### #90489 fix(sessions): clarify cross-agent visibility guidance
+
+- bucket: ready_for_maintainer
+- author: sahibzada-allahyar
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T23:18:05Z
+- live url: https://github.com/openclaw/openclaw/pull/90489
+
+### #90156 fix(agent-runtime): guard prompt cache tool names
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: XS, P2, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-14T23:18:11Z
+- live url: https://github.com/openclaw/openclaw/pull/90156
+
+### #90182 fix(plugins): isolate definition metadata failures
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-14T23:18:16Z
+- live url: https://github.com/openclaw/openclaw/pull/90182
+
+### #90204 fix(windows): resolve compatibility, path redaction, symlink EPERM, and channel sorting issues
+
+- bucket: needs_proof
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T23:18:32Z
+- live url: https://github.com/openclaw/openclaw/pull/90204
+
+### #78591 fix(channels): list channel catalog status
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: cli, commands, maintainer, size: M, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T23:36:31Z
+- live url: https://github.com/openclaw/openclaw/pull/78591
+
+### #90537 Warn on generated wrapper overwrites and status diagnostics
+
+- bucket: ready_for_maintainer
+- author: TurboTheTurtle
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, cli, commands, size: M, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-14T23:51:45Z
+- live url: https://github.com/openclaw/openclaw/pull/90537
+
+### #90586 fix(telegram): avoid restarts for runtime reloads
+
+- bucket: needs_proof
+- author: sahibzada-allahyar
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, gateway, size: S, proof: supplied, proof: sufficient, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-14T23:52:55Z
+- live url: https://github.com/openclaw/openclaw/pull/90586
+
+### #90611 feat(i18n): localize runtime user-facing copy
+
+- bucket: maintainer_owned
+- author: lanzhi-lee
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: channel: imessage, app: web-ui, gateway, agents, size: L, extensions: qa-lab, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-14T23:53:18Z
+- live url: https://github.com/openclaw/openclaw/pull/90611
+
+### #83161 fix(telegram): move preview-streamed dedup to channel layer (#80520)
+
+- bucket: needs_proof
+- author: Elarwei001
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: M, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P1, rating: unranked krab, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-15T00:04:29Z
+- live url: https://github.com/openclaw/openclaw/pull/83161
+
+### #83178 fix(memory-flush): fallback to estimatePromptTokensFromSessionTranscript when usage data is unavailable
+
+- bucket: needs_proof
+- author: njuboy11
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-15T00:05:22Z
+- live url: https://github.com/openclaw/openclaw/pull/83178
+
+### #83203 fix(gateway): separate finish_reason from content chunks in streaming
+
+- bucket: needs_proof
+- author: niuma996
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-15T00:05:39Z
+- live url: https://github.com/openclaw/openclaw/pull/83203
+
+### #83227 fix(openai): mark mp3 TTS voice output compatible
+
+- bucket: ready_for_maintainer
+- author: HemantSudarshan
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: openai, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T00:06:09Z
+- live url: https://github.com/openclaw/openclaw/pull/83227
+
+### #83242 fix(ui): clarify imported insights cluster tabs
+
+- bucket: needs_proof
+- author: HemantSudarshan
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: M, triage: mock-only-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-15T00:06:41Z
+- live url: https://github.com/openclaw/openclaw/pull/83242
+
+### #83254 fix(telegram): stamp bot api user agent
+
+- bucket: needs_proof
+- author: HemantSudarshan
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: S, proof: supplied, P2, rating: gold shrimp, status: needs proof
+- live updated: 2026-06-15T00:07:15Z
+- live url: https://github.com/openclaw/openclaw/pull/83254
+
+### #83295 perf(agents): bootstrap context cache, PI model-discovery cache, auth-store option keys, tool-descriptor kill switch
+
+- bucket: needs_proof
+- author: atlaspetco
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-15T00:08:12Z
+- live url: https://github.com/openclaw/openclaw/pull/83295
+
+### #83296 Avoid writing plaintext profile keys to models.json
+
+- bucket: ready_for_maintainer
+- author: JackSpiece
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: gold shrimp, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-15T00:08:31Z
+- live url: https://github.com/openclaw/openclaw/pull/83296
+
+### #83368 fix(gateway): preserve raw external session aliases
+
+- bucket: needs_proof
+- author: stainlu
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XL, proof: supplied, proof: sufficient, P2, rating: unranked krab, merge-risk: session-state, status: waiting on author
+- live updated: 2026-06-15T00:09:46Z
+- live url: https://github.com/openclaw/openclaw/pull/83368
+
+### #83383 fix(auth): clean refresh contention diagnostics
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: M, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T00:10:03Z
+- live url: https://github.com/openclaw/openclaw/pull/83383
+
+### #93093 docs(memory): warn about session memory overlap
+
+- bucket: ready_for_maintainer
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T00:10:15Z
+- live url: https://github.com/openclaw/openclaw/pull/93093
+
+### #83391 fix(cli): harden config and command validation
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: commands, maintainer, size: M, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T00:10:23Z
+- live url: https://github.com/openclaw/openclaw/pull/83391
+
+### #83458 fix(feishu): preserve ACP topic conversation bindings
+
+- bucket: needs_proof
+- author: veryoung
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, channel: feishu, size: S, triage: mock-only-proof, P2, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-15T00:12:04Z
+- live url: https://github.com/openclaw/openclaw/pull/83458
+
+### #83489 Fix gateway service startup race
+
+- bucket: ready_for_maintainer
+- author: ThiagoCAltoe
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, triage: refactor-only, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-15T00:12:16Z
+- live url: https://github.com/openclaw/openclaw/pull/83489
+
+### #83492 fix: skip TTS for explicit command replies
+
+- bucket: needs_proof
+- author: honor2030
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-15T00:12:20Z
+- live url: https://github.com/openclaw/openclaw/pull/83492
+
+### #83573 feat(mattermost): add /model dialog picker
+
+- bucket: maintainer_owned
+- author: mukhtharcm
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: docs, channel: mattermost, size: XL, proof: supplied, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-15T00:14:12Z
+- live url: https://github.com/openclaw/openclaw/pull/83573
+
+### #83590 plugin-sdk: restore legacy compat helper exports
+
+- bucket: needs_proof
+- author: san-tian
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T00:14:21Z
+- live url: https://github.com/openclaw/openclaw/pull/83590
+
+### #83611 feat: add shared notification wake policy
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: docs, channel: discord, channel: telegram, maintainer, size: L, mantis: telegram-visible-proof, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-15T00:15:01Z
+- live url: https://github.com/openclaw/openclaw/pull/83611
+
+### #83629 fix(sessions): include subagent metadata in json
+
+- bucket: needs_proof
+- author: YuanHanzhong
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: S, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-15T00:15:23Z
+- live url: https://github.com/openclaw/openclaw/pull/83629
+
+### #83630 fix(doctor): preview missing transcript cleanup
+
+- bucket: needs_proof
+- author: YuanHanzhong
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: supplied, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-15T00:15:27Z
+- live url: https://github.com/openclaw/openclaw/pull/83630

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-007.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-007.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T110752-007
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#83665"
+  - "#83703"
+  - "#83715"
+  - "#83718"
+  - "#83760"
+  - "#83819"
+  - "#83826"
+  - "#83842"
+  - "#83862"
+  - "#90738"
+  - "#79397"
+  - "#80681"
+  - "#80683"
+  - "#80707"
+  - "#80788"
+  - "#80928"
+  - "#80981"
+  - "#81164"
+  - "#81208"
+  - "#81258"
+  - "#81352"
+  - "#81407"
+  - "#81418"
+  - "#81470"
+  - "#81572"
+  - "#81592"
+  - "#81736"
+  - "#81786"
+  - "#83980"
+  - "#84023"
+  - "#84028"
+  - "#84060"
+  - "#84072"
+  - "#84111"
+  - "#84122"
+  - "#84123"
+  - "#84140"
+  - "#84156"
+  - "#84157"
+  - "#84248"
+cluster_refs:
+  - "#83665"
+  - "#83703"
+  - "#83715"
+  - "#83718"
+  - "#83760"
+  - "#83819"
+  - "#83826"
+  - "#83842"
+  - "#83862"
+  - "#90738"
+  - "#79397"
+  - "#80681"
+  - "#80683"
+  - "#80707"
+  - "#80788"
+  - "#80928"
+  - "#80981"
+  - "#81164"
+  - "#81208"
+  - "#81258"
+  - "#81352"
+  - "#81407"
+  - "#81418"
+  - "#81470"
+  - "#81572"
+  - "#81592"
+  - "#81736"
+  - "#81786"
+  - "#83980"
+  - "#84023"
+  - "#84028"
+  - "#84060"
+  - "#84072"
+  - "#84111"
+  - "#84122"
+  - "#84123"
+  - "#84140"
+  - "#84156"
+  - "#84157"
+  - "#84248"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T11:07:52.837Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 7
+
+This is a high-volume live inventory shard over open pull requests, including previously represented PRs being refreshed against live GitHub state.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #83665 fix(codex): unwrap app-server auth token wrappers
+
+- bucket: needs_proof
+- author: ecochran76
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: codex, triage: mock-only-proof, P2, rating: unranked krab, merge-risk: auth-provider, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-15T00:16:02Z
+- live url: https://github.com/openclaw/openclaw/pull/83665
+
+### #83703 Add Claude ignore rules for generated assets
+
+- bucket: needs_proof
+- author: sravan27
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P3, rating: silver shellfish, merge-risk: automation, status: needs proof
+- live updated: 2026-06-15T00:16:56Z
+- live url: https://github.com/openclaw/openclaw/pull/83703
+
+### #83715 [codex] Guard doctor repairs for newer configs
+
+- bucket: draft
+- author: ejames-dev
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: commands, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-15T00:17:06Z
+- live url: https://github.com/openclaw/openclaw/pull/83715
+
+### #83718 fix(memory-core): treat dreaming fence marker lines as inside-fence in promotion guard (#80613)
+
+- bucket: ready_for_maintainer
+- author: grifjef
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T00:17:12Z
+- live url: https://github.com/openclaw/openclaw/pull/83718
+
+### #83760 feat(comfy): dynamic aspect ratio width/height injection
+
+- bucket: needs_proof
+- author: sola-ryu
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, agents, size: L, triage: needs-real-behavior-proof, proof: sufficient, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-15T00:17:56Z
+- live url: https://github.com/openclaw/openclaw/pull/83760
+
+### #83819 fix(heartbeat-runner): add wakeGuard pre-flight hook to skip no-op wakes (OME-332)
+
+- bucket: draft
+- author: Omerbahari
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: availability, status: needs proof
+- live updated: 2026-06-15T00:18:31Z
+- live url: https://github.com/openclaw/openclaw/pull/83819
+
+### #83826 test(android): poll for stale TLS probe cleanup in auth test
+
+- bucket: needs_proof
+- author: NeatGuyCoding
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: android, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-15T00:18:35Z
+- live url: https://github.com/openclaw/openclaw/pull/83826
+
+### #83842 fix(discord): add native reply opt-out
+
+- bucket: ready_for_maintainer
+- author: reirei-agent
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T00:18:49Z
+- live url: https://github.com/openclaw/openclaw/pull/83842
+
+### #83862 fix(cli): add configure and onboard to interactive TTY command skip list
+
+- bucket: needs_proof
+- author: lml2468
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: availability, status: needs proof
+- live updated: 2026-06-15T00:19:07Z
+- live url: https://github.com/openclaw/openclaw/pull/83862
+
+### #90738 fix(msteams): read file attachments on Teams channel messages (team GUID + channel fallback + thread-reply URL)
+
+- bucket: ready_for_maintainer
+- author: colton-octaria
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: msteams, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T00:25:56Z
+- live url: https://github.com/openclaw/openclaw/pull/90738
+
+### #79397 fix(nextcloud-talk): parse structured mention payloads
+
+- bucket: ready_for_maintainer
+- author: iclem
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: nextcloud-talk, size: L, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T00:36:59Z
+- live url: https://github.com/openclaw/openclaw/pull/79397
+
+### #80681 feat(trajectory): allow OPENCLAW_TRAJECTORY_RUNTIME_EVENT_MAX_BYTES override for per-event byte cap
+
+- bucket: ready_for_maintainer
+- author: wAngByg
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: M, extensions: codex, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T00:38:02Z
+- live url: https://github.com/openclaw/openclaw/pull/80681
+
+### #80683 fix(memory-lancedb): add retry mechanism for Windows Docker bind mount sync delays
+
+- bucket: needs_proof
+- author: mturac
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-lancedb, size: M, proof: supplied, P2, rating: silver shellfish, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-15T00:38:11Z
+- live url: https://github.com/openclaw/openclaw/pull/80683
+
+### #80707 fix(cron): guard task liveness during startup
+
+- bucket: needs_proof
+- author: nanookclaw
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P2, rating: unranked krab, merge-risk: session-state, status: waiting on author
+- live updated: 2026-06-15T00:38:22Z
+- live url: https://github.com/openclaw/openclaw/pull/80707
+
+### #80788 Fix Discord gzip response parsing
+
+- bucket: maintainer_owned
+- author: jbetala7
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: channel: discord, stale, size: S, proof: supplied, proof: sufficient, P1, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-15T00:38:26Z
+- live url: https://github.com/openclaw/openclaw/pull/80788
+
+### #80928 fix(telegram): suppress fallback reply when plugin command returns suppressReply: true
+
+- bucket: ready_for_maintainer
+- author: alexuser
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, size: XS, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look, proof: video
+- live updated: 2026-06-15T00:38:32Z
+- live url: https://github.com/openclaw/openclaw/pull/80928
+
+### #80981 docs(cli): clarify strict json parsing
+
+- bucket: ready_for_maintainer
+- author: addu2612
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-15T00:38:36Z
+- live url: https://github.com/openclaw/openclaw/pull/80981
+
+### #81164 feat(context-engine): add interceptCompaction contract for context-engine plugins
+
+- bucket: maintainer_owned
+- author: 100yenadmin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: jalehman
+- labels: docs, agents, stale, size: XL, extensions: codex, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: availability, status: needs proof
+- live updated: 2026-06-15T00:39:04Z
+- live url: https://github.com/openclaw/openclaw/pull/81164
+
+### #81208 fix(amazon-bedrock-mantle): gate implicit discovery on AWS creds presence (#67288)
+
+- bucket: needs_proof
+- author: lonexreb
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-15T00:39:08Z
+- live url: https://github.com/openclaw/openclaw/pull/81208
+
+### #81258 feat(feishu): add tts.preserveText to keep text alongside voice media
+
+- bucket: needs_proof
+- author: KhanCold
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: feishu, size: S, proof: supplied, proof: sufficient, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-15T00:39:53Z
+- live url: https://github.com/openclaw/openclaw/pull/81258
+
+### #81352 Require non-empty owner keys for task access
+
+- bucket: needs_proof
+- author: MarkSurfas
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-15T00:40:50Z
+- live url: https://github.com/openclaw/openclaw/pull/81352
+
+### #81407 feat(hooks): add senderId to outbound message:sent event
+
+- bucket: needs_proof
+- author: haseo-ai
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: refactor-only, triage: blank-template, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-15T00:41:25Z
+- live url: https://github.com/openclaw/openclaw/pull/81407
+
+### #81418 fix(mcp): parent-PID watchdog to prevent orphan channel-server workers
+
+- bucket: needs_proof
+- author: 22kyasue
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-15T00:41:42Z
+- live url: https://github.com/openclaw/openclaw/pull/81418
+
+### #81470 fix(webchat): include TTS audio in broadcastChatFinal when media already appended
+
+- bucket: needs_proof
+- author: zlh66
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-15T00:42:18Z
+- live url: https://github.com/openclaw/openclaw/pull/81470
+
+### #81572 fix(cron): persist due job outcomes incrementally
+
+- bucket: ready_for_maintainer
+- author: efpiva
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-15T00:43:37Z
+- live url: https://github.com/openclaw/openclaw/pull/81572
+
+### #81592 [codex] Route Telegram management commands to the control lane
+
+- bucket: draft
+- author: Kyzcreig
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: channel: telegram, size: XS, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P1, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-15T00:43:42Z
+- live url: https://github.com/openclaw/openclaw/pull/81592
+
+### #81736 feat(catalog): add DingTalk to official external channel catalog
+
+- bucket: maintainer_owned
+- author: meng93
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: sliverp
+- labels: scripts, stale, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-15T00:44:54Z
+- live url: https://github.com/openclaw/openclaw/pull/81736
+
+### #81786 chore(agent): port audit guardrails to mainline
+
+- bucket: needs_proof
+- author: chkh6
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, commands, agents, size: XL, extensions: qa-lab, proof: supplied, proof: sufficient, dependencies-changed, P2, rating: silver shellfish, merge-risk: automation, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-15T00:45:33Z
+- live url: https://github.com/openclaw/openclaw/pull/81786
+
+### #83980 fix: stabilize macOS app node connection and eliminate pairing file read/write race
+
+- bucket: needs_proof
+- author: AllynSheep
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: M, proof: supplied, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: availability, status: needs proof
+- live updated: 2026-06-15T00:49:24Z
+- live url: https://github.com/openclaw/openclaw/pull/83980
+
+### #84023 Emit WhatsApp Web health hook events
+
+- bucket: needs_proof
+- author: girgizrazvan-lgtm
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: whatsapp-web, size: S, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-15T00:50:19Z
+- live url: https://github.com/openclaw/openclaw/pull/84023
+
+### #84028 fix(ui): improve Arabic Control UI translations
+
+- bucket: ready_for_maintainer
+- author: aim9sour
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T00:50:26Z
+- live url: https://github.com/openclaw/openclaw/pull/84028
+
+### #84060 refactor(terminal): optimize OSC progress label sanitization
+
+- bucket: needs_proof
+- author: esadomer
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P3, rating: silver shellfish, status: waiting on author
+- live updated: 2026-06-15T00:50:59Z
+- live url: https://github.com/openclaw/openclaw/pull/84060
+
+### #84072 [codex] Add model fallback circuit breaker
+
+- bucket: needs_proof
+- author: wiatrM
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: refactor-only, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: availability, status: needs proof
+- live updated: 2026-06-15T00:51:12Z
+- live url: https://github.com/openclaw/openclaw/pull/84072
+
+### #84111 feat (auth): offer interactive repair for undecryptable legacy agent OAuth sidecars
+
+- bucket: needs_proof
+- author: bdjben
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: L, triage: refactor-only, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-15T00:51:38Z
+- live url: https://github.com/openclaw/openclaw/pull/84111
+
+### #84122 fix(feishu): use middle-dot separator in card note footer
+
+- bucket: needs_proof
+- author: bugkill3r
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: XS, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-15T00:52:11Z
+- live url: https://github.com/openclaw/openclaw/pull/84122
+
+### #84123 feat(google-vertex): support per-model location override
+
+- bucket: needs_proof
+- author: bugkill3r
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-15T00:52:15Z
+- live url: https://github.com/openclaw/openclaw/pull/84123
+
+### #84140 chore: format oxfmt-touched files
+
+- bucket: ready_for_maintainer
+- author: tw19880217-creator
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, cli, scripts, commands, agents, size: M, extensions: kimi-coding, extensions: qa-lab, extensions: memory-wiki, triage: refactor-only, triage: dirty-candidate, extensions: deepinfra, proof: supplied, proof: sufficient, extensions: oc-path, extensions: google, extensions: openrouter, P3, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-15T00:52:52Z
+- live url: https://github.com/openclaw/openclaw/pull/84140
+
+### #84156 fix(cron): respect recovered tool errors
+
+- bucket: ready_for_maintainer
+- author: Elarwei001
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T00:53:09Z
+- live url: https://github.com/openclaw/openclaw/pull/84156
+
+### #84157 fix(sessions): heal stale running rows on abort no-active-run and restart
+
+- bucket: needs_proof
+- author: Marvae
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, agents, size: M, proof: supplied, proof: sufficient, P1, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-15T00:53:17Z
+- live url: https://github.com/openclaw/openclaw/pull/84157
+
+### #84248 [codex] isolate heartbeat context-engine session keys
+
+- bucket: needs_proof
+- author: NianJiuZst
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, extensions: codex, proof: supplied, P1, rating: silver shellfish, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-15T00:55:26Z
+- live url: https://github.com/openclaw/openclaw/pull/84248

--- a/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-008.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260618T110752-008.md
@@ -1,0 +1,564 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260618T110752-008
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#84280"
+  - "#84288"
+  - "#84326"
+  - "#84334"
+  - "#84340"
+  - "#84352"
+  - "#84424"
+  - "#81467"
+  - "#83874"
+  - "#85179"
+  - "#78071"
+  - "#78815"
+  - "#78827"
+  - "#79185"
+  - "#80181"
+  - "#81278"
+  - "#81279"
+  - "#83095"
+  - "#83274"
+  - "#84292"
+  - "#84366"
+  - "#84438"
+  - "#84441"
+  - "#84453"
+  - "#84461"
+  - "#84465"
+  - "#84485"
+  - "#84547"
+  - "#84554"
+  - "#84563"
+  - "#84566"
+  - "#84578"
+  - "#84582"
+  - "#84584"
+  - "#84589"
+  - "#84602"
+  - "#84603"
+  - "#84613"
+  - "#84617"
+  - "#84636"
+cluster_refs:
+  - "#84280"
+  - "#84288"
+  - "#84326"
+  - "#84334"
+  - "#84340"
+  - "#84352"
+  - "#84424"
+  - "#81467"
+  - "#83874"
+  - "#85179"
+  - "#78071"
+  - "#78815"
+  - "#78827"
+  - "#79185"
+  - "#80181"
+  - "#81278"
+  - "#81279"
+  - "#83095"
+  - "#83274"
+  - "#84292"
+  - "#84366"
+  - "#84438"
+  - "#84441"
+  - "#84453"
+  - "#84461"
+  - "#84465"
+  - "#84485"
+  - "#84547"
+  - "#84554"
+  - "#84563"
+  - "#84566"
+  - "#84578"
+  - "#84582"
+  - "#84584"
+  - "#84589"
+  - "#84602"
+  - "#84603"
+  - "#84613"
+  - "#84617"
+  - "#84636"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-18T11:07:52.838Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 8
+
+This is a high-volume live inventory shard over open pull requests, including previously represented PRs being refreshed against live GitHub state.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #84280 fix: handle SIGUSR1 restart on Windows where the signal is unsupported
+
+- bucket: needs_proof
+- author: Thatgfsj
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, proof: supplied, P2, rating: unranked krab, merge-risk: availability, status: needs proof
+- live updated: 2026-06-15T00:55:56Z
+- live url: https://github.com/openclaw/openclaw/pull/84280
+
+### #84288 fix(discord): avoid duplicate typing keepalive for tool replies
+
+- bucket: ready_for_maintainer
+- author: dr00-eth
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: S, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T00:56:08Z
+- live url: https://github.com/openclaw/openclaw/pull/84288
+
+### #84326 Doctor: expose sandbox registry findings
+
+- bucket: maintainer_owned
+- author: giodl73-repo
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: docs, commands, maintainer, size: XL, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof, proof: screenshot
+- live updated: 2026-06-15T00:56:46Z
+- live url: https://github.com/openclaw/openclaw/pull/84326
+
+### #84334 fix(gateway): mark SIGUSR1 token consumed on restartIntent path, reset stale tokens on in-process restart
+
+- bucket: needs_proof
+- author: 6a6f686e6e79
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: availability, status: needs proof
+- live updated: 2026-06-15T00:56:51Z
+- live url: https://github.com/openclaw/openclaw/pull/84334
+
+### #84340 Doctor: expose extra gateway service findings
+
+- bucket: maintainer_owned
+- author: giodl73-repo
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: docs, commands, maintainer, size: XL, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-15T00:57:01Z
+- live url: https://github.com/openclaw/openclaw/pull/84340
+
+### #84352 Fix WebChat dispatch failure session status
+
+- bucket: maintainer_owned
+- author: jesse-merhi
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, maintainer, size: XL, P2, rating: unranked krab, merge-risk: session-state, status: waiting on author, proof: video
+- live updated: 2026-06-15T00:57:20Z
+- live url: https://github.com/openclaw/openclaw/pull/84352
+
+### #84424 fix(doctor): honor per-agent bootstrap profile in size check
+
+- bucket: needs_proof
+- author: kasangyong
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: S, triage: needs-real-behavior-proof, P2, rating: gold shrimp, status: needs proof
+- live updated: 2026-06-15T00:57:43Z
+- live url: https://github.com/openclaw/openclaw/pull/84424
+
+### #81467 fix(usage): show every calendar day in Daily Token Usage / Daily Cost chart
+
+- bucket: ready_for_maintainer
+- author: adapepper
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T01:00:46Z
+- live url: https://github.com/openclaw/openclaw/pull/81467
+
+### #83874 feat: add agent architecture runtime contracts
+
+- bucket: needs_proof
+- author: seanzhao-debug
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: web-ui, cli, agents, size: XL, extensions: qa-lab, extensions: memory-wiki, proof: supplied, extensions: google, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-15T01:00:58Z
+- live url: https://github.com/openclaw/openclaw/pull/83874
+
+### #85179 test(qa-lab): add personal redacted traceability scenario
+
+- bucket: needs_proof
+- author: iFiras-Max1
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: M, extensions: qa-lab, proof: supplied, proof: sufficient, P3, rating: gold shrimp, status: waiting on author
+- live updated: 2026-06-15T01:07:10Z
+- live url: https://github.com/openclaw/openclaw/pull/85179
+
+### #78071 test(gateway): cover reserved admin method scopes
+
+- bucket: needs_proof
+- author: bryce-d-greybeard
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, proof: supplied, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-15T01:22:11Z
+- live url: https://github.com/openclaw/openclaw/pull/78071
+
+### #78815 fix(compaction): resolve Claude CLI model aliases
+
+- bucket: needs_proof
+- author: mobykax949
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: L, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-15T01:22:43Z
+- live url: https://github.com/openclaw/openclaw/pull/78815
+
+### #78827 fix(agents): handle MiniMax prompt_cache_hit_tokens in normalizeUsage
+
+- bucket: draft
+- author: lykeion-dev
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: agents, size: XS, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-15T01:22:47Z
+- live url: https://github.com/openclaw/openclaw/pull/78827
+
+### #79185 fix(tts/xiaomi): support Token Plan TTS endpoint
+
+- bucket: needs_proof
+- author: kidding1412
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: S, extensions: xiaomi, extensions: tts-local-cli, plugin: azure-speech, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-15T01:23:03Z
+- live url: https://github.com/openclaw/openclaw/pull/79185
+
+### #80181 fix: add resilient fallback policy for user model overrides
+
+- bucket: needs_proof
+- author: jetd1
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, agents, size: M, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: auth-provider, status: waiting on author
+- live updated: 2026-06-15T01:23:44Z
+- live url: https://github.com/openclaw/openclaw/pull/80181
+
+### #81278 docs: clarify local-prefix managed Node runtime
+
+- bucket: needs_proof
+- author: ThiagoCAltoe
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, scripts, size: XS, proof: supplied, proof: sufficient, P3, rating: gold shrimp, status: waiting on author
+- live updated: 2026-06-15T01:23:56Z
+- live url: https://github.com/openclaw/openclaw/pull/81278
+
+### #81279 ui(i18n): localize skills page grouping labels, status chips and missing prefixes for zh-CN
+
+- bucket: needs_proof
+- author: git-jxj
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XL, proof: supplied, proof: sufficient, P3, rating: gold shrimp, status: waiting on author, proof: screenshot
+- live updated: 2026-06-15T01:24:06Z
+- live url: https://github.com/openclaw/openclaw/pull/81279
+
+### #83095 fix(canvas): prefer path-scoped capability tokens
+
+- bucket: needs_proof
+- author: LaPhilosophie
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, proof: supplied, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-15T01:24:53Z
+- live url: https://github.com/openclaw/openclaw/pull/83095
+
+### #83274 Fix subagent thread spawn safety
+
+- bucket: needs_proof
+- author: Svetznaniy33
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, agents, size: M, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-15T01:25:22Z
+- live url: https://github.com/openclaw/openclaw/pull/83274
+
+### #84292 fix(agents): preserve delivered message send results
+
+- bucket: needs_proof
+- author: zerone0x
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, P2, rating: silver shellfish, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-15T01:26:41Z
+- live url: https://github.com/openclaw/openclaw/pull/84292
+
+### #84366 Doctor: expose session lock findings
+
+- bucket: maintainer_owned
+- author: giodl73-repo
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: docs, commands, maintainer, size: XL, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-15T01:26:50Z
+- live url: https://github.com/openclaw/openclaw/pull/84366
+
+### #84438 fix(cli): use flag terminator constant
+
+- bucket: needs_proof
+- author: humanbeingz-7
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, triage: needs-real-behavior-proof, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T01:27:00Z
+- live url: https://github.com/openclaw/openclaw/pull/84438
+
+### #84441 fix(outbound): sanitize assistant reasoning before delivery
+
+- bucket: needs_proof
+- author: spinnakerbuilding-debug
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-15T01:27:03Z
+- live url: https://github.com/openclaw/openclaw/pull/84441
+
+### #84453 fix(scripts): detect destructured/re-export/dynamic imports in dist scanner
+
+- bucket: ready_for_maintainer
+- author: iFwu
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: L, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: automation, status: ready for maintainer look
+- live updated: 2026-06-15T01:27:26Z
+- live url: https://github.com/openclaw/openclaw/pull/84453
+
+### #84461 feat(channels/telegram): per-sender inbound rate limit
+
+- bucket: needs_proof
+- author: ralflukner
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: L, proof: supplied, mantis: telegram-visible-proof, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: message-delivery, merge-risk: availability, status: needs proof
+- live updated: 2026-06-15T01:27:32Z
+- live url: https://github.com/openclaw/openclaw/pull/84461
+
+### #84465 Strip apiKey fields from generated models.json
+
+- bucket: needs_proof
+- author: javi-codeworks
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: waiting on author
+- live updated: 2026-06-15T01:27:36Z
+- live url: https://github.com/openclaw/openclaw/pull/84465
+
+### #84485 fix(discord): guard message-tool-only final delivery
+
+- bucket: ready_for_maintainer
+- author: anyech
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XL, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-15T01:28:08Z
+- live url: https://github.com/openclaw/openclaw/pull/84485
+
+### #84547 perf: attach jiti-normalized alias via source-object property
+
+- bucket: needs_proof
+- author: jokemanfire
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: M, triage: needs-real-behavior-proof, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-15T01:28:56Z
+- live url: https://github.com/openclaw/openclaw/pull/84547
+
+### #84554 fix(memory-core): guard builtin fallback after qmd failures
+
+- bucket: ready_for_maintainer
+- author: jetd1
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T01:28:59Z
+- live url: https://github.com/openclaw/openclaw/pull/84554
+
+### #84563 fix(telegram): avoid silent truncation in partial streaming finals
+
+- bucket: needs_proof
+- author: vice-magus-faolan
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: M, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P1, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-15T01:29:22Z
+- live url: https://github.com/openclaw/openclaw/pull/84563
+
+### #84566 [codex] fix: omit provider api keys from generated models.json
+
+- bucket: draft
+- author: piaoguodeafei
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-15T01:29:26Z
+- live url: https://github.com/openclaw/openclaw/pull/84566
+
+### #84578 fix(whatsapp): deliver final error payloads so incomplete-turn errors reach users
+
+- bucket: needs_proof
+- author: NianJiuZst
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: whatsapp-web, size: XS, proof: supplied, P1, rating: silver shellfish, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-15T01:30:01Z
+- live url: https://github.com/openclaw/openclaw/pull/84578
+
+### #84582 fix(net): conditionalize proxyTls only for HTTPS proxies to fix Telegram plugin proxy issues
+
+- bucket: needs_proof
+- author: tanjingme
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-15T01:30:22Z
+- live url: https://github.com/openclaw/openclaw/pull/84582
+
+### #84584 fix: enforce slash command boundaries
+
+- bucket: ready_for_maintainer
+- author: JulyanXu
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T01:30:28Z
+- live url: https://github.com/openclaw/openclaw/pull/84584
+
+### #84589 fix(message): describe channel parameter as provider name
+
+- bucket: ready_for_maintainer
+- author: spacegeologist
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: automation, status: ready for maintainer look
+- live updated: 2026-06-15T01:30:34Z
+- live url: https://github.com/openclaw/openclaw/pull/84589
+
+### #84602 fix(agents): surface user-visible error when embedded session is stuck or overflows context (#84536)
+
+- bucket: needs_proof
+- author: lml2468
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P1, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-15T01:31:08Z
+- live url: https://github.com/openclaw/openclaw/pull/84602
+
+### #84603 fix(cron): skip delivery mirror for routed peer sessions to prevent session lock races
+
+- bucket: needs_proof
+- author: NianJiuZst
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: M, proof: supplied, mantis: telegram-visible-proof, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-15T01:31:17Z
+- live url: https://github.com/openclaw/openclaw/pull/84603
+
+### #84613 Prevent plaintext provider keys in generated models config
+
+- bucket: needs_proof
+- author: VibhorGautam
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-15T01:31:25Z
+- live url: https://github.com/openclaw/openclaw/pull/84613
+
+### #84617 fix(gateway): rate-limit device pairing and token management RPCs
+
+- bucket: needs_proof
+- author: davidangularme
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, proof: supplied, P2, rating: silver shellfish, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-15T01:31:30Z
+- live url: https://github.com/openclaw/openclaw/pull/84617
+
+### #84636 memory: add local continuity snapshot helpers
+
+- bucket: ready_for_maintainer
+- author: iHow1
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XL, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-15T01:31:48Z
+- live url: https://github.com/openclaw/openclaw/pull/84636


### PR DESCRIPTION
## Summary
- refresh the live OpenClaw PR inventory from GitHub
- add eight plan-only shards covering 320 currently open PRs
- include previously represented refs so classification uses current state rather than stale queue history

## Safety
- `mode: plan` only
- close/comment/label recommendations remain non-mutating
- security-shaped candidates are excluded

## Verification
- `npm run validate`