### PR TITLE
fix: extend repair execution window

### DIFF
--- a/.github/workflows/cluster-worker.yml
+++ b/.github/workflows/cluster-worker.yml
@@ -550,7 +550,7 @@ jobs:
 
       - name: Execute credited fix artifact
         if: ${{ env.CLOWNFISH_ALLOW_EXECUTE == '1' && env.CLOWNFISH_ALLOW_FIX_PR == '1' }}
-        timeout-minutes: 25
+        timeout-minutes: 30
         run: npm run execute-fix -- "${{ needs.prepare.outputs.job }}" --latest
 
       - name: Apply safe closure actions

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -29,7 +29,7 @@ test("execute-fix-artifact bounds auxiliary GitHub and git subprocesses by the f
   assert.match(source, /function closeSupersededSourcePr\([\s\S]*?const closed = runStatus\("gh", \["pr", "close"/);
   assert.match(
     workflow,
-    /- name: Execute credited fix artifact[\s\S]*?timeout-minutes: 25[\s\S]*?run: npm run execute-fix/,
+    /- name: Execute credited fix artifact[\s\S]*?timeout-minutes: 30[\s\S]*?run: npm run execute-fix/,
   );
 });
 


### PR DESCRIPTION
Raises the credited repair step cap from 25 to 30 minutes.

The live executor retains a bounded `CLOWNFISH_FIX_STEP_TIMEOUT_MS`; this preserves time for report upload and subsequent guarded stages after an expensive repair validation.

Validation:
- `node --test test/execute-fix-artifact.test.mjs`
- `npm run validate`