### PR TITLE
fix: allow local autoreview validation

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -3033,6 +3033,14 @@ function parseAllowedValidationCommand(command) {
 }
 
 function isAllowedAutoreviewValidation(parts) {
+  if (
+    parts.length === 3 &&
+    parts[0] === ".agents/skills/autoreview/scripts/autoreview" &&
+    parts[1] === "--mode" &&
+    parts[2] === "local"
+  ) {
+    return true;
+  }
   return (
     parts.length === 5 &&
     parts[0] === ".agents/skills/autoreview/scripts/autoreview" &&

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -646,6 +646,19 @@ test("execute-fix-artifact accepts the bounded OpenClaw branch autoreview comman
   assert.equal(run.report.status, "planned");
 });
 
+test("execute-fix-artifact accepts the bounded OpenClaw local autoreview command", () => {
+  const output = "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.";
+  const run = runBaselineChangedGateFixture({
+    clusterId: "openclaw-local-autoreview-validation-cluster",
+    baselineOutput: output,
+    postOutput: output,
+    validationCommands: [".agents/skills/autoreview/scripts/autoreview --mode local"],
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "planned");
+});
+
 test("execute-fix-artifact accepts a bounded shell syntax validation", () => {
   const run = runBaselineChangedGateFixture({
     clusterId: "shell-syntax-validation-cluster",


### PR DESCRIPTION
Accept the bounded OpenClaw local autoreview validation command emitted by repair artifacts.

The executor already permits the branch-mode autoreview variant; this adds only the exact `--mode local` form and preserves all other command restrictions.

Validation:
- `node --test test/execute-fix-artifact.test.mjs`
- `npm run validate`