### PR TITLE
fix: allow corepack changed validation

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -3025,6 +3025,7 @@ function parseAllowedValidationCommand(command) {
   if (isAllowedAutoreviewValidation(parts)) return parts;
   if (rawParts.length === parts.length && isAllowedShellSyntaxValidation(parts)) return parts;
   if (rawParts.length === parts.length && isAllowedPullRequestArtifactReviewValidation(parts)) return parts;
+  if (rawParts.length === parts.length && isAllowedCorepackChangedValidation(parts)) return parts;
   if (rawParts.length === parts.length && isAllowedCorepackOxfmtValidation(parts)) return parts;
   if (!["pnpm", "npm", "node", "git"].includes(parts[0])) {
     throw new Error(`unsupported validation command: ${text}`);
@@ -3062,6 +3063,10 @@ function isAllowedPullRequestArtifactReviewValidation(parts) {
     parts[1] === "review-validate-artifacts" &&
     /^[1-9][0-9]*$/.test(parts[2])
   );
+}
+
+function isAllowedCorepackChangedValidation(parts) {
+  return parts.length === 3 && parts[0] === "corepack" && parts[1] === "pnpm" && parts[2] === "check:changed";
 }
 
 function isAllowedCorepackOxfmtValidation(parts) {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -659,6 +659,19 @@ test("execute-fix-artifact accepts the bounded OpenClaw local autoreview command
   assert.equal(run.report.status, "planned");
 });
 
+test("execute-fix-artifact accepts the bounded corepack changed validation command", () => {
+  const output = "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.";
+  const run = runBaselineChangedGateFixture({
+    clusterId: "corepack-changed-validation-cluster",
+    baselineOutput: output,
+    postOutput: output,
+    validationCommands: ["corepack pnpm check:changed"],
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "planned");
+});
+
 test("execute-fix-artifact accepts a bounded shell syntax validation", () => {
   const run = runBaselineChangedGateFixture({
     clusterId: "shell-syntax-validation-cluster",


### PR DESCRIPTION
Accept the exact OpenClaw `corepack pnpm check:changed` validation form emitted by repair artifacts.

Changed-only execution still normalizes this to the existing `pnpm check:changed` hard gate.

Validation:
- `node --test test/execute-fix-artifact.test.mjs`
- `npm run validate`