### PR TITLE
fix(executor): resume contributor checkpoints

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -706,6 +706,11 @@ function executeRepairBranch({ fixArtifact, targetDir, scopeBlock = null, rebase
     ensureCodexWritePreflight,
   });
   noteFixStage("rebase_complete", { pull_request: sourcePr.number, rebased });
+  const resumedRepairCheckpoint = hasClownfishRepairCheckpoint({
+    targetDir,
+    baseBranch,
+    clusterId: result.cluster_id,
+  });
   let expectedRemoteHeadSha = String(pull.head?.sha ?? "");
   const pushedCheckpointCommits = [];
   const branchProgress = {
@@ -714,6 +719,7 @@ function executeRepairBranch({ fixArtifact, targetDir, scopeBlock = null, rebase
     target: sourcePr.url,
     head_repo: pull.head.repo.full_name,
     head_ref: pull.head.ref,
+    resumed_checkpoint: resumedRepairCheckpoint,
   };
   const pushRepairCheckpoint = () => {
     const pushArgs = repairBranchPushArgs({ pull, rebased, expectedHeadSha: expectedRemoteHeadSha });
@@ -763,9 +769,9 @@ function executeRepairBranch({ fixArtifact, targetDir, scopeBlock = null, rebase
     branch,
     mode: "repair",
     baseBranch,
-    // Only explicit rebase-only jobs may stop after a successful rebase. Ordinary
-    // contributor repairs still need Codex to address the artifact's concrete defect.
-    allowExistingChanges: rebaseOnly && rebased,
+    // Fresh contributor repairs need an edit. A prior Clownfish checkpoint has
+    // already been edited, so a requeue should validate and review it instead.
+    allowExistingChanges: (rebaseOnly && rebased) || resumedRepairCheckpoint,
     allowReviewFixes: !rebaseOnly,
     refreshBaseBeforeReview: rebaseOnly,
     pushCheckpoint: dryRun ? null : pushRepairCheckpoint,
@@ -3544,6 +3550,14 @@ function branchHasBaseDiff({ targetDir, baseBranch }) {
   const retryDetail = `${retry.stderr ?? ""}\n${retry.stdout ?? ""}`;
   if (/no merge base/i.test(retryDetail)) return true;
   throw new Error(retryDetail.trim());
+}
+
+function hasClownfishRepairCheckpoint({ targetDir, baseBranch, clusterId }) {
+  const subjects = run("git", ["log", "--format=%s", `origin/${baseBranch}..HEAD`], { cwd: targetDir });
+  return subjects
+    .split("\n")
+    .map((subject) => subject.trim())
+    .some((subject) => subject.startsWith("fix(clownfish):") && subject.includes(clusterId));
 }
 
 function ensureMergeBaseAvailable({ targetDir, baseBranch }) {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -210,12 +210,17 @@ test("execute-fix-artifact routes rebased fork repairs to replacement before exp
   assert.match(source, /fork branch requiring rebase/);
 });
 
-test("execute-fix-artifact runs ordinary contributor repairs after a successful rebase", () => {
+test("execute-fix-artifact resumes contributor checkpoint branches without a duplicate edit", () => {
   const source = fs.readFileSync(path.join(repoRoot, "scripts", "execute-fix-artifact.mjs"), "utf8");
 
   assert.match(
     source,
-    /mode: "repair",\s*baseBranch,\s*\/\/ Only explicit rebase-only jobs[\s\S]*?allowExistingChanges: rebaseOnly && rebased,/,
+    /const resumedRepairCheckpoint = hasClownfishRepairCheckpoint\(\{\s*targetDir,\s*baseBranch,\s*clusterId: result\.cluster_id,\s*\}\);/,
+  );
+  assert.match(source, /allowExistingChanges: \(rebaseOnly && rebased\) \|\| resumedRepairCheckpoint,/);
+  assert.match(
+    source,
+    /function hasClownfishRepairCheckpoint\(\{ targetDir, baseBranch, clusterId \}\) \{[\s\S]*?git", \["log", "--format=%s", `origin\/\$\{baseBranch\}\.\.HEAD`\]/,
   );
 });
 


### PR DESCRIPTION
Resume contributor repair branches that already contain a Clownfish checkpoint.

This avoids rerunning Codex edits after a recoverable timeout and sends the replay straight to validation and review.

Validation:
- node --test test/execute-fix-artifact.test.mjs
- npm run validate