### PR TITLE
chore(clownfish): record repair canary dispatch

### DIFF
--- a/results/comment-router-latest.json
+++ b/results/comment-router-latest.json
@@ -1,16 +1,16 @@
 {
   "status": "executed",
-  "generated_at": "2026-06-19T03:31:03.229Z",
+  "generated_at": "2026-06-19T03:34:51.754Z",
   "repo": "openclaw/openclaw",
   "clownfish_repo": "openclaw/clownfish",
   "clawsweeper_repo": "openclaw/clawsweeper",
-  "since": "2026-06-19T00:30:47.354Z",
+  "since": "2026-06-19T00:34:34.841Z",
   "execute": true,
   "max_comments": 1,
   "requested_comment_ids": [
-    "4748266409"
+    "4748280139"
   ],
-  "all_comments_scanned": 902,
+  "all_comments_scanned": 905,
   "max_autoclose_targets": 8,
   "scanned_comments": 1,
   "commands_seen": 1,
@@ -28,17 +28,17 @@
   "max_auto_repairs_per_pr": 5,
   "commands": [
     {
-      "idempotency_key": "comment-router:openclaw/openclaw:90882:4748266409:2026-06-19T03:30:17Z:automerge",
-      "comment_id": "4748266409",
-      "comment_node_id": "IC_kwDOQb6kR88AAAABGwTLqQ",
-      "comment_version_key": "4748266409:2026-06-19T03:30:17Z",
-      "comment_url": "https://github.com/openclaw/openclaw/pull/90882#issuecomment-4748266409",
+      "idempotency_key": "comment-router:openclaw/openclaw:94659:4748280139:2026-06-19T03:34:11Z:automerge",
+      "comment_id": "4748280139",
+      "comment_node_id": "IC_kwDOQb6kR88AAAABGwUBSw",
+      "comment_version_key": "4748280139:2026-06-19T03:34:11Z",
+      "comment_url": "https://github.com/openclaw/openclaw/pull/94659#issuecomment-4748280139",
       "repo": "openclaw/openclaw",
-      "issue_number": 90882,
+      "issue_number": 94659,
       "author": "vincentkoc",
       "author_association": "MEMBER",
-      "comment_created_at": "2026-06-19T03:30:17Z",
-      "comment_updated_at": "2026-06-19T03:30:17Z",
+      "comment_created_at": "2026-06-19T03:34:11Z",
+      "comment_updated_at": "2026-06-19T03:34:11Z",
       "trigger": "slash",
       "command": "automerge",
       "intent": "automerge",
@@ -65,53 +65,62 @@
           "action": "dispatch_clawsweeper",
           "workflow": "sweep.yml",
           "status": "executed",
-          "dispatched_at": "2026-06-19T03:31:11.471Z",
+          "dispatched_at": "2026-06-19T03:34:59.179Z",
           "event": "repository_dispatch",
           "repo": "openclaw/clawsweeper",
-          "item_number": 90882
+          "item_number": 94659
         },
         {
           "action": "comment",
           "status": "executed",
-          "commented_at": "2026-06-19T03:31:13.444Z"
+          "commented_at": "2026-06-19T03:35:01.369Z"
         }
       ],
       "author_repository_permission": "admin",
       "target": {
         "kind": "pull_request",
-        "title": "fix: add self-knowledge docs rule to system prompt",
-        "branch": "sutrah/self-knowledge-docs-prompt",
-        "head_sha": "88a7db5d2a5678f33ff9c4b03351b45f79060c34",
-        "author": "sutrahsing",
+        "title": "fix(doctor): stop promising --fix for working isolated shell-prompt cron jobs (#94655)",
+        "branch": "radar/issue-94655",
+        "head_sha": "b90075f60d40a5b643b964c336330627c59d81fa",
+        "author": "zengwen-dt",
         "labels": [
-          "docs",
-          "agents",
-          "size: XS",
+          "commands",
+          "size: S",
           "proof: supplied",
           "proof: sufficient",
-          "P3",
+          "P2",
           "rating: 🐚 platinum hermit",
           "status: 👀 ready for maintainer look",
           "clownfish:automerge"
         ],
         "is_clownfish_pr": false,
-        "cluster_id": "automerge-openclaw-openclaw-90882",
-        "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-90882.md",
-        "automerge_cluster_id": "automerge-openclaw-openclaw-90882",
-        "automerge_job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-90882.md",
+        "cluster_id": "automerge-openclaw-openclaw-94659",
+        "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-94659.md",
+        "automerge_cluster_id": "automerge-openclaw-openclaw-94659",
+        "automerge_job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-94659.md",
         "mode": "autonomous",
         "merge_state_status": "UNKNOWN",
         "review_decision": "",
         "checks": {
-          "total": 197,
+          "total": 262,
           "counts": {
-            "CANCELLED": 2,
-            "SKIPPED": 48,
-            "SUCCESS": 146,
+            "CANCELLED": 12,
+            "SKIPPED": 100,
+            "SUCCESS": 149,
             "NEUTRAL": 1
           },
           "blockers": [
             "auto-response:CANCELLED",
+            "auto-response:CANCELLED",
+            "auto-response:CANCELLED",
+            "auto-response:CANCELLED",
+            "auto-response:CANCELLED",
+            "auto-response:CANCELLED",
+            "Real behavior proof:CANCELLED",
+            "Real behavior proof:CANCELLED",
+            "Real behavior proof:CANCELLED",
+            "Real behavior proof:CANCELLED",
+            "Real behavior proof:CANCELLED",
             "Real behavior proof:CANCELLED"
           ]
         }

--- a/results/comment-router.json
+++ b/results/comment-router.json
@@ -1,5 +1,5 @@
 {
-  "updated_at": "2026-06-19T03:31:13.444Z",
+  "updated_at": "2026-06-19T03:35:01.369Z",
   "commands": [
     {
       "idempotency_key": "clawsweeper-repair:openclaw/openclaw:74102:4341160275:2026-04-29T05:39:44Z:clawsweeper_auto_repair",
@@ -3239,6 +3239,36 @@
         "head_sha": "88a7db5d2a5678f33ff9c4b03351b45f79060c34",
         "cluster_id": "automerge-openclaw-openclaw-90882",
         "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-90882.md"
+      }
+    },
+    {
+      "idempotency_key": "comment-router:openclaw/openclaw:94659:4748280139:2026-06-19T03:34:11Z:automerge",
+      "comment_id": "4748280139",
+      "comment_version_key": "4748280139:2026-06-19T03:34:11Z",
+      "comment_url": "https://github.com/openclaw/openclaw/pull/94659#issuecomment-4748280139",
+      "comment_created_at": "2026-06-19T03:34:11Z",
+      "comment_updated_at": "2026-06-19T03:34:11Z",
+      "repo": "openclaw/openclaw",
+      "issue_number": 94659,
+      "author": "vincentkoc",
+      "author_association": "MEMBER",
+      "trigger": "slash",
+      "command": "automerge",
+      "intent": "automerge",
+      "trusted_bot": false,
+      "trusted_bot_author": null,
+      "automation_source": null,
+      "repair_reason": null,
+      "expected_head_sha": null,
+      "finding_id": null,
+      "status": "executed",
+      "processed_at": "2026-06-19T03:35:01.369Z",
+      "target": {
+        "kind": "pull_request",
+        "branch": "radar/issue-94655",
+        "head_sha": "b90075f60d40a5b643b964c336330627c59d81fa",
+        "cluster_id": "automerge-openclaw-openclaw-94659",
+        "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-94659.md"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- persist the idempotent record for the post-bridge repair canary on openclaw/openclaw#94659
- record both opt-in labels and the exact ClawSweeper review dispatch

## Verification
- `git diff --check`
- live router dry run then exact `--execute` for comment `4748280139`

This is controller audit state for a bounded repair-path canary; branch-write gates remain closed pending the fresh verdict.