### PR TITLE
fix(router): replay legacy automerge opt-ins

### DIFF
--- a/scripts/comment-router-core.mjs
+++ b/scripts/comment-router-core.mjs
@@ -202,7 +202,7 @@ export function parseTrustedAutomation(comment, { trustedAuthors = new Set() } =
 }
 
 export function renderResponse(command, dispatched) {
-  const markerId = command.comment_version_key ?? command.comment_id;
+  const markerId = command.response_marker_key ?? command.comment_version_key ?? command.comment_id;
   const marker = `<!-- clownfish-command:${markerId}:${command.intent}:${command.target?.head_sha ?? "na"} -->`;
   if (command.intent === "help") {
     return [

--- a/scripts/comment-router-utils.mjs
+++ b/scripts/comment-router-utils.mjs
@@ -68,6 +68,7 @@ export function appendLedger(current, entries) {
 }
 
 function ledgerEntryKey(entry) {
+  if (entry.idempotency_key) return entry.idempotency_key;
   return entry.comment_version_key ?? `${entry.comment_id ?? "unknown"}:${entry.comment_updated_at ?? "legacy"}`;
 }
 

--- a/scripts/comment-router.mjs
+++ b/scripts/comment-router.mjs
@@ -70,6 +70,7 @@ const model = String(args.model ?? process.env.CLOWNFISH_MODEL ?? "gpt-5.5");
 const headPrefix = String(args["head-prefix"] ?? process.env.CLOWNFISH_HEAD_PREFIX ?? DEFAULT_HEAD_PREFIX);
 const label = String(args.label ?? process.env.CLOWNFISH_LABEL ?? DEFAULT_LABEL);
 const execute = Boolean(args.execute);
+const replayLegacyAutomerge = Boolean(args["replay-legacy-automerge"]);
 const writeReport = Boolean(args["write-report"] || execute);
 const waitForCapacity = Boolean(args["wait-for-capacity"]);
 const maxLiveWorkers = readMaxLiveWorkers(args);
@@ -116,9 +117,18 @@ const clownfishAuthors = commaSet(
 assertRepo(targetRepo, "repo");
 assertRepo(clownfishRepo, "clownfish-repo");
 assertRepo(clawsweeperRepo, "clawsweeper-repo");
+if (replayLegacyAutomerge && requestedCommentIds.size === 0) {
+  throw new Error("--replay-legacy-automerge requires --comment-ids for exact replay scope");
+}
 
 const ledger = readLedger(ledgerPath());
 const processedCommentVersions = new Set((ledger.commands ?? []).map(commentVersionKey).filter(Boolean));
+const processedLegacyAutomergeReplays = new Set(
+  (ledger.commands ?? [])
+    .filter((entry) => entry.automation_source === "legacy_automerge_bridge")
+    .map((entry) => entry.idempotency_key)
+    .filter(Boolean),
+);
 const plannedAutoRepairHeads = new Set();
 const collaboratorPermissionCache = new Map();
 const allComments = listRecentComments();
@@ -223,20 +233,36 @@ function classifyCommand(command) {
   if (!command.issue_number) {
     return { ...command, status: "ignored", reason: "could not resolve issue or PR number" };
   }
-  if (command.comment_version_key && processedCommentVersions.has(command.comment_version_key)) {
+  const processed = command.comment_version_key && processedCommentVersions.has(command.comment_version_key);
+  if (processed && !(replayLegacyAutomerge && command.intent === "automerge")) {
     return { ...command, status: "skipped", reason: "comment version already processed in ledger" };
   }
 
   const issue = fetchIssue(command.issue_number);
   const pull = issue.pull_request ? fetchPullRequestView(command.issue_number) : null;
   const target = pull ? classifyPullTarget(pull, command.issue_number) : classifyIssueTarget(issue);
-  const next = { ...command, target };
+  let next = { ...command, target };
+  if (processed) {
+    if (!isLegacyAutomergeBridgeCandidate({ issue, target })) {
+      return { ...next, status: "skipped", reason: "comment version already processed in ledger" };
+    }
+    const replayIdempotencyKey = legacyAutomergeReplayKey(command);
+    if (processedLegacyAutomergeReplays.has(replayIdempotencyKey)) {
+      return { ...next, status: "skipped", reason: "legacy automerge bridge replay already processed" };
+    }
+    next = {
+      ...next,
+      idempotency_key: replayIdempotencyKey,
+      automation_source: "legacy_automerge_bridge",
+      response_marker_key: `${command.comment_version_key}:legacy-automerge-bridge-v1`,
+    };
+  }
 
   if (
     hasExistingResponse(
-      command.issue_number,
-      command.comment_version_key ?? command.comment_id,
-      command.intent,
+      next.issue_number,
+      next.response_marker_key ?? next.comment_version_key ?? next.comment_id,
+      next.intent,
       target.head_sha,
     )
   ) {
@@ -519,6 +545,16 @@ function autoRepairHeadKey(command) {
   const sha = command.target?.head_sha;
   if (!sha) return null;
   return `${command.repo}#${command.issue_number}:${sha}`;
+}
+
+function isLegacyAutomergeBridgeCandidate({ issue, target }) {
+  return (
+    String(issue?.state ?? "").toLowerCase() === "open" &&
+    target?.kind === "pull_request" &&
+    hasLabel(target, AUTOMERGE_LABEL) &&
+    !hasLabel(target, CLAWSWEEPER_AUTOMERGE_LABEL) &&
+    !hasLabel(target, HUMAN_REVIEW_LABEL)
+  );
 }
 
 function executeCommand(command) {
@@ -1271,6 +1307,10 @@ function ledgerPath() {
 function idempotencyKey(parsed, issueNumber, commentId, commentUpdatedAt) {
   const prefix = parsed.trusted_bot ? "clawsweeper-repair" : "comment-router";
   return `${prefix}:${targetRepo}:${issueNumber}:${commentId}:${commentUpdatedAt ?? "unknown"}:${parsed.intent}`;
+}
+
+function legacyAutomergeReplayKey(command) {
+  return `${command.idempotency_key}:legacy-automerge-bridge-v1`;
 }
 
 function commentVersionKey(entry) {

--- a/test/comment-router-core.test.mjs
+++ b/test/comment-router-core.test.mjs
@@ -297,6 +297,25 @@ test("renderResponse reports automerge resume actions", () => {
   assert.match(body, /\/clownfish stop/);
 });
 
+test("renderResponse gives legacy automerge bridge replays their own marker", () => {
+  const body = renderResponse(
+    {
+      comment_id: "459",
+      comment_version_key: "459:2026-04-29T07:12:31Z",
+      response_marker_key: "459:2026-04-29T07:12:31Z:legacy-automerge-bridge-v1",
+      intent: "automerge",
+      target: { head_sha: "def459" },
+    },
+    {
+      clawsweeper: {
+        workflow: "sweep.yml",
+      },
+    },
+  );
+
+  assert.match(body, /clownfish-command:459:2026-04-29T07:12:31Z:legacy-automerge-bridge-v1:automerge:def459/);
+});
+
 test("renderResponse reports maintainer autoclose results", () => {
   const body = renderResponse(
     {

--- a/test/comment-router-utils.test.mjs
+++ b/test/comment-router-utils.test.mjs
@@ -35,3 +35,44 @@ test("appendLedger keeps edited comment versions separate", () => {
     ["123:2026-04-29T01:00:00Z", "123:2026-04-29T02:00:00Z"],
   );
 });
+
+test("appendLedger preserves a legacy automerge bridge replay", () => {
+  const ledger = {
+    updated_at: null,
+    commands: [
+      {
+        idempotency_key: "comment-router:openclaw/openclaw:74075:123:2026-04-29T01:00:00Z:automerge",
+        comment_id: "123",
+        comment_version_key: "123:2026-04-29T01:00:00Z",
+        comment_updated_at: "2026-04-29T01:00:00Z",
+        status: "executed",
+        intent: "automerge",
+        issue_number: 74075,
+        repo: "openclaw/openclaw",
+      },
+    ],
+  };
+
+  appendLedger(ledger, [
+    {
+      idempotency_key: "comment-router:openclaw/openclaw:74075:123:2026-04-29T01:00:00Z:automerge:legacy-automerge-bridge-v1",
+      comment_id: "123",
+      comment_version_key: "123:2026-04-29T01:00:00Z",
+      comment_updated_at: "2026-04-29T01:00:00Z",
+      automation_source: "legacy_automerge_bridge",
+      status: "executed",
+      intent: "automerge",
+      issue_number: 74075,
+      repo: "openclaw/openclaw",
+    },
+  ]);
+
+  assert.equal(ledger.commands.length, 2);
+  assert.deepEqual(
+    ledger.commands.map((entry) => entry.idempotency_key),
+    [
+      "comment-router:openclaw/openclaw:74075:123:2026-04-29T01:00:00Z:automerge",
+      "comment-router:openclaw/openclaw:74075:123:2026-04-29T01:00:00Z:automerge:legacy-automerge-bridge-v1",
+    ],
+  );
+});


### PR DESCRIPTION
Restores only explicitly selected legacy `/clownfish automerge` commands that were processed before the ClawSweeper-label bridge.

- requires exact comment IDs
- only replays open PRs still carrying `clownfish:automerge` without ClawSweeper or human-review labels
- writes a distinct replay idempotency key and response marker

Validation:
- `node --test test/comment-router-core.test.mjs test/comment-router-utils.test.mjs`
- `npm run validate`
- live dry run against four legacy opt-ins