### PR TITLE
chore(clownfish): adopt automerge intake

### DIFF
--- a/jobs/openclaw/inbox/automerge-openclaw-openclaw-92383.md
+++ b/jobs/openclaw/inbox/automerge-openclaw-openclaw-92383.md
@@ -1,0 +1,46 @@
+---
+repo: openclaw/openclaw
+cluster_id: automerge-openclaw-openclaw-92383
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - fix
+  - raise_pr
+blocked_actions:
+  - close
+  - merge
+require_human_for:
+  - close
+  - merge
+canonical:
+  - #92383
+candidates:
+  - #92383
+cluster_refs:
+  - #92383
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: clownfish/automerge-openclaw-openclaw-92383
+source: pr_automerge
+---
+
+# Clownfish automerge repair candidate
+
+Maintainer opted #92383 into Clownfish automerge.
+
+Source PR: https://github.com/openclaw/openclaw/pull/92383
+Title: fix(gateway): never return an empty chat.history transcript
+
+Clownfish should use this job only for the bounded ClawSweeper review/fix loop:
+
+- If ClawSweeper requests changes, returns `needs-human`, or finds failing checks/rebase work, and the PR branch is safe to update, emit a fix artifact with `repair_strategy: "repair_contributor_branch"` and `source_prs: ["https://github.com/openclaw/openclaw/pull/92383"]`.
+- If the PR branch cannot be safely updated, emit a narrow credited replacement only when the artifact can preserve the original contributor credit; otherwise return `needs_human`.
+- Do not merge, close, or bypass review gates from the worker. The comment router owns final merge only after a passing ClawSweeper verdict for the exact current head.
+- Keep repair scope limited to actionable ClawSweeper findings, failing relevant checks, and required review feedback on this PR.

--- a/jobs/openclaw/inbox/automerge-openclaw-openclaw-92574.md
+++ b/jobs/openclaw/inbox/automerge-openclaw-openclaw-92574.md
@@ -1,0 +1,46 @@
+---
+repo: openclaw/openclaw
+cluster_id: automerge-openclaw-openclaw-92574
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - fix
+  - raise_pr
+blocked_actions:
+  - close
+  - merge
+require_human_for:
+  - close
+  - merge
+canonical:
+  - #92574
+candidates:
+  - #92574
+cluster_refs:
+  - #92574
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: clownfish/automerge-openclaw-openclaw-92574
+source: pr_automerge
+---
+
+# Clownfish automerge repair candidate
+
+Maintainer opted #92574 into Clownfish automerge.
+
+Source PR: https://github.com/openclaw/openclaw/pull/92574
+Title: test(browser): cover action-input CLI request bodies
+
+Clownfish should use this job only for the bounded ClawSweeper review/fix loop:
+
+- If ClawSweeper requests changes, returns `needs-human`, or finds failing checks/rebase work, and the PR branch is safe to update, emit a fix artifact with `repair_strategy: "repair_contributor_branch"` and `source_prs: ["https://github.com/openclaw/openclaw/pull/92574"]`.
+- If the PR branch cannot be safely updated, emit a narrow credited replacement only when the artifact can preserve the original contributor credit; otherwise return `needs_human`.
+- Do not merge, close, or bypass review gates from the worker. The comment router owns final merge only after a passing ClawSweeper verdict for the exact current head.
+- Keep repair scope limited to actionable ClawSweeper findings, failing relevant checks, and required review feedback on this PR.

--- a/jobs/openclaw/inbox/automerge-openclaw-openclaw-92873.md
+++ b/jobs/openclaw/inbox/automerge-openclaw-openclaw-92873.md
@@ -1,0 +1,46 @@
+---
+repo: openclaw/openclaw
+cluster_id: automerge-openclaw-openclaw-92873
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - fix
+  - raise_pr
+blocked_actions:
+  - close
+  - merge
+require_human_for:
+  - close
+  - merge
+canonical:
+  - #92873
+candidates:
+  - #92873
+cluster_refs:
+  - #92873
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: clownfish/automerge-openclaw-openclaw-92873
+source: pr_automerge
+---
+
+# Clownfish automerge repair candidate
+
+Maintainer opted #92873 into Clownfish automerge.
+
+Source PR: https://github.com/openclaw/openclaw/pull/92873
+Title: test(diffs): add viewerState, toolbar toggle, shadow root, and hydrateProps tests (fixes #83915)
+
+Clownfish should use this job only for the bounded ClawSweeper review/fix loop:
+
+- If ClawSweeper requests changes, returns `needs-human`, or finds failing checks/rebase work, and the PR branch is safe to update, emit a fix artifact with `repair_strategy: "repair_contributor_branch"` and `source_prs: ["https://github.com/openclaw/openclaw/pull/92873"]`.
+- If the PR branch cannot be safely updated, emit a narrow credited replacement only when the artifact can preserve the original contributor credit; otherwise return `needs_human`.
+- Do not merge, close, or bypass review gates from the worker. The comment router owns final merge only after a passing ClawSweeper verdict for the exact current head.
+- Keep repair scope limited to actionable ClawSweeper findings, failing relevant checks, and required review feedback on this PR.

--- a/results/comment-router.json
+++ b/results/comment-router.json
@@ -1,5 +1,5 @@
 {
-  "updated_at": "2026-06-19T03:55:41.021Z",
+  "updated_at": "2026-06-19T04:09:21.248Z",
   "commands": [
     {
       "idempotency_key": "clawsweeper-repair:openclaw/openclaw:74102:4341160275:2026-04-29T05:39:44Z:clawsweeper_auto_repair",
@@ -3569,6 +3569,96 @@
         "head_sha": "6ba0afbe106c0de2a56c285d765debb4f7c3f767",
         "cluster_id": "automerge-openclaw-openclaw-94687",
         "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-94687.md"
+      }
+    },
+    {
+      "idempotency_key": "comment-router:openclaw/openclaw:92383:4748408028:2026-06-19T04:07:46Z:automerge",
+      "comment_id": "4748408028",
+      "comment_version_key": "4748408028:2026-06-19T04:07:46Z",
+      "comment_url": "https://github.com/openclaw/openclaw/pull/92383#issuecomment-4748408028",
+      "comment_created_at": "2026-06-19T04:07:46Z",
+      "comment_updated_at": "2026-06-19T04:07:46Z",
+      "repo": "openclaw/openclaw",
+      "issue_number": 92383,
+      "author": "vincentkoc",
+      "author_association": "MEMBER",
+      "trigger": "slash",
+      "command": "automerge",
+      "intent": "automerge",
+      "trusted_bot": false,
+      "trusted_bot_author": null,
+      "automation_source": null,
+      "repair_reason": null,
+      "expected_head_sha": null,
+      "finding_id": null,
+      "status": "executed",
+      "processed_at": "2026-06-19T04:09:21.248Z",
+      "target": {
+        "kind": "pull_request",
+        "branch": "hide/fix/chat-history-empty-fallback",
+        "head_sha": "f2fa246ab79ca1d2095b32d001792d23b28e4516",
+        "cluster_id": "automerge-openclaw-openclaw-92383",
+        "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-92383.md"
+      }
+    },
+    {
+      "idempotency_key": "comment-router:openclaw/openclaw:92574:4748407961:2026-06-19T04:07:45Z:automerge",
+      "comment_id": "4748407961",
+      "comment_version_key": "4748407961:2026-06-19T04:07:45Z",
+      "comment_url": "https://github.com/openclaw/openclaw/pull/92574#issuecomment-4748407961",
+      "comment_created_at": "2026-06-19T04:07:45Z",
+      "comment_updated_at": "2026-06-19T04:07:45Z",
+      "repo": "openclaw/openclaw",
+      "issue_number": 92574,
+      "author": "vincentkoc",
+      "author_association": "MEMBER",
+      "trigger": "slash",
+      "command": "automerge",
+      "intent": "automerge",
+      "trusted_bot": false,
+      "trusted_bot_author": null,
+      "automation_source": null,
+      "repair_reason": null,
+      "expected_head_sha": null,
+      "finding_id": null,
+      "status": "executed",
+      "processed_at": "2026-06-19T04:09:21.248Z",
+      "target": {
+        "kind": "pull_request",
+        "branch": "openmeta/agent-83877-broad-cli-command-surface-has-no-1781316672048",
+        "head_sha": "c070a8d51b9b041da3397d61c8c24a3e091ca471",
+        "cluster_id": "automerge-openclaw-openclaw-92574",
+        "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-92574.md"
+      }
+    },
+    {
+      "idempotency_key": "comment-router:openclaw/openclaw:92873:4748407912:2026-06-19T04:07:44Z:automerge",
+      "comment_id": "4748407912",
+      "comment_version_key": "4748407912:2026-06-19T04:07:44Z",
+      "comment_url": "https://github.com/openclaw/openclaw/pull/92873#issuecomment-4748407912",
+      "comment_created_at": "2026-06-19T04:07:44Z",
+      "comment_updated_at": "2026-06-19T04:07:44Z",
+      "repo": "openclaw/openclaw",
+      "issue_number": 92873,
+      "author": "vincentkoc",
+      "author_association": "MEMBER",
+      "trigger": "slash",
+      "command": "automerge",
+      "intent": "automerge",
+      "trusted_bot": false,
+      "trusted_bot_author": null,
+      "automation_source": null,
+      "repair_reason": null,
+      "expected_head_sha": null,
+      "finding_id": null,
+      "status": "executed",
+      "processed_at": "2026-06-19T04:09:21.248Z",
+      "target": {
+        "kind": "pull_request",
+        "branch": "fix/viewer-client-test-coverage-v2",
+        "head_sha": "a09ee505843428cf962e3e3085cbf0d20165d224",
+        "cluster_id": "automerge-openclaw-openclaw-92873",
+        "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-92873.md"
       }
     }
   ]


### PR DESCRIPTION
Records the exact Clownfish automerge intake for openclaw/openclaw PRs #92383, #92574, and #92873.

Each target was re-fetched clean and check-green before the router dispatch. The resulting jobs and idempotency ledger are included for repair continuity.

Validation:
- `npm run validate` (6147 jobs)
- live router dry run before execution