### PR TITLE
chore(clownfish): replay legacy automerge opt-ins

### DIFF
--- a/results/comment-router.json
+++ b/results/comment-router.json
@@ -1,5 +1,5 @@
 {
-  "updated_at": "2026-06-19T04:09:21.248Z",
+  "updated_at": "2026-06-19T04:13:50.866Z",
   "commands": [
     {
       "idempotency_key": "clawsweeper-repair:openclaw/openclaw:74102:4341160275:2026-04-29T05:39:44Z:clawsweeper_auto_repair",
@@ -3659,6 +3659,96 @@
         "head_sha": "a09ee505843428cf962e3e3085cbf0d20165d224",
         "cluster_id": "automerge-openclaw-openclaw-92873",
         "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-92873.md"
+      }
+    },
+    {
+      "idempotency_key": "comment-router:openclaw/openclaw:94696:4748169548:2026-06-19T03:09:45Z:automerge:legacy-automerge-bridge-v1",
+      "comment_id": "4748169548",
+      "comment_version_key": "4748169548:2026-06-19T03:09:45Z",
+      "comment_url": "https://github.com/openclaw/openclaw/pull/94696#issuecomment-4748169548",
+      "comment_created_at": "2026-06-19T03:09:45Z",
+      "comment_updated_at": "2026-06-19T03:09:45Z",
+      "repo": "openclaw/openclaw",
+      "issue_number": 94696,
+      "author": "vincentkoc",
+      "author_association": "MEMBER",
+      "trigger": "slash",
+      "command": "automerge",
+      "intent": "automerge",
+      "trusted_bot": false,
+      "trusted_bot_author": null,
+      "automation_source": "legacy_automerge_bridge",
+      "repair_reason": null,
+      "expected_head_sha": null,
+      "finding_id": null,
+      "status": "executed",
+      "processed_at": "2026-06-19T04:13:50.865Z",
+      "target": {
+        "kind": "pull_request",
+        "branch": "radar/issue-94691",
+        "head_sha": "5d3ea0f07ec46d553c9613bb0cea06b8243bcf3c",
+        "cluster_id": "automerge-openclaw-openclaw-94696",
+        "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-94696.md"
+      }
+    },
+    {
+      "idempotency_key": "comment-router:openclaw/openclaw:94756:4748168899:2026-06-19T03:09:38Z:automerge:legacy-automerge-bridge-v1",
+      "comment_id": "4748168899",
+      "comment_version_key": "4748168899:2026-06-19T03:09:38Z",
+      "comment_url": "https://github.com/openclaw/openclaw/pull/94756#issuecomment-4748168899",
+      "comment_created_at": "2026-06-19T03:09:38Z",
+      "comment_updated_at": "2026-06-19T03:09:38Z",
+      "repo": "openclaw/openclaw",
+      "issue_number": 94756,
+      "author": "vincentkoc",
+      "author_association": "MEMBER",
+      "trigger": "slash",
+      "command": "automerge",
+      "intent": "automerge",
+      "trusted_bot": false,
+      "trusted_bot_author": null,
+      "automation_source": "legacy_automerge_bridge",
+      "repair_reason": null,
+      "expected_head_sha": null,
+      "finding_id": null,
+      "status": "executed",
+      "processed_at": "2026-06-19T04:13:50.866Z",
+      "target": {
+        "kind": "pull_request",
+        "branch": "fix/codex-turn-start-text-bound",
+        "head_sha": "1510a3d13a2b469997d862247521bd29866a0e79",
+        "cluster_id": "automerge-openclaw-openclaw-94756",
+        "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-94756.md"
+      }
+    },
+    {
+      "idempotency_key": "comment-router:openclaw/openclaw:94257:4748167981:2026-06-19T03:09:30Z:automerge:legacy-automerge-bridge-v1",
+      "comment_id": "4748167981",
+      "comment_version_key": "4748167981:2026-06-19T03:09:30Z",
+      "comment_url": "https://github.com/openclaw/openclaw/pull/94257#issuecomment-4748167981",
+      "comment_created_at": "2026-06-19T03:09:30Z",
+      "comment_updated_at": "2026-06-19T03:09:30Z",
+      "repo": "openclaw/openclaw",
+      "issue_number": 94257,
+      "author": "vincentkoc",
+      "author_association": "MEMBER",
+      "trigger": "slash",
+      "command": "automerge",
+      "intent": "automerge",
+      "trusted_bot": false,
+      "trusted_bot_author": null,
+      "automation_source": "legacy_automerge_bridge",
+      "repair_reason": null,
+      "expected_head_sha": null,
+      "finding_id": null,
+      "status": "executed",
+      "processed_at": "2026-06-19T04:13:50.866Z",
+      "target": {
+        "kind": "pull_request",
+        "branch": "fix/media-types-index-alignment",
+        "head_sha": "62db437d10e8f94ad5d9313f188b3032d961baec",
+        "cluster_id": "automerge-openclaw-openclaw-94257",
+        "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-94257.md"
       }
     }
   ]


### PR DESCRIPTION
Records the explicit legacy replay for openclaw/openclaw PRs #94696, #94756, and #94257 after the ClawSweeper-label bridge landed.

Each replay preserved the original maintainer command and added a distinct `legacy-automerge-bridge-v1` idempotency key.

Validation:
- `npm run validate` (6147 jobs)
- live exact-comment router dry run before execution