### PR TITLE
chore(clownfish): record legacy Trello automerge replay

### DIFF
--- a/results/comment-router.json
+++ b/results/comment-router.json
@@ -1,5 +1,5 @@
 {
-  "updated_at": "2026-06-19T04:13:50.866Z",
+  "updated_at": "2026-06-19T04:22:41.906Z",
   "commands": [
     {
       "idempotency_key": "clawsweeper-repair:openclaw/openclaw:74102:4341160275:2026-04-29T05:39:44Z:clawsweeper_auto_repair",
@@ -3749,6 +3749,36 @@
         "head_sha": "62db437d10e8f94ad5d9313f188b3032d961baec",
         "cluster_id": "automerge-openclaw-openclaw-94257",
         "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-94257.md"
+      }
+    },
+    {
+      "idempotency_key": "comment-router:openclaw/openclaw:94729:4747996883:2026-06-19T02:40:43Z:automerge:legacy-automerge-bridge-v1",
+      "comment_id": "4747996883",
+      "comment_version_key": "4747996883:2026-06-19T02:40:43Z",
+      "comment_url": "https://github.com/openclaw/openclaw/pull/94729#issuecomment-4747996883",
+      "comment_created_at": "2026-06-19T02:40:43Z",
+      "comment_updated_at": "2026-06-19T02:40:43Z",
+      "repo": "openclaw/openclaw",
+      "issue_number": 94729,
+      "author": "vincentkoc",
+      "author_association": "MEMBER",
+      "trigger": "slash",
+      "command": "automerge",
+      "intent": "automerge",
+      "trusted_bot": false,
+      "trusted_bot_author": null,
+      "automation_source": "legacy_automerge_bridge",
+      "repair_reason": null,
+      "expected_head_sha": null,
+      "finding_id": null,
+      "status": "executed",
+      "processed_at": "2026-06-19T04:22:41.906Z",
+      "target": {
+        "kind": "pull_request",
+        "branch": "fix/trello-requires-bins-curl",
+        "head_sha": "83ae5e8bef093afe2225e6dae54f1c541aaa889f",
+        "cluster_id": "automerge-openclaw-openclaw-94729",
+        "job_path": "jobs/openclaw/inbox/automerge-openclaw-openclaw-94729.md"
       }
     }
   ]


### PR DESCRIPTION
Records the bounded replay of the existing maintainer automerge command for [openclaw/openclaw#94729](https://github.com/openclaw/openclaw/pull/94729).

- idempotency key: `comment-router:openclaw/openclaw:94729:4747996883:2026-06-19T02:40:43Z:automerge:legacy-automerge-bridge-v1`
- live preflight: open, clean, mergeable, one metadata-only skill dependency declaration
- ClawSweeper dispatch and response comment completed

Validation: `npm run validate` (6,147 jobs).