### PR TITLE
fix: retain unrecorded open target jobs

### DIFF
--- a/scripts/sweep-openclaw-jobs.mjs
+++ b/scripts/sweep-openclaw-jobs.mjs
@@ -126,6 +126,18 @@ function classifyJob(jobPath) {
     return { ...row, status: "delete_test_job", reason: "old smoke/test job has a published result and no open clownfish PR" };
   }
   if (!latest) {
+    if (
+      verifyTargetRefsLive &&
+      row.live_target_refs_total > 0 &&
+      row.live_target_refs_missing === 0 &&
+      row.live_target_refs_open > 0
+    ) {
+      return {
+        ...row,
+        status: "keep",
+        reason: "no published run record found, but target issue/PR refs remain open in live GitHub state",
+      };
+    }
     return { ...row, status: "move_to_stuck", reason: "no published run record found" };
   }
   if (needsRequeue(latest)) {

--- a/test/sweep-openclaw-jobs.test.mjs
+++ b/test/sweep-openclaw-jobs.test.mjs
@@ -126,6 +126,29 @@ test("sweep-openclaw-jobs preserves requeue candidates with open target refs", (
   assert.equal(dryReport.requeue_candidates[0].reason, "latest result has blocked apply actions");
 });
 
+test("sweep-openclaw-jobs keeps unrecorded jobs with open target refs", () => {
+  const fixture = makeFixture();
+  writeJob(path.join(fixture.inbox, "unrecorded-open.md"), {
+    clusterId: "unrecorded-open-cluster",
+    canonical: ["#321"],
+    candidates: ["#321"],
+    clusterRefs: ["#321"],
+  });
+
+  const liveRefReport = path.join(fixture.root, "live-refs.json");
+  fs.writeFileSync(liveRefReport, `${JSON.stringify({ refs: [liveRef(321, "OPEN")] }, null, 2)}\n`);
+
+  const dryRun = sweep(fixture, liveRefReport);
+  assert.equal(dryRun.status, 0, dryRun.stderr || dryRun.stdout);
+  const dryReport = JSON.parse(fs.readFileSync(fixture.report, "utf8"));
+  assert.equal(dryReport.totals.move_to_stuck ?? 0, 0);
+  assert.equal(dryReport.totals.keep, 1);
+  assert.equal(
+    dryReport.keep_jobs[0].reason,
+    "no published run record found, but target issue/PR refs remain open in live GitHub state",
+  );
+});
+
 test("sweep-openclaw-jobs keeps pushed repairs when only post-flight merge is blocked", () => {
   const fixture = makeFixture();
   writeJob(path.join(fixture.inbox, "pushed-repair.md"), {


### PR DESCRIPTION
Prevents `sweep-openclaw-jobs` from moving a job to `outbox/stuck` solely because it lacks a local run record when its target issue or PR is still open in live GitHub state.

This preserves active comment-router and repair lanes while retaining the existing finalize path for closed targets.

Validation:
- node --test test/sweep-openclaw-jobs.test.mjs
- npm run validate