### PR TITLE
chore: plan live PR remediation wave

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260619T052239-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260619T052239-001.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260619T052239-001
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93402"
+  - "#80627"
+  - "#59695"
+  - "#94566"
+  - "#80924"
+cluster_refs:
+  - "#93402"
+  - "#80627"
+  - "#59695"
+  - "#94566"
+  - "#80924"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-19T05:22:39.046Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #93402 fix(gateway): log websocket handshake phase
+
+- bucket: ready_for_maintainer
+- author: 849261680
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-17T00:53:21Z
+- live url: https://github.com/openclaw/openclaw/pull/93402
+
+### #80627 fix: improve error messages for skills update argument validation
+
+- bucket: ready_for_maintainer
+- author: Sujabaral
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-18T10:48:54Z
+- live url: https://github.com/openclaw/openclaw/pull/80627
+
+### #59695 Replace SHA-1 with SHA-256 for config fingerprinting
+
+- bucket: ready_for_maintainer
+- author: YonganZhang
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-18T12:56:07Z
+- live url: https://github.com/openclaw/openclaw/pull/59695
+
+### #94566 fix(android): make offline chat actionable
+
+- bucket: ready_for_maintainer
+- author: Tosko4
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: android, size: M, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-18T13:06:52Z
+- live url: https://github.com/openclaw/openclaw/pull/94566
+
+### #80924 feat(i18n): translate dreaming module UI strings to Simplified Chinese
+
+- bucket: ready_for_maintainer
+- author: git-jxj
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: L, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-18T13:30:47Z
+- live url: https://github.com/openclaw/openclaw/pull/80924

--- a/jobs/openclaw/inbox/live-pr-inventory-20260619T052239-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260619T052239-002.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260619T052239-002
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#73649"
+  - "#94627"
+  - "#78105"
+  - "#78139"
+  - "#78884"
+cluster_refs:
+  - "#73649"
+  - "#94627"
+  - "#78105"
+  - "#78139"
+  - "#78884"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-19T05:22:39.047Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 2
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #73649 fix(issue-template): split logs and screenshots into separate fields
+
+- bucket: ready_for_maintainer
+- author: d1rshan
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P3, rating: diamond lobster, status: ready for maintainer look, proof: video
+- live updated: 2026-06-18T14:11:12Z
+- live url: https://github.com/openclaw/openclaw/pull/73649
+
+### #94627 fix(ios): centralize app accent colors
+
+- bucket: ready_for_maintainer
+- author: zats
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: ios, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-18T17:21:04Z
+- live url: https://github.com/openclaw/openclaw/pull/94627
+
+### #78105 fix(plugins): make empty-allowlist actionable for new users
+
+- bucket: ready_for_maintainer
+- author: pahuchi-joe
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: S, proof: supplied, proof: sufficient, P3, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-18T19:17:49Z
+- live url: https://github.com/openclaw/openclaw/pull/78105
+
+### #78139 fix(cron): hint after disable about list filtering disabled jobs
+
+- bucket: ready_for_maintainer
+- author: kate
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-18T19:18:46Z
+- live url: https://github.com/openclaw/openclaw/pull/78139
+
+### #78884 docs: document local avatar file size limit
+
+- bucket: ready_for_maintainer
+- author: wangjieweb3-design
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-18T19:29:06Z
+- live url: https://github.com/openclaw/openclaw/pull/78884

--- a/jobs/openclaw/inbox/live-pr-inventory-20260619T052239-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260619T052239-003.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260619T052239-003
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#79853"
+  - "#79985"
+  - "#80455"
+  - "#82514"
+  - "#80947"
+cluster_refs:
+  - "#79853"
+  - "#79985"
+  - "#80455"
+  - "#82514"
+  - "#80947"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-19T05:22:39.047Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 3
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #79853 test(model-usage): make helper tests runnable from repo root
+
+- bucket: ready_for_maintainer
+- author: suyua9
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-18T20:18:55Z
+- live url: https://github.com/openclaw/openclaw/pull/79853
+
+### #79985 docs+tests: clarify agents.list visibility scope across CLI and Gateway
+
+- bucket: ready_for_maintainer
+- author: Kansodata
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-18T20:22:58Z
+- live url: https://github.com/openclaw/openclaw/pull/79985
+
+### #80455 fix(doctor): suppress --fix trailer when no pending config changes remain
+
+- bucket: ready_for_maintainer
+- author: KeWang0622
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-18T20:49:32Z
+- live url: https://github.com/openclaw/openclaw/pull/80455
+
+### #82514 feat(ui-i18n): localize Settings toolbar chrome strings (#46217 partial)
+
+- bucket: ready_for_maintainer
+- author: ObliviateRickLin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XL, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-18T21:59:50Z
+- live url: https://github.com/openclaw/openclaw/pull/82514
+
+### #80947 fix(doctor): warn and document QMD session recall gates
+
+- bucket: ready_for_maintainer
+- author: anyech
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, commands, size: S, proof: supplied, proof: sufficient, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-18T23:26:20Z
+- live url: https://github.com/openclaw/openclaw/pull/80947

--- a/jobs/openclaw/inbox/live-pr-inventory-20260619T052239-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260619T052239-004.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260619T052239-004
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#68389"
+  - "#79398"
+  - "#86925"
+  - "#87061"
+  - "#87121"
+cluster_refs:
+  - "#68389"
+  - "#79398"
+  - "#86925"
+  - "#87061"
+  - "#87121"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-19T05:22:39.047Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 4
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #68389 plugins: clarify allowlist warning when entries don't match discovered ids
+
+- bucket: ready_for_maintainer
+- author: lyfuci
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: sufficient, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-19T01:41:59Z
+- live url: https://github.com/openclaw/openclaw/pull/68389
+
+### #79398 Add context compaction quality probes
+
+- bucket: ready_for_maintainer
+- author: martins-oss
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: M, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-19T01:43:55Z
+- live url: https://github.com/openclaw/openclaw/pull/79398
+
+### #86925 i18n(zh-CN): Fix and unify Chinese translation
+
+- bucket: ready_for_maintainer
+- author: YDYm233
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, proof: sufficient, P3, rating: gold shrimp, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-19T04:00:09Z
+- live url: https://github.com/openclaw/openclaw/pull/86925
+
+### #87061 feat(agents): add top-level subsystem logger
+
+- bucket: ready_for_maintainer
+- author: caulslorenzo1-png
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-19T04:01:15Z
+- live url: https://github.com/openclaw/openclaw/pull/87061
+
+### #87121 test(cli): add banner emission reset helper
+
+- bucket: ready_for_maintainer
+- author: lizuju
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-19T04:02:51Z
+- live url: https://github.com/openclaw/openclaw/pull/87121

--- a/jobs/openclaw/inbox/live-pr-inventory-20260619T052239-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260619T052239-005.md
@@ -1,0 +1,94 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260619T052239-005
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#88900"
+  - "#85710"
+  - "#87986"
+  - "#88085"
+cluster_refs:
+  - "#88900"
+  - "#85710"
+  - "#87986"
+  - "#88085"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-19T05:22:39.048Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 5
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #88900 fix(discord): balance truncated progress italics
+
+- bucket: ready_for_maintainer
+- author: charles-openclaw
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: sufficient, P3, rating: gold shrimp, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-19T05:00:12Z
+- live url: https://github.com/openclaw/openclaw/pull/88900
+
+### #85710 fix: use FLAG_TERMINATOR constant in getCommandPathInternal
+
+- bucket: ready_for_maintainer
+- author: d3Lap1ace
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-19T05:02:35Z
+- live url: https://github.com/openclaw/openclaw/pull/85710
+
+### #87986 docs(skills): allow model-usage with Linux codexbar
+
+- bucket: ready_for_maintainer
+- author: shbernal
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: sufficient, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-19T05:06:01Z
+- live url: https://github.com/openclaw/openclaw/pull/87986
+
+### #88085 fix(cli): guard against commander rawArgs API drift in action reparse
+
+- bucket: ready_for_maintainer
+- author: Ylsssq926
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, proof: supplied, proof: sufficient, P3, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-19T05:07:48Z
+- live url: https://github.com/openclaw/openclaw/pull/88085


### PR DESCRIPTION
Adds five plan-only remediation inventory shards covering 24 freshly hydrated P3, proof-sufficient, maintainer-ready OpenClaw PRs.

The source shortlist excludes draft PRs, existing Clownfish/ClawSweeper ownership, human-review, security, triage, and merge-risk labels. Each worker must re-fetch current state and may only emit a plan; no GitHub mutations are allowed by these jobs.

Validation:
- npm run validate