### PR TITLE
chore: add small dedupe plan wave

### DIFF
--- a/jobs/openclaw/inbox/gitcrawl-1050-small-dedupe-wave.md
+++ b/jobs/openclaw/inbox/gitcrawl-1050-small-dedupe-wave.md
@@ -1,0 +1,70 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1050-small-dedupe-wave
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#92141"
+candidates:
+  - "#61009"
+  - "#87213"
+  - "#92141"
+cluster_refs:
+  - "#61009"
+  - "#87213"
+  - "#92141"
+overlap_policy: "skip-any"
+security_policy: central_security_only
+import_security_policy: "skip-any"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #92141 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1050 on 2026-06-19."
+---
+
+# Gitcrawl Cluster 1050
+
+Generated from local gitcrawl run cluster 1050 for `openclaw/openclaw`.
+
+Display title:
+
+> [Bug]: WebChat/OpenAI Codex session does not expose host=node exec despite connected Windows node
+
+Cluster shape from gitcrawl:
+
+- total members: 3
+- issues: 3
+- pull requests: 0
+- open candidates in local store: 3
+- representative: #92141, currently open in local store
+- latest member update: 2026-06-19T02:13:00.151327Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #61009 [Bug]: docs/tools/exec says host=node override is allowed from auto, but runtime rejects it
+- #87213 [Bug]: exec(host=node) rejects same node when bound and requested selectors differ
+- #92141 [Bug]: WebChat/OpenAI Codex session does not expose host=node exec despite connected Windows node

--- a/jobs/openclaw/inbox/gitcrawl-1079-small-dedupe-wave.md
+++ b/jobs/openclaw/inbox/gitcrawl-1079-small-dedupe-wave.md
@@ -1,0 +1,67 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1079-small-dedupe-wave
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#82250"
+candidates:
+  - "#82250"
+  - "#88309"
+cluster_refs:
+  - "#82250"
+  - "#88309"
+overlap_policy: "skip-any"
+security_policy: central_security_only
+import_security_policy: "skip-any"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #82250 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1079 on 2026-06-19."
+---
+
+# Gitcrawl Cluster 1079
+
+Generated from local gitcrawl run cluster 1079 for `openclaw/openclaw`.
+
+Display title:
+
+> macOS LaunchAgent KeepAlive=true restarts after clean already-running gateway exit
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 2
+- pull requests: 0
+- open candidates in local store: 2
+- representative: #82250, currently open in local store
+- latest member update: 2026-06-19T02:13:01.018047Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #82250 macOS LaunchAgent KeepAlive=true restarts after clean already-running gateway exit
+- #88309 Restart race condition with LaunchAgent KeepAlive causes shutdown instead of restart

--- a/jobs/openclaw/inbox/gitcrawl-1247-small-dedupe-wave.md
+++ b/jobs/openclaw/inbox/gitcrawl-1247-small-dedupe-wave.md
@@ -1,0 +1,67 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1247-small-dedupe-wave
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#40945"
+candidates:
+  - "#40945"
+  - "#94466"
+cluster_refs:
+  - "#40945"
+  - "#94466"
+overlap_policy: "skip-any"
+security_policy: central_security_only
+import_security_policy: "skip-any"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #40945 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1247 on 2026-06-19."
+---
+
+# Gitcrawl Cluster 1247
+
+Generated from local gitcrawl run cluster 1247 for `openclaw/openclaw`.
+
+Display title:
+
+> Control UI chat markdown only renders data URI images, not remote https image URLs
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 2
+- pull requests: 0
+- open candidates in local store: 2
+- representative: #40945, currently open in local store
+- latest member update: 2026-06-19T02:13:00.381805Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #40945 Control UI chat markdown only renders data URI images, not remote https image URLs
+- #94466 [Bug]: Native Mac App WebChat cannot open server-hosted images (Open/Download buttons unresponsive, browser Control UI works)

--- a/jobs/openclaw/inbox/gitcrawl-415-small-dedupe-wave.md
+++ b/jobs/openclaw/inbox/gitcrawl-415-small-dedupe-wave.md
@@ -1,0 +1,67 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-415-small-dedupe-wave
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#38439"
+candidates:
+  - "#38439"
+  - "#41201"
+cluster_refs:
+  - "#38439"
+  - "#41201"
+overlap_policy: "skip-any"
+security_policy: central_security_only
+import_security_policy: "skip-any"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #38439 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 415 on 2026-06-19."
+---
+
+# Gitcrawl Cluster 415
+
+Generated from local gitcrawl run cluster 415 for `openclaw/openclaw`.
+
+Display title:
+
+> [Bug] Webchat avatar endpoint /avatar/{agentId} returns 404 even with valid IDENTITY.md avatar
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 2
+- pull requests: 0
+- open candidates in local store: 2
+- representative: #38439, currently open in local store
+- latest member update: 2026-06-19T02:13:00.664719Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #38439 [Bug] Webchat avatar endpoint /avatar/{agentId} returns 404 even with valid IDENTITY.md avatar
+- #41201 [Bug]: Control UI Avatar not displaying (broken image)

--- a/jobs/openclaw/inbox/gitcrawl-818-small-dedupe-wave.md
+++ b/jobs/openclaw/inbox/gitcrawl-818-small-dedupe-wave.md
@@ -1,0 +1,67 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-818-small-dedupe-wave
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#74767"
+candidates:
+  - "#74767"
+  - "#91384"
+cluster_refs:
+  - "#74767"
+  - "#91384"
+overlap_policy: "skip-any"
+security_policy: central_security_only
+import_security_policy: "skip-any"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #74767 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 818 on 2026-06-19."
+---
+
+# Gitcrawl Cluster 818
+
+Generated from local gitcrawl run cluster 818 for `openclaw/openclaw`.
+
+Display title:
+
+> [Bug]: Feishu streaming card messages not searchable — interactive card content not indexed by Feishu search
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 2
+- pull requests: 0
+- open candidates in local store: 2
+- representative: #74767, currently open in local store
+- latest member update: 2026-06-19T02:13:01.209756Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #74767 [Bug]: Feishu streaming card messages not searchable — interactive card content not indexed by Feishu search
+- #91384 [Feishu] Regression since #88276: default renderMode forces plain replies into (non-searchable) streaming cards


### PR DESCRIPTION
Adds five plan-only Gitcrawl jobs for small, unblocked duplicate families.

Each job is read-only in the batch workflow: no close, comment, label, merge, or fix action can be applied.

Validated with npm run validate.