### PR TITLE
fix(worker): recover dispatch and executor timeouts

### DIFF
--- a/.github/workflows/cluster-worker.yml
+++ b/.github/workflows/cluster-worker.yml
@@ -1,6 +1,6 @@
 name: cluster worker
 
-run-name: cluster worker ${{ github.event.client_payload.dispatch_id || github.event.inputs.job || 'manual' }}
+run-name: cluster worker ${{ github.event.client_payload.dispatch_id || github.event.inputs.dispatch_id || github.event.inputs.job || 'manual' }}
 
 on:
   repository_dispatch:
@@ -8,6 +8,11 @@ on:
       - projectclownfish_worker
   workflow_dispatch:
     inputs:
+      dispatch_id:
+        description: "Optional idempotency id for a dispatcher retry"
+        required: false
+        default: ""
+        type: string
       job:
         description: "Job markdown path, for example jobs/openclaw/inbox/cluster-001.md"
         required: true
@@ -565,7 +570,7 @@ jobs:
 
       - name: Execute credited fix artifact
         if: ${{ env.CLOWNFISH_ALLOW_EXECUTE == '1' && env.CLOWNFISH_ALLOW_FIX_PR == '1' }}
-        timeout-minutes: 30
+        timeout-minutes: 50
         run: npm run execute-fix -- "${{ needs.prepare.outputs.job }}" --latest
 
       - name: Apply safe closure actions

--- a/scripts/dispatch-jobs.mjs
+++ b/scripts/dispatch-jobs.mjs
@@ -538,27 +538,7 @@ function dispatchJob(relative, position) {
   if (repositoryWorkerDispatch) return dispatchRepositoryWorker(relative, position);
   return runCommand(
     ghCommand,
-    [
-      "workflow",
-      "run",
-      workflow,
-      "--repo",
-      repo,
-      ...(ref ? ["--ref", ref] : []),
-      "-f",
-      `job=${relative}`,
-      "-f",
-      `mode=${mode}`,
-      "-f",
-      `runner=${runner}`,
-      "-f",
-      `execution_runner=${executionRunner}`,
-      "-f",
-      `model=${model}`,
-      "-f",
-      `dry_run=${dryRunBoolean ? "true" : "false"}`,
-      ...Object.entries(hydrationInputs).flatMap(([name, value]) => ["-f", `${name}=${value}`]),
-    ],
+    workflowDispatchArgs(relative),
     relative,
     position,
   );
@@ -593,7 +573,57 @@ function dispatchRepositoryWorker(relative, position) {
     position,
     `${JSON.stringify(payload)}\n`,
     workerDispatchId,
-  );
+  ).then((result) => {
+    if (!isRepositoryDispatchSchemaBug(result)) return result;
+
+    console.warn(
+      `repository_dispatch returned the known GitHub 422 schema error for ${relative}; retrying via workflow_dispatch`,
+    );
+    return runCommand(
+      ghCommand,
+      workflowDispatchArgs(relative, workerDispatchId),
+      relative,
+      position,
+      null,
+      workerDispatchId,
+    ).then((fallback) => ({
+      ...fallback,
+      dispatch_event: "workflow",
+      dispatch_fallback_reason: "repository_dispatch_422_links_schema",
+    }));
+  });
+}
+
+function workflowDispatchArgs(relative, dispatchId = null) {
+  return [
+    "workflow",
+    "run",
+    workflow,
+    "--repo",
+    repo,
+    "--ref",
+    ref || "main",
+    ...(dispatchId ? ["-f", `dispatch_id=${dispatchId}`] : []),
+    "-f",
+    `job=${relative}`,
+    "-f",
+    `mode=${mode}`,
+    "-f",
+    `runner=${runner}`,
+    "-f",
+    `execution_runner=${executionRunner}`,
+    "-f",
+    `model=${model}`,
+    "-f",
+    `dry_run=${dryRunBoolean ? "true" : "false"}`,
+    ...Object.entries(hydrationInputs).flatMap(([name, value]) => ["-f", `${name}=${value}`]),
+  ];
+}
+
+function isRepositoryDispatchSchemaBug(result) {
+  if (result.status === 0) return false;
+  const output = `${result.stderr ?? ""}\n${result.stdout ?? ""}`;
+  return /HTTP 422/i.test(output) && /links\/0\/schema/i.test(output);
 }
 
 function dispatchRepositoryBatch(batch, position) {
@@ -667,7 +697,8 @@ function dispatchAttempt(result, status) {
     position: result.position,
     dispatched_at: result.dispatched_at ?? new Date().toISOString(),
     batch_dispatch_id: result.batch_dispatch_id ?? null,
-    dispatch_event: dispatchEvent,
+    dispatch_event: result.dispatch_event ?? dispatchEvent,
+    dispatch_fallback_reason: result.dispatch_fallback_reason ?? null,
     error: status === "failed" ? stripAnsi(result.stderr || result.stdout || "") : null,
   };
 }

--- a/scripts/requeue-job.mjs
+++ b/scripts/requeue-job.mjs
@@ -257,8 +257,54 @@ function dispatchJob(jobPath, mode, requiredAncestorSha, dispatchId) {
     },
   );
   if (result.status !== 0) {
+    if (isRepositoryDispatchSchemaBug(result)) {
+      const fallback = spawnSync(
+        "gh",
+        [
+          "workflow",
+          "run",
+          workflow,
+          "--repo",
+          repo,
+          "--ref",
+          "main",
+          "-f",
+          `dispatch_id=${dispatchId}`,
+          "-f",
+          `job=${jobPath}`,
+          "-f",
+          `mode=${mode}`,
+          "-f",
+          `runner=${runner}`,
+          "-f",
+          `execution_runner=${executionRunner}`,
+          "-f",
+          `model=${model}`,
+          "-f",
+          "dry_run=false",
+        ],
+        {
+          cwd: repoRoot(),
+          encoding: "utf8",
+          env: ghEnv(),
+          stdio: "pipe",
+        },
+      );
+      if (fallback.status === 0) {
+        console.warn(
+          `repository_dispatch returned the known GitHub 422 schema error for ${jobPath}; retried via workflow_dispatch`,
+        );
+        return;
+      }
+      throw new Error(`failed to dispatch ${jobPath} with workflow fallback: ${fallback.stderr || fallback.stdout}`);
+    }
     throw new Error(`failed to dispatch ${jobPath}: ${result.stderr || result.stdout}`);
   }
+}
+
+function isRepositoryDispatchSchemaBug(result) {
+  const output = `${result.stderr ?? ""}\n${result.stdout ?? ""}`;
+  return /HTTP 422/i.test(output) && /links\/0\/schema/i.test(output);
 }
 
 function waitForObservedRuns({ expectedCount, dispatchId, since }) {

--- a/test/app-token-auth.test.mjs
+++ b/test/app-token-auth.test.mjs
@@ -190,6 +190,53 @@ test("dispatch supports repository-worker canary dispatch", () => {
   assert.match(result.stdout, /dispatched 1\/1/);
 });
 
+test("repository-worker falls back only from the known GitHub schema 422", () => {
+  const fixture = makeFixture();
+  writeFailingGh(fixture.bin, "gh");
+  const fakeGhx = writeFakeGh(fixture.bin, "ghx");
+  writeShallowCheckoutGit(fixture.bin);
+  const env = {
+    ...process.env,
+    PATH: `${fixture.bin}${path.delimiter}${process.env.PATH}`,
+    EXPECT_REPOSITORY_WORKER_FIELDS: "1",
+    EXPECT_REPOSITORY_DISPATCH_FALLBACK: "1",
+  };
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "scripts/dispatch-jobs.mjs",
+      "jobs/openclaw/inbox/cluster-example.md",
+      "--mode",
+      "autonomous",
+      "--dispatch-event",
+      "repository-worker",
+      "--gh-bin",
+      fakeGhx,
+      "--allow-app-token-auth",
+      "--skip-publish-backlog-check",
+      "--max-live-workers",
+      "1",
+      "--hydrate-comments",
+      "1",
+      "--max-linked-refs",
+      "20",
+      "--max-comments-per-item",
+      "30",
+      "--max-review-comments-per-pr",
+      "50",
+      "--dry-run",
+      "1",
+      "--no-dispatch-ledger",
+    ],
+    { cwd: repoRoot, encoding: "utf8", env },
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stderr, /known GitHub 422 schema error/);
+  assert.match(result.stdout, /dispatched 1\/1/);
+});
+
 test("repository-worker dispatch fetches main when a shallow checkout lacks origin/main", () => {
   const fixture = makeFixture();
   writeFailingGh(fixture.bin, "gh");
@@ -351,6 +398,29 @@ if (args[0] === "variable" && args[1] === "list") {
   process.exit(0);
 }
 if (args[0] === "workflow" && args[1] === "run") {
+  if (process.env.EXPECT_REPOSITORY_DISPATCH_FALLBACK === "1") {
+    if (!args.join(" ").includes("dispatch_id=dispatch-")) {
+      console.error("missing repository dispatch fallback id", args.join(" "));
+      process.exit(1);
+    }
+    for (const expected of [
+      "job=jobs/openclaw/inbox/cluster-example.md",
+      "mode=autonomous",
+      "runner=ubuntu-latest",
+      "execution_runner=blacksmith-16vcpu-ubuntu-2404",
+      "model=gpt-5.5",
+      "dry_run=true",
+      "hydrate_comments=1",
+      "max_linked_refs=20",
+      "max_comments_per_item=30",
+      "max_review_comments_per_pr=50",
+    ]) {
+      if (!args.includes(expected)) {
+        console.error("missing repository fallback field", expected, args.join(" "));
+        process.exit(1);
+      }
+    }
+  }
   if (process.env.EXPECT_HYDRATION_FIELDS === "1") {
     for (const expected of [
       "hydrate_comments=0",
@@ -408,6 +478,10 @@ if (args[0] === "api" && args.includes("repos/openclaw/clownfish/dispatches")) {
       console.error("wrong required_ancestor_sha", client.required_ancestor_sha, "wanted", process.env.EXPECT_REQUIRED_ANCESTOR);
       process.exit(1);
     }
+  }
+  if (process.env.EXPECT_REPOSITORY_DISPATCH_FALLBACK === "1") {
+    console.error("gh: Invalid request.\\nFor 'links/0/schema', nil is not an object. (HTTP 422)");
+    process.exit(1);
   }
   console.log("accepted repository dispatch");
   process.exit(0);

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -63,7 +63,7 @@ test("execute-fix-artifact bounds auxiliary GitHub and git subprocesses by the f
   assert.match(source, /function closeSupersededSourcePr\([\s\S]*?const closed = runStatus\("gh", \["pr", "close"/);
   assert.match(
     workflow,
-    /- name: Execute credited fix artifact[\s\S]*?timeout-minutes: 30[\s\S]*?run: npm run execute-fix/,
+    /- name: Execute credited fix artifact[\s\S]*?timeout-minutes: 50[\s\S]*?run: npm run execute-fix/,
   );
 });
 

--- a/test/requeue-job.test.mjs
+++ b/test/requeue-job.test.mjs
@@ -175,4 +175,5 @@ test("requeue rejects a write-mode override until the job itself is promoted", (
 test("cluster worker run names expose repository dispatch ids", () => {
   const workflow = fs.readFileSync(path.join(repoRoot, ".github/workflows/cluster-worker.yml"), "utf8");
   assert.match(workflow, /run-name: cluster worker .*github\.event\.client_payload\.dispatch_id/);
+  assert.match(workflow, /github\.event\.inputs\.dispatch_id/);
 });


### PR DESCRIPTION
## Summary
- retry repository-worker dispatches through workflow dispatch only for GitHub's known `HTTP 422` `links/0/schema` response
- preserve a dispatch id in workflow titles and dispatch ledger records
- give the executor step enough time to honor its configured 40-minute repair budget and still upload reports
- cover the fallback path and workflow timeout with focused tests

## Validation
- `node --test test/execute-fix-artifact.test.mjs test/app-token-auth.test.mjs test/requeue-job.test.mjs`