### PR TITLE
chore(queue): add plan intake clusters

### DIFF
--- a/jobs/openclaw/inbox/gitcrawl-1101-intake-20260621.md
+++ b/jobs/openclaw/inbox/gitcrawl-1101-intake-20260621.md
@@ -1,0 +1,144 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1101-intake-20260621
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical: []
+candidates:
+  - "#94033"
+cluster_refs:
+  - "#94033"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#50621"
+  - "#78164"
+  - "#82662"
+  - "#82710"
+  - "#84110"
+  - "#84567"
+  - "#84662"
+  - "#84871"
+  - "#85051"
+  - "#85249"
+  - "#86103"
+  - "#86733"
+  - "#86893"
+  - "#86955"
+  - "#88396"
+  - "#89442"
+  - "#91055"
+  - "#91363"
+  - "#91515"
+  - "#92371"
+  - "#93530"
+  - "#93535"
+  - "#93549"
+  - "#93561"
+  - "#93572"
+  - "#93591"
+  - "#93867"
+  - "#93912"
+  - "#93914"
+  - "#94060"
+  - "#94082"
+  - "#94090"
+  - "#94093"
+  - "#94193"
+  - "#94199"
+  - "#94212"
+  - "#94465"
+  - "#94609"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #93530 is already owned by an existing job; worker must choose the best live canonical from the remaining open refs."
+notes: "Generated from gitcrawl run cluster 1101 on 2026-06-21. Existing-overlap refs #50621, #78164, #82662, #82710, #84110, #84567, #84662, #84871, #85051, #85249, #86103, #86733, #86893, #86955, #88396, #89442, #91055, #91363, #91515, #92371, #93530, #93535, #93549, #93561, #93572, #93591, #93867, #93912, #93914, #94060, #94082, #94090, #94093, #94193, #94199, #94212, #94465, #94609 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1101
+
+Generated from local gitcrawl run cluster 1101 for `openclaw/openclaw`.
+
+Display title:
+
+> cron isolated-agent turn: pre-execution watchdog race with runEmbeddedAgent phase reporting
+
+Cluster shape from gitcrawl:
+
+- total members: 39
+- issues: 13
+- pull requests: 26
+- open candidates in local store: 1
+- excluded existing-overlap refs: #50621, #78164, #82662, #82710, #84110, #84567, #84662, #84871, #85051, #85249, #86103, #86733, #86893, #86955, #88396, #89442, #91055, #91363, #91515, #92371, #93530, #93535, #93549, #93561, #93572, #93591, #93867, #93912, #93914, #94060, #94082, #94090, #94093, #94193, #94199, #94212, #94465, #94609
+- representative: #93530, currently open in local store
+- latest member update: 2026-06-19T02:13:01.196338Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #94033 Bug: Cron isolated agent timeout during long tool execution
+
+Existing-overlap context refs:
+
+- #50621 Cron systemEvent job times out after ~960s even though agent runs in main session
+- #78164 [security-signal] Experiment with agent worker runtime isolation
+- #82662 [Bug]: Isolated cron agentTurn fails with 'setup timed out before runner start' — all fallback models exhausted on 2026.5.12
+- #82710 [Feature]: Extend `models status --probe` with Codex app-server viability checks
+- #84110 [Bug]: Codex app-server rewrites prompt on tool-call continuation turns, busting OpenAI prompt cache mid-turn (cache ratio 93% → 47%)
+- #84567 [Bug]: Codex bundled harness initialize still hangs in 2026.5.18 isolated cron — surfaces via #64744 timeout-wrapping as 'isolated agent setup timed out before runner start'
+- #84662 [Bug]: Codex app-server stores per-turn OpenClaw runtime context in native user history, causing runaway response.create input growth
+- #84871 [security-signal] fix(codex): preserve responses session streams
+- #85051 Isolated cron jobs fail: Cannot read properties of undefined (reading 'sourceReplyDeliveryMode')
+- #85249 fix(cron): guard against undefined sourceDelivery in isolated executor
+- #86103 [Bug]: TUI/Web turns remain In progress with Runtime: OpenAI Codex on 2026.5.22 after successful OAuth
+- #86733 fix(cron): extend main system event timeout
+- #86893 Fix isolated cron cold runner setup timeout
+- #86955 fix(runtime): isolate workers and bound cron top-off
+- #88396 feat(cron): make isolated-agent setup watchdog configurable
+- #89442 [security-signal] fix #84567: [Bug]: Codex bundled harness initialize still hangs in 2026.5.18 isolated cron — surfaces via #64744 timeout-wrapping as 'isolated agent setup timed out before runner start'
+- #91055 [security-signal] fix(codex): compact group context without losing mission
+- #91363 Isolated cron consistently fails with "LLM request failed" on model-call-started phase
+- #91515 fix(cron): classify spaced 'timed out' failures as retryable timeout
+- #92371 [security-signal] fix(codex): restore continuity after cron interleave
+- #93530 [security-signal] cron isolated-agent turn: pre-execution watchdog race with runEmbeddedAgent phase reporting
+- #93535 fix(cron): emit before_agent_reply phase unconditionally for cron triggers
+- #93549 [security-signal] fix(cron): clear pre-execution watchdog on any phase signal, not only execution-stage phases
+- #93561 [security-signal] fix(cron): always emit before_agent_reply phase to clear pre-executio…
+- #93572 [security-signal] fix(cron): always emit before_agent_reply phase for cron triggers to prevent watchdog false-positive
+- #93591 fix(cron): clear pre-execution watchdog on any phase notification (#93530)
+- #93867 [Bug]: cron agentTurn isolated-session "model-call-started" timeout blocks all isolated cron jobs intermittently
+- #93912 cron isolated agent pre-execution watchdog aborts runs despite setup progress
+- #93914 [security-signal] fix(cron): treat isolated setup phases as progress
+- #94060 fix(agents): keep lane timeout alive during long tool execution
+- #94082 fix(cron): prevent lane timeout during long tool execution
+- #94090 fix(cron): add lane progress heartbeat during embedded agent tool execution (fixes #94033)
+- #94093 Prevent Codex thread rotation from losing next-step context
+- #94193 fix(cron): prevent lane timeout expiry during long tool execution in isolated cron jobs
+- #94199 fix(cron): retry isolated setup timeouts
+- #94212 [security-signal] fix(cron): always emit before_agent_reply phase for cron triggers to prevent watchdog false-positive
+- #94465 fix(agents): keep lane-task timeout alive during long-running tools (fixes #94033)
+- #94609 fix(codex): keep runtime context out of turn input

--- a/jobs/openclaw/inbox/gitcrawl-1109-intake-20260621.md
+++ b/jobs/openclaw/inbox/gitcrawl-1109-intake-20260621.md
@@ -1,0 +1,104 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1109-intake-20260621
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical: []
+candidates:
+  - "#94426"
+cluster_refs:
+  - "#94426"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#94379"
+  - "#94394"
+  - "#94399"
+  - "#94415"
+  - "#94448"
+  - "#94456"
+  - "#94463"
+  - "#94469"
+  - "#94471"
+  - "#94596"
+  - "#94602"
+  - "#94604"
+  - "#94607"
+  - "#94611"
+  - "#94613"
+  - "#94616"
+  - "#94630"
+  - "#94635"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #94394 is already owned by an existing job; worker must choose the best live canonical from the remaining open refs."
+notes: "Generated from gitcrawl run cluster 1109 on 2026-06-21. Existing-overlap refs #94379, #94394, #94399, #94415, #94448, #94456, #94463, #94469, #94471, #94596, #94602, #94604, #94607, #94611, #94613, #94616, #94630, #94635 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1109
+
+Generated from local gitcrawl run cluster 1109 for `openclaw/openclaw`.
+
+Display title:
+
+> fix(infra): probe 127.0.0.1 in ensurePortAvailable to detect IPv4-only occupants
+
+Cluster shape from gitcrawl:
+
+- total members: 19
+- issues: 3
+- pull requests: 16
+- open candidates in local store: 1
+- excluded existing-overlap refs: #94379, #94394, #94399, #94415, #94448, #94456, #94463, #94469, #94471, #94596, #94602, #94604, #94607, #94611, #94613, #94616, #94630, #94635
+- representative: #94394, currently open in local store
+- latest member update: 2026-06-19T02:13:00.321652Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #94426 isPortBusy preflight misses IPv4-only occupant (same address-family flaw as #94379)
+
+Existing-overlap context refs:
+
+- #94379 [security-signal] [Bug]: ensurePortAvailable() pre-flight misses IPv4-only loopback occupant → Chrome CDP bind fails with misleading "HTTP 401"
+- #94394 [security-signal] fix(infra): probe 127.0.0.1 in ensurePortAvailable to detect IPv4-only occupants
+- #94399 fix(ports): specify IPv4 loopback host in ensurePortAvailable
+- #94415 fix(ports): probe all address families in ensurePortAvailable
+- #94448 fix(cli): add IPv4 loopback host to isPortBusy
+- #94456 [security-signal] fix(cli): route isPortBusy through checkPortInUse to detect IPv4-only occupants
+- #94463 [security-signal] fix: isPortBusy preflight misses IPv4-only occupant
+- #94469 [security-signal] fix(cli): isPortBusy probes all 4 address families to catch IPv4-only listeners
+- #94471 fix: #94426 isPortBusy probes all address families via checkPortInUse
+- #94596 ensurePortAvailable in startSshPortForward misses IPv4-only occupants (same address-family flaw as #94379)
+- #94602 fix(infra): pin ensurePortAvailable to 127.0.0.1 in startSshPortForward
+- #94604 [security-signal] fix(ssh-tunnel): pass 127.0.0.1 host to ensurePortAvailable in startSshPortForward
+- #94607 fix(ssh): scope tunnel port preflight to loopback (#94603)
+- #94611 fix(infra): pin ensurePortAvailable to 127.0.0.1 in startSshPortForward (fixes #94596)
+- #94613 fix(ssh-tunnel): pin ensurePortAvailable to IPv4 loopback
+- #94616 fix(ssh): bind ensurePortAvailable to IPv4 loopback
+- #94630 [security-signal] fix(infra): bind ensurePortAvailable to 127.0.0.1 in startSshPortForward
+- #94635 [security-signal] fix(infra): pass 127.0.0.1 to ensurePortAvailable in SSH tunnel start

--- a/jobs/openclaw/inbox/gitcrawl-1111-intake-20260621.md
+++ b/jobs/openclaw/inbox/gitcrawl-1111-intake-20260621.md
@@ -1,0 +1,102 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1111-intake-20260621
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical: []
+candidates:
+  - "#93205"
+cluster_refs:
+  - "#93205"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#45082"
+  - "#52120"
+  - "#52236"
+  - "#69010"
+  - "#71930"
+  - "#72513"
+  - "#77378"
+  - "#77442"
+  - "#93203"
+  - "#93204"
+  - "#93232"
+  - "#93234"
+  - "#93242"
+  - "#93243"
+  - "#93264"
+  - "#93692"
+  - "#93865"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #93264 is already owned by an existing job; worker must choose the best live canonical from the remaining open refs."
+notes: "Generated from gitcrawl run cluster 1111 on 2026-06-21. Existing-overlap refs #45082, #52120, #52236, #69010, #71930, #72513, #77378, #77442, #93203, #93204, #93232, #93234, #93242, #93243, #93264, #93692, #93865 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1111
+
+Generated from local gitcrawl run cluster 1111 for `openclaw/openclaw`.
+
+Display title:
+
+> fix(mattermost): wake agent on bare @bot mention [AI]
+
+Cluster shape from gitcrawl:
+
+- total members: 18
+- issues: 6
+- pull requests: 12
+- open candidates in local store: 1
+- excluded existing-overlap refs: #45082, #52120, #52236, #69010, #71930, #72513, #77378, #77442, #93203, #93204, #93232, #93234, #93242, #93243, #93264, #93692, #93865
+- representative: #93264, currently open in local store
+- latest member update: 2026-06-19T02:13:01.010151Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #93205 Mattermost: bare @mention with no body text is dropped instead of waking the agent (split from #65729)
+
+Existing-overlap context refs:
+
+- #45082 fix(mattermost): proactive message tool sends ignore thread context
+- #52120 fix(mattermost): inherit thread context in message tool send action
+- #52236 fix(mattermost): persist threadId in delivery context for all session types
+- #69010 [security-signal] fix(gateway): prefer current route delivery context
+- #71930 Mattermost plugin drops post_edited events — @mentions added via edit do not trigger agent wake
+- #72513 fix(mattermost): handle post_edited websocket events (#71930)
+- #77378 [Bug]: Session rotation creates duplicate sessions with broken delivery context
+- #77442 fix(session): persist delivery context for inbound non-direct sessions
+- #93203 Mattermost: make DM threading configurable (dmReplyToMode) — split from #65729
+- #93204 Mattermost: thread context lost after restart/session-clear — no server-side backfill (split from #65729)
+- #93232 fix(mattermost): allow bare @mention with empty body to wake the agent (fixes #93205)
+- #93234 fix(mattermost): backfill thread history only on first-sighting recovery
+- #93242 fix(mattermost): keep bare @mention with empty body instead of dropping it
+- #93243 fix(mattermost): backfill thread history from server when in-memory window is empty
+- #93264 [security-signal] fix(mattermost): wake agent on bare @bot mention [AI]
+- #93692 fix(mattermost): backfill thread history from server when in-memory window is empty (fixes #93204)
+- #93865 [security-signal] fix(mattermost): backfill thread history from server when in-memory window is empty

--- a/jobs/openclaw/inbox/gitcrawl-1181-intake-20260621.md
+++ b/jobs/openclaw/inbox/gitcrawl-1181-intake-20260621.md
@@ -1,0 +1,75 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1181-intake-20260621
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#94360"
+candidates:
+  - "#94360"
+cluster_refs:
+  - "#94360"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#94374"
+  - "#94381"
+  - "#94454"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #94360 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1181 on 2026-06-21. Existing-overlap refs #94374, #94381, #94454 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1181
+
+Generated from local gitcrawl run cluster 1181 for `openclaw/openclaw`.
+
+Display title:
+
+> [Bug]: Feishu - exec stderr output sent as user-visible reply, covers actual agent response
+
+Cluster shape from gitcrawl:
+
+- total members: 4
+- issues: 1
+- pull requests: 3
+- open candidates in local store: 1
+- excluded existing-overlap refs: #94374, #94381, #94454
+- representative: #94360, currently open in local store
+- latest member update: 2026-06-18T11:25:19.633972Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #94360 [Bug]: Feishu - exec stderr output sent as user-visible reply, covers actual agent response
+
+Existing-overlap context refs:
+
+- #94374 [security-signal] fix: suppress exec stderr warnings from covering channel replies (#94360)
+- #94381 #94360: Feishu - exec stderr output sent as user-visible reply
+- #94454 fix: separate exec stdout from stderr for user-facing output (#94360)

--- a/jobs/openclaw/inbox/gitcrawl-1219-intake-20260621.md
+++ b/jobs/openclaw/inbox/gitcrawl-1219-intake-20260621.md
@@ -1,0 +1,72 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1219-intake-20260621
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical: []
+candidates:
+  - "#93770"
+cluster_refs:
+  - "#93770"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#93579"
+  - "#93838"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #93838 is already owned by an existing job; worker must choose the best live canonical from the remaining open refs."
+notes: "Generated from gitcrawl run cluster 1219 on 2026-06-21. Existing-overlap refs #93579, #93838 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1219
+
+Generated from local gitcrawl run cluster 1219 for `openclaw/openclaw`.
+
+Display title:
+
+> fix(telegram): enhance richMessages config help text with troubleshooting guidance
+
+Cluster shape from gitcrawl:
+
+- total members: 3
+- issues: 1
+- pull requests: 2
+- open candidates in local store: 1
+- excluded existing-overlap refs: #93579, #93838
+- representative: #93838, currently open in local store
+- latest member update: 2026-06-19T02:13:00.617054Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #93770 [Feature]: Add config option to disable Telegram Rich-Text (sendRichMessage)
+
+Existing-overlap context refs:
+
+- #93579 feat(telegram): add richMessagesAutoDetect opt-in config field
+- #93838 [security-signal] fix(telegram): enhance richMessages config help text with troubleshooting guidance

--- a/jobs/openclaw/inbox/gitcrawl-1238-intake-20260621.md
+++ b/jobs/openclaw/inbox/gitcrawl-1238-intake-20260621.md
@@ -1,0 +1,73 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1238-intake-20260621
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#94269"
+candidates:
+  - "#94269"
+cluster_refs:
+  - "#94269"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#94404"
+  - "#94461"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #94269 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1238 on 2026-06-21. Existing-overlap refs #94404, #94461 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1238
+
+Generated from local gitcrawl run cluster 1238 for `openclaw/openclaw`.
+
+Display title:
+
+> Z.ai static catalog models resolve without baseUrl and fall through to OpenAI API
+
+Cluster shape from gitcrawl:
+
+- total members: 3
+- issues: 1
+- pull requests: 2
+- open candidates in local store: 1
+- excluded existing-overlap refs: #94404, #94461
+- representative: #94269, currently open in local store
+- latest member update: 2026-06-19T02:13:00.536015Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #94269 Z.ai static catalog models resolve without baseUrl and fall through to OpenAI API
+
+Existing-overlap context refs:
+
+- #94404 fix(zai): fall back to default baseUrl when template lacks one for catalog models
+- #94461 [security-signal] fix(zai): fall back to manifest baseUrl for synthesized GLM-5 models

--- a/jobs/openclaw/inbox/gitcrawl-1240-intake-20260621.md
+++ b/jobs/openclaw/inbox/gitcrawl-1240-intake-20260621.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1240-intake-20260621
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#92827"
+candidates:
+  - "#92827"
+cluster_refs:
+  - "#92827"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#92872"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #92827 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1240 on 2026-06-21. Existing-overlap refs #92872 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1240
+
+Generated from local gitcrawl run cluster 1240 for `openclaw/openclaw`.
+
+Display title:
+
+> [Bug]: 如果启用沙箱，agent无法将文件发送到webchat和QQBot
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #92872
+- representative: #92827, currently open in local store
+- latest member update: 2026-06-19T02:13:01.177688Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #92827 [Bug]: 如果启用沙箱，agent无法将文件发送到webchat和QQBot
+
+Existing-overlap context refs:
+
+- #92872 [security-signal] fix(qqbot): allow scoped sandbox media sends

--- a/jobs/openclaw/inbox/gitcrawl-1242-intake-20260621.md
+++ b/jobs/openclaw/inbox/gitcrawl-1242-intake-20260621.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1242-intake-20260621
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#88812"
+candidates:
+  - "#88812"
+cluster_refs:
+  - "#88812"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#94459"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #88812 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1242 on 2026-06-21. Existing-overlap refs #94459 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1242
+
+Generated from local gitcrawl run cluster 1242 for `openclaw/openclaw`.
+
+Display title:
+
+> Measure and reduce OpenClaw-owned pre-model latency in channel replies
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #94459
+- representative: #88812, currently open in local store
+- latest member update: 2026-06-19T02:13:00.403875Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #88812 Measure and reduce OpenClaw-owned pre-model latency in channel replies
+
+Existing-overlap context refs:
+
+- #94459 fix: add OTel reply latency decomposition


### PR DESCRIPTION
Adds eight plan-only Gitcrawl intake jobs for untracked active members.

The importer used `--overlap-policy exclude-existing`; security-sensitive and blocked candidates remained excluded.

Validation: `npm run validate`.