### PR TITLE
chore: add plan intake batch

### DIFF
--- a/jobs/openclaw/inbox/gitcrawl-1243-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1243-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1243-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#42351"
+candidates:
+  - "#42351"
+cluster_refs:
+  - "#42351"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#92893"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #42351 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1243 on 2026-06-21. Existing-overlap refs #92893 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1243
+
+Generated from local gitcrawl run cluster 1243 for `openclaw/openclaw`.
+
+Display title:
+
+> Gateway 重启 - 缺少 bot_p2p_chat_entered_v1 事件处理器
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #92893
+- representative: #42351, currently open in local store
+- latest member update: 2026-06-15T19:04:12.647591Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #42351 Gateway 重启 - 缺少 bot_p2p_chat_entered_v1 事件处理器
+
+Existing-overlap context refs:
+
+- #92893 fix(feishu): ignore bot_p2p_chat_entered_v1 events to prevent gateway restarts (fixes #42351)

--- a/jobs/openclaw/inbox/gitcrawl-1244-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1244-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1244-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#41495"
+candidates:
+  - "#41495"
+cluster_refs:
+  - "#41495"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#93101"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #41495 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1244 on 2026-06-21. Existing-overlap refs #93101 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1244
+
+Generated from local gitcrawl run cluster 1244 for `openclaw/openclaw`.
+
+Display title:
+
+> Gemini models output inline buttons as raw JSON text instead of using tool format
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #93101
+- representative: #41495, currently open in local store
+- latest member update: 2026-06-19T02:13:00.566858Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #41495 Gemini models output inline buttons as raw JSON text instead of using tool format
+
+Existing-overlap context refs:
+
+- #93101 fix(message-tool): parse inline [[...]] button JSON from model text output

--- a/jobs/openclaw/inbox/gitcrawl-1245-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1245-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1245-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#92425"
+candidates:
+  - "#92425"
+cluster_refs:
+  - "#92425"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#92898"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #92425 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1245 on 2026-06-21. Existing-overlap refs #92898 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1245
+
+Generated from local gitcrawl run cluster 1245 for `openclaw/openclaw`.
+
+Display title:
+
+> skill_workshop: increase or make configurable the 160-byte description limit
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #92898
+- representative: #92425, currently open in local store
+- latest member update: 2026-06-19T02:13:01.183781Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #92425 skill_workshop: increase or make configurable the 160-byte description limit
+
+Existing-overlap context refs:
+
+- #92898 [security-signal] skill_workshop: increase or make configurable the 160-byte description limit

--- a/jobs/openclaw/inbox/gitcrawl-1252-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1252-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1252-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#33413"
+candidates:
+  - "#33413"
+cluster_refs:
+  - "#33413"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#94345"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #33413 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1252 on 2026-06-21. Existing-overlap refs #94345 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1252
+
+Generated from local gitcrawl run cluster 1252 for `openclaw/openclaw`.
+
+Display title:
+
+> Slack: Show tool-level progress in assistant thread status
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #94345
+- representative: #33413, currently open in local store
+- latest member update: 2026-06-19T02:13:00.519084Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #33413 Slack: Show tool-level progress in assistant thread status
+
+Existing-overlap context refs:
+
+- #94345 feat(slack): update assistant thread status text per tool during execution (fixes #33413)

--- a/jobs/openclaw/inbox/gitcrawl-1261-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1261-intake-20260621b.md
@@ -1,0 +1,70 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1261-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical: []
+candidates:
+  - "#93728"
+cluster_refs:
+  - "#93728"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#88750"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #88750 is already owned by an existing job; worker must choose the best live canonical from the remaining open refs."
+notes: "Generated from gitcrawl run cluster 1261 on 2026-06-21. Existing-overlap refs #88750 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1261
+
+Generated from local gitcrawl run cluster 1261 for `openclaw/openclaw`.
+
+Display title:
+
+> feat(context-engine): pass runtime settings into lifecycle
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #88750
+- representative: #88750, currently open in local store
+- latest member update: 2026-06-19T02:13:00.631678Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #93728 Implement RFC 0008: Context Engine Runtime Settings
+
+Existing-overlap context refs:
+
+- #88750 feat(context-engine): pass runtime settings into lifecycle

--- a/jobs/openclaw/inbox/gitcrawl-1266-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1266-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1266-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#56068"
+candidates:
+  - "#56068"
+cluster_refs:
+  - "#56068"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#93699"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #56068 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1266 on 2026-06-21. Existing-overlap refs #93699 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1266
+
+Generated from local gitcrawl run cluster 1266 for `openclaw/openclaw`.
+
+Display title:
+
+> UI seamColor config setting is ignored by frontend
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #93699
+- representative: #56068, currently open in local store
+- latest member update: 2026-06-19T02:13:00.634342Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #56068 UI seamColor config setting is ignored by frontend
+
+Existing-overlap context refs:
+
+- #93699 [security-signal] fix(control-ui): apply seamColor bootstrap config

--- a/jobs/openclaw/inbox/gitcrawl-1272-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1272-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1272-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#51333"
+candidates:
+  - "#51333"
+cluster_refs:
+  - "#51333"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#93106"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #51333 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1272 on 2026-06-21. Existing-overlap refs #93106 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1272
+
+Generated from local gitcrawl run cluster 1272 for `openclaw/openclaw`.
+
+Display title:
+
+> Document the cloud-orchestrator plus local-text-workers pattern
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #93106
+- representative: #51333, currently open in local store
+- latest member update: 2026-06-19T02:13:00.717894Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #51333 Document the cloud-orchestrator plus local-text-workers pattern
+
+Existing-overlap context refs:
+
+- #93106 [security-signal] docs(gateway): add cloud-orchestrator plus local-text-workers pattern

--- a/jobs/openclaw/inbox/gitcrawl-1275-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1275-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1275-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#91243"
+candidates:
+  - "#91243"
+cluster_refs:
+  - "#91243"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#93143"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #91243 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1275 on 2026-06-21. Existing-overlap refs #93143 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1275
+
+Generated from local gitcrawl run cluster 1275 for `openclaw/openclaw`.
+
+Display title:
+
+> Remove client-side iMessage split-send coalescing once imsg coalesces upstream
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #93143
+- representative: #91243, currently open in local store
+- latest member update: 2026-06-19T02:13:01.141334Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #91243 Remove client-side iMessage split-send coalescing once imsg coalesces upstream
+
+Existing-overlap context refs:
+
+- #93143 fix(imessage): keep split-send coalescing opt-in

--- a/jobs/openclaw/inbox/gitcrawl-1278-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1278-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1278-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#64334"
+candidates:
+  - "#64334"
+cluster_refs:
+  - "#64334"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#94308"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #64334 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1278 on 2026-06-21. Existing-overlap refs #94308 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1278
+
+Generated from local gitcrawl run cluster 1278 for `openclaw/openclaw`.
+
+Display title:
+
+> Add session cost to /status output
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #94308
+- representative: #64334, currently open in local store
+- latest member update: 2026-06-19T02:13:00.04963Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #64334 Add session cost to /status output
+
+Existing-overlap context refs:
+
+- #94308 feat(status): show session costs

--- a/jobs/openclaw/inbox/gitcrawl-1282-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1282-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1282-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#90254"
+candidates:
+  - "#90254"
+cluster_refs:
+  - "#90254"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#94506"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #90254 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1282 on 2026-06-21. Existing-overlap refs #94506 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1282
+
+Generated from local gitcrawl run cluster 1282 for `openclaw/openclaw`.
+
+Display title:
+
+> [Bug]: webhookUrl configured but long-polling transport still runs getUpdates, continuously wiping the registered webhook
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #94506
+- representative: #90254, currently open in local store
+- latest member update: 2026-06-19T02:13:00.889437Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #90254 [Bug]: webhookUrl configured but long-polling transport still runs getUpdates, continuously wiping the registered webhook
+
+Existing-overlap context refs:
+
+- #94506 fix(telegram): stop clearing registered webhook on channel restart

--- a/jobs/openclaw/inbox/gitcrawl-1288-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1288-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1288-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#89352"
+candidates:
+  - "#89352"
+cluster_refs:
+  - "#89352"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#94526"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #89352 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1288 on 2026-06-21. Existing-overlap refs #94526 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1288
+
+Generated from local gitcrawl run cluster 1288 for `openclaw/openclaw`.
+
+Display title:
+
+> Telegram forum topics: streaming think-block causes reply to drop message_thread_id
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #94526
+- representative: #89352, currently open in local store
+- latest member update: 2026-06-19T02:13:00.257004Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #89352 Telegram forum topics: streaming think-block causes reply to drop message_thread_id
+
+Existing-overlap context refs:
+
+- #94526 test(telegram): add regression test for forum topic message_thread_id with streamed reasoning

--- a/jobs/openclaw/inbox/gitcrawl-1292-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1292-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1292-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#81103"
+candidates:
+  - "#81103"
+cluster_refs:
+  - "#81103"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#93091"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #81103 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1292 on 2026-06-21. Existing-overlap refs #93091 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1292
+
+Generated from local gitcrawl run cluster 1292 for `openclaw/openclaw`.
+
+Display title:
+
+> [Bug]: Feishu inbound JSON file_name CJK mojibake (distinct from Content-Disposition path)
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #93091
+- representative: #81103, currently open in local store
+- latest member update: 2026-06-15T19:04:12.172136Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #81103 [Bug]: Feishu inbound JSON file_name CJK mojibake (distinct from Content-Disposition path)
+
+Existing-overlap context refs:
+
+- #93091 fix(feishu): recover CJK filenames from JSON file_name field (fixes #81103)

--- a/jobs/openclaw/inbox/gitcrawl-1294-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1294-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1294-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#80569"
+candidates:
+  - "#80569"
+cluster_refs:
+  - "#80569"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#94051"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #80569 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1294 on 2026-06-21. Existing-overlap refs #94051 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1294
+
+Generated from local gitcrawl run cluster 1294 for `openclaw/openclaw`.
+
+Display title:
+
+> Telegram replies ignore silent notification intent and leak `notify=false` into message body
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #94051
+- representative: #80569, currently open in local store
+- latest member update: 2026-06-19T02:13:00.492553Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #80569 Telegram replies ignore silent notification intent and leak `notify=false` into message body
+
+Existing-overlap context refs:
+
+- #94051 fix(telegram): strip trailing notify=false marker and send as silent

--- a/jobs/openclaw/inbox/gitcrawl-1302-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1302-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1302-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#78481"
+candidates:
+  - "#78481"
+cluster_refs:
+  - "#78481"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#93082"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #78481 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1302 on 2026-06-21. Existing-overlap refs #93082 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1302
+
+Generated from local gitcrawl run cluster 1302 for `openclaw/openclaw`.
+
+Display title:
+
+> Update button silently no-ops when update.run is coalesced
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #93082
+- representative: #78481, currently open in local store
+- latest member update: 2026-06-19T02:13:00.660056Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #78481 Update button silently no-ops when update.run is coalesced
+
+Existing-overlap context refs:
+
+- #93082 [security-signal] fix(ui): show coalesced update restarts

--- a/jobs/openclaw/inbox/gitcrawl-1304-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1304-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1304-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#78177"
+candidates:
+  - "#78177"
+cluster_refs:
+  - "#78177"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#94112"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #78177 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1304 on 2026-06-21. Existing-overlap refs #94112 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1304
+
+Generated from local gitcrawl run cluster 1304 for `openclaw/openclaw`.
+
+Display title:
+
+> Reply delivery can leak current-message scaffolding and '(no output)' placeholders
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #94112
+- representative: #78177, currently open in local store
+- latest member update: 2026-06-19T02:13:00.060333Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #78177 Reply delivery can leak current-message scaffolding and '(no output)' placeholders
+
+Existing-overlap context refs:
+
+- #94112 fix(reply): strip leaked current-message scaffolding and (no output) placeholders

--- a/jobs/openclaw/inbox/gitcrawl-1306-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1306-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1306-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#88253"
+candidates:
+  - "#88253"
+cluster_refs:
+  - "#88253"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#93224"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #88253 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1306 on 2026-06-21. Existing-overlap refs #93224 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1306
+
+Generated from local gitcrawl run cluster 1306 for `openclaw/openclaw`.
+
+Display title:
+
+> Sandboxed agents can't reply to channel DMs — message tool excluded from default sandbox allowlist; plain-text reply routes to internal webchat
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #93224
+- representative: #88253, currently open in local store
+- latest member update: 2026-06-19T02:13:01.013565Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #88253 Sandboxed agents can't reply to channel DMs — message tool excluded from default sandbox allowlist; plain-text reply routes to internal webchat
+
+Existing-overlap context refs:
+
+- #93224 [security-signal] [codex] Allow message tool in default sandbox allowlist

--- a/jobs/openclaw/inbox/gitcrawl-1308-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1308-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1308-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#76496"
+candidates:
+  - "#76496"
+cluster_refs:
+  - "#76496"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#93045"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #76496 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1308 on 2026-06-21. Existing-overlap refs #93045 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1308
+
+Generated from local gitcrawl run cluster 1308 for `openclaw/openclaw`.
+
+Display title:
+
+> sessions.usage: aggregate totals silently capped by limit parameter
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #93045
+- representative: #76496, currently open in local store
+- latest member update: 2026-06-15T19:04:12.371928Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #76496 sessions.usage: aggregate totals silently capped by limit parameter
+
+Existing-overlap context refs:
+
+- #93045 fix(gateway): compute sessions.usage aggregate totals from all sessions, not just the limited page (fixes #76496)

--- a/jobs/openclaw/inbox/gitcrawl-1309-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1309-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1309-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#75152"
+candidates:
+  - "#75152"
+cluster_refs:
+  - "#75152"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#94481"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #75152 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1309 on 2026-06-21. Existing-overlap refs #94481 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1309
+
+Generated from local gitcrawl run cluster 1309 for `openclaw/openclaw`.
+
+Display title:
+
+> [Bug]:  Edit faild, cant correctly use Edit tool
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #94481
+- representative: #75152, currently open in local store
+- latest member update: 2026-06-19T02:13:00.557016Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #75152 [Bug]:  Edit faild, cant correctly use Edit tool
+
+Existing-overlap context refs:
+
+- #94481 fix(edit): unwrap XML-RPC {item: {oldText, newText}} edit transport shape

--- a/jobs/openclaw/inbox/gitcrawl-1324-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1324-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1324-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#83879"
+candidates:
+  - "#83879"
+cluster_refs:
+  - "#83879"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#93188"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #83879 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1324 on 2026-06-21. Existing-overlap refs #93188 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1324
+
+Generated from local gitcrawl run cluster 1324 for `openclaw/openclaw`.
+
+Display title:
+
+> No tests cover parseRootCommand or the command-dispatch switch in main()
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #93188
+- representative: #83879, currently open in local store
+- latest member update: 2026-06-15T19:04:12.05537Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #83879 No tests cover parseRootCommand or the command-dispatch switch in main()
+
+Existing-overlap context refs:
+
+- #93188 test(macos): cover root CLI command parsing

--- a/jobs/openclaw/inbox/gitcrawl-1325-intake-20260621b.md
+++ b/jobs/openclaw/inbox/gitcrawl-1325-intake-20260621b.md
@@ -1,0 +1,71 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-1325-intake-20260621b
+mode: plan
+allowed_actions:
+  - comment
+  - label
+  - close
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+  - fix
+  - raise_pr
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#84623"
+candidates:
+  - "#84623"
+cluster_refs:
+  - "#84623"
+overlap_policy: "exclude-existing"
+existing_overlap_refs:
+  - "#94294"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+canonical_hint: "gitcrawl representative #84623 is open; worker must verify it is still the best live canonical."
+notes: "Generated from gitcrawl run cluster 1325 on 2026-06-21. Existing-overlap refs #94294 were excluded from actionable refs and kept as context only."
+---
+
+# Gitcrawl Cluster 1325
+
+Generated from local gitcrawl run cluster 1325 for `openclaw/openclaw`.
+
+Display title:
+
+> Non-streaming dispatchReplyFromConfig delivers final reply payload twice
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 1
+- pull requests: 1
+- open candidates in local store: 1
+- excluded existing-overlap refs: #94294
+- representative: #84623, currently open in local store
+- latest member update: 2026-06-19T02:13:00.108041Z
+
+## Goal
+
+Classify the open candidate issues and PRs in read-only plan mode. Do not close anything. If the representative is closed, report whether another open item should become the live canonical. If the cluster contains multiple root causes, split them in the action matrix instead of forcing a single duplicate family.
+
+## Member Inventory
+
+Closed context refs:
+
+- none
+
+Open candidates:
+
+- #84623 Non-streaming dispatchReplyFromConfig delivers final reply payload twice
+
+Existing-overlap context refs:
+
+- #94294 [security-signal] fix: dedupe duplicate non-streaming final replies


### PR DESCRIPTION
Adds 20 disjoint gitcrawl cluster jobs for read-only plan classification.

The importer skipped existing, overlapped, blocked-label, product feature, and security-sensitive clusters. Every generated job remains `mode: plan`; fix, merge, and replacement-PR actions are blocked.

Validation: `npm run validate`