### PR TITLE
fix: honor calibrated repair retries

### DIFF
--- a/jobs/openclaw/inbox/automerge-openclaw-openclaw-92230.md
+++ b/jobs/openclaw/inbox/automerge-openclaw-openclaw-92230.md
@@ -25,6 +25,8 @@ allow_merge: false
 allow_unmerged_fix_close: false
 allow_post_merge_close: false
 require_fix_before_close: true
+force_fresh_repair: true
+preserve_focused_validation: true
 security_policy: central_security_only
 security_sensitive: false
 target_branch: clownfish/automerge-openclaw-openclaw-92230

--- a/schemas/job.schema.json
+++ b/schemas/job.schema.json
@@ -78,6 +78,12 @@
     "allow_post_merge_close": {
       "type": "boolean"
     },
+    "force_fresh_repair": {
+      "type": "boolean"
+    },
+    "preserve_focused_validation": {
+      "type": "boolean"
+    },
     "security_policy": {
       "type": "string",
       "enum": ["central_security_only"]

--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -116,6 +116,8 @@ if (jobErrors.length > 0) {
   console.error(jobErrors.join("\n"));
   process.exit(1);
 }
+const forceFreshRepair = job.frontmatter.force_fresh_repair === true;
+const preserveFocusedValidation = job.frontmatter.preserve_focused_validation === true;
 
 assertAllowedOwner(job.frontmatter.repo, process.env.CLOWNFISH_ALLOWED_OWNER);
 
@@ -218,6 +220,8 @@ if (rebaseOnlyRepair) {
 }
 noteFixStage("execution_started", {
   rebase_only: rebaseOnlyRepair,
+  force_fresh_repair: forceFreshRepair,
+  preserve_focused_validation: preserveFocusedValidation,
   fix_step_timeout_ms: fixStepDeadlineAtMs - fixExecutionStartedAtMs,
 });
 const rebaseOnlyBlock = validateRebaseOnlyRepair({ job, fixArtifact });
@@ -778,7 +782,7 @@ function executeRepairBranch({ fixArtifact, job, targetDir, scopeBlock = null, r
     baseBranch,
     // Fresh contributor repairs need an edit. A prior Clownfish checkpoint has
     // already been edited, so a requeue should validate and review it instead.
-    allowExistingChanges: (rebaseOnly && rebased) || resumedRepairCheckpoint,
+    allowExistingChanges: !forceFreshRepair && ((rebaseOnly && rebased) || resumedRepairCheckpoint),
     allowReviewFixes: !rebaseOnly,
     refreshBaseBeforeReview: rebaseOnly,
     allowedFixFiles,
@@ -2972,7 +2976,7 @@ function targetValidationEnv() {
 function resolveAllowedValidationCommands(command, cwd, baseBranch = DEFAULT_BASE_BRANCH) {
   const parts = parseAllowedValidationCommand(command);
   const scripts = readPackageScriptSet(cwd);
-  if (!strictTargetValidation && scripts.has("check:changed")) {
+  if (!strictTargetValidation && !preserveFocusedValidation && scripts.has("check:changed")) {
     return [["pnpm", "check:changed"]];
   }
   if (parts[0] === "npm" && parts[1] === "run" && parts[2] === "validate") {

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -390,6 +390,8 @@ export function validateJob(job) {
     "allow_broad_fix_artifacts",
     "require_fix_before_close",
     "rebase_only",
+    "force_fresh_repair",
+    "preserve_focused_validation",
     "security_sensitive",
   ]) {
     if (fm[key] !== undefined && typeof fm[key] !== "boolean") {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -315,18 +315,26 @@ test("execute-fix-artifact falls back to replacement when review proves a contri
   assert.match(fallback, /if \(unsafeContributorDiff\) return true;/);
 });
 
-test("execute-fix-artifact resumes contributor checkpoint branches without a duplicate edit", () => {
+test("execute-fix-artifact resumes contributor checkpoint branches unless a fresh repair is required", () => {
   const source = fs.readFileSync(path.join(repoRoot, "scripts", "execute-fix-artifact.mjs"), "utf8");
 
   assert.match(
     source,
     /const resumedRepairCheckpoint = hasClownfishRepairCheckpoint\(\{\s*targetDir,\s*baseBranch,\s*clusterId: result\.cluster_id,\s*\}\);/,
   );
-  assert.match(source, /allowExistingChanges: \(rebaseOnly && rebased\) \|\| resumedRepairCheckpoint,/);
+  assert.match(source, /const forceFreshRepair = job\.frontmatter\.force_fresh_repair === true;/);
+  assert.match(source, /allowExistingChanges: !forceFreshRepair && \(\(rebaseOnly && rebased\) \|\| resumedRepairCheckpoint\),/);
   assert.match(
     source,
     /function hasClownfishRepairCheckpoint\(\{ targetDir, baseBranch, clusterId \}\) \{[\s\S]*?git", \["log", "--format=%s", `origin\/\$\{baseBranch\}\.\.HEAD`\]/,
   );
+});
+
+test("execute-fix-artifact preserves requested focused validation ahead of changed-only normalization", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "execute-fix-artifact.mjs"), "utf8");
+
+  assert.match(source, /const preserveFocusedValidation = job\.frontmatter\.preserve_focused_validation === true;/);
+  assert.match(source, /if \(!strictTargetValidation && !preserveFocusedValidation && scripts\.has\("check:changed"\)\) \{/);
 });
 
 test("execute-fix-artifact checkpoints contributor repairs before slow validation", () => {


### PR DESCRIPTION
Makes calibrated repair jobs enforce their explicit requirements without changing global validation policy.

- `force_fresh_repair` does not treat an older Clownfish checkpoint as a completed repair
- `preserve_focused_validation` keeps named test files ahead of the normal changed-only gate
- applies both controls to the #92230 retry job

Validation: `npm test` (220 passing), `npm run validate`