### PR TITLE
fix(jobs): preserve 92230 binding guard

### DIFF
--- a/jobs/openclaw/inbox/automerge-openclaw-openclaw-92230.md
+++ b/jobs/openclaw/inbox/automerge-openclaw-openclaw-92230.md
@@ -49,10 +49,10 @@ Clownfish should use this job only for the bounded ClawSweeper review/fix loop:
 
 ## Pinned repair requirements
 
-Start from the current source PR head `917bfb2cc552c40fa6e8d20233c4d2b2e4ab4db2`. Do not rebase or replay the existing Telegram sanitizer patch without addressing these two defects.
+Start from the current source PR head `f97f5520051b84c6859721221106210537d01c89`. Keep the fresh model-picker repair, but correct these two remaining defects before adding unrelated scope.
 
-1. Make `extensions/discord/src/monitor/native-command.model-picker.test.ts` deterministic. In `beforeEach`, use the existing native-command test seam to install a fixed unbound `main` Discord route, and restore the real resolver in `afterEach`. Do not change production Discord picker behavior unless the isolated test proves it necessary.
-2. Preserve Telegram model reachability. Bare `/model` must not emit a partial `tgcmd` menu when any configured model exceeds Telegram callback limits. Use the existing browse picker or compact `mdl_sel` callback path so both short and long models remain selectable. Replace the test that expects the long model to disappear with coverage that proves it remains selectable.
+1. Preserve configured Discord ACP binding readiness for bare `/model`. The picker branch must resolve the same guarded native route state as the normal command path before it loads picker data or replies. When a configured binding is unavailable, return the existing unavailable-binding response and do not expose a picker or its agent catalog. Add a regression test with a failed configured binding that proves the picker loader/reply is not invoked.
+2. Prove Telegram long-model reachability, not merely dispatch fallback. When any `/model` choice cannot fit Telegram callback data, do not emit a partial `tgcmd` keyboard; fall back to the established `/model` handling and assert it renders usable browse/compact `mdl_sel` controls that include a route to select the long model. Retain short-model behavior where all callbacks fit.
 3. Run this focused suite before pushing a checkpoint:
 
    ```bash


### PR DESCRIPTION
## Summary
- require the #92230 repair to retain configured Discord binding readiness before rendering the model picker
- require Telegram fallback proof through usable compact/browse controls for oversized model ids

## Verification
- `npm run validate` (6,203 jobs)
- `git diff --check`