### PR TITLE
fix(workers): preserve repair review budget

### DIFF
--- a/.github/workflows/cluster-worker.yml
+++ b/.github/workflows/cluster-worker.yml
@@ -429,7 +429,7 @@ jobs:
       - cluster
     if: ${{ needs.cluster.result == 'success' && (needs.prepare.outputs.mode == 'execute' || needs.prepare.outputs.mode == 'autonomous') && needs.prepare.outputs.dry_run != 'true' }}
     runs-on: ${{ needs.prepare.outputs.execution_runner }}
-    timeout-minutes: 60
+    timeout-minutes: 70
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
@@ -442,7 +442,7 @@ jobs:
       CLOWNFISH_REBASE_REPAIR_ATTEMPTS: ${{ vars.CLOWNFISH_REBASE_REPAIR_ATTEMPTS || '4' }}
       CLOWNFISH_ALLOW_REBASED_FORK_REPAIR: ${{ vars.CLOWNFISH_ALLOW_REBASED_FORK_REPAIR || '0' }}
       CLOWNFISH_FIX_CODEX_TIMEOUT_MS: ${{ vars.CLOWNFISH_FIX_CODEX_TIMEOUT_MS || '1200000' }}
-      CLOWNFISH_FIX_STEP_TIMEOUT_MS: ${{ vars.CLOWNFISH_FIX_STEP_TIMEOUT_MS || '2400000' }}
+      CLOWNFISH_FIX_STEP_TIMEOUT_MS: ${{ vars.CLOWNFISH_FIX_STEP_TIMEOUT_MS || '3300000' }}
       CLOWNFISH_REBASE_ONLY_FIX_STEP_TIMEOUT_MS: ${{ vars.CLOWNFISH_REBASE_ONLY_FIX_STEP_TIMEOUT_MS || '1500000' }}
       CLOWNFISH_REBASE_ONLY_REVIEW_TIMEOUT_MS: ${{ vars.CLOWNFISH_REBASE_ONLY_REVIEW_TIMEOUT_MS || '300000' }}
       CLOWNFISH_FIX_TIMEOUT_RESERVE_MS: ${{ vars.CLOWNFISH_FIX_TIMEOUT_RESERVE_MS || '300000' }}
@@ -570,7 +570,7 @@ jobs:
 
       - name: Execute credited fix artifact
         if: ${{ env.CLOWNFISH_ALLOW_EXECUTE == '1' && env.CLOWNFISH_ALLOW_FIX_PR == '1' }}
-        timeout-minutes: 50
+        timeout-minutes: 60
         run: npm run execute-fix -- "${{ needs.prepare.outputs.job }}" --latest
 
       - name: Apply safe closure actions

--- a/jobs/openclaw/inbox/automerge-openclaw-openclaw-92230.md
+++ b/jobs/openclaw/inbox/automerge-openclaw-openclaw-92230.md
@@ -49,10 +49,10 @@ Clownfish should use this job only for the bounded ClawSweeper review/fix loop:
 
 ## Pinned repair requirements
 
-Start from the current source PR head `e012d5b51d99919f76ea8b8ed9c101a5bf66065f`. Keep the fresh model-picker repair, but correct these two remaining defects before adding unrelated scope.
+Start from the current source PR head `25949bd916f46682a8fa120ccb878346e498af97`. Keep the fresh model-picker repair, but correct these two remaining defects before adding unrelated scope.
 
 1. Preserve configured Discord ACP binding readiness for bare `/model`. The picker branch must resolve the same guarded native route state as the normal command path before it loads picker data or replies. When a configured binding is unavailable, return the existing unavailable-binding response and do not expose a picker or its agent catalog. Add a regression test with a failed configured binding that proves the picker loader/reply is not invoked.
-2. Prove Telegram long-model reachability, not merely dispatch fallback. When any `/model` choice cannot fit Telegram callback data, do not emit a partial `tgcmd` keyboard; fall back to the established `/model` handling and assert it renders usable browse/compact `mdl_sel` controls that include a route to select the long model. Retain short-model behavior where all callbacks fit.
+2. Prove Telegram long-model reachability, not merely the provider-browser entry. When any `/model` choice cannot fit Telegram callback data, do not emit a partial `tgcmd` keyboard; exercise the existing provider browse callback and assert the next menu exposes a usable `mdl_sel` route for the long model. `mdl_prov` alone is not sufficient proof. Retain short-model behavior where all callbacks fit.
 3. Run this focused suite before pushing a checkpoint:
 
    ```bash

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -63,7 +63,7 @@ test("execute-fix-artifact bounds auxiliary GitHub and git subprocesses by the f
   assert.match(source, /function closeSupersededSourcePr\([\s\S]*?const closed = runStatus\("gh", \["pr", "close"/);
   assert.match(
     workflow,
-    /- name: Execute credited fix artifact[\s\S]*?timeout-minutes: 50[\s\S]*?run: npm run execute-fix/,
+    /- name: Execute credited fix artifact[\s\S]*?timeout-minutes: 60[\s\S]*?run: npm run execute-fix/,
   );
 });
 


### PR DESCRIPTION
## Summary
- extend the bounded executor window so normal validation and `/review` can both complete
- require the #92230 Telegram regression to prove long-model selection, not only provider browse entry

## Verification
- `npm test` (220 passing)
- `npm run validate` (6,203 jobs)
- `git diff --check`