### PR TITLE
fix(jobs): use provider-scoped Telegram callback

### DIFF
--- a/jobs/openclaw/inbox/automerge-openclaw-openclaw-92230.md
+++ b/jobs/openclaw/inbox/automerge-openclaw-openclaw-92230.md
@@ -49,10 +49,10 @@ Clownfish should use this job only for the bounded ClawSweeper review/fix loop:
 
 ## Pinned repair requirements
 
-Start from the current source PR head `25949bd916f46682a8fa120ccb878346e498af97`. Keep the fresh model-picker repair, but correct these two remaining defects before adding unrelated scope.
+Start from the current source PR head `38ee9edebfc7633bb232871a0df05c3dedcd1490`. Keep the fresh model-picker repair, but correct these two remaining defects before adding unrelated scope.
 
 1. Preserve configured Discord ACP binding readiness for bare `/model`. The picker branch must resolve the same guarded native route state as the normal command path before it loads picker data or replies. When a configured binding is unavailable, return the existing unavailable-binding response and do not expose a picker or its agent catalog. Add a regression test with a failed configured binding that proves the picker loader/reply is not invoked.
-2. Prove Telegram long-model reachability, not merely the provider-browser entry. When any `/model` choice cannot fit Telegram callback data, do not emit a partial `tgcmd` keyboard; exercise the existing provider browse callback and assert the next menu exposes a usable `mdl_sel` route for the long model. `mdl_prov` alone is not sufficient proof. Retain short-model behavior where all callbacks fit.
+2. Prove Telegram long-model reachability, not merely the provider-browser entry. When any `/model` choice cannot fit Telegram callback data, do not emit a partial `tgcmd` keyboard; exercise the existing provider browse callback and assert the next menu exposes the real provider-scoped `mdl_sel_<provider>/<model>` route for the long model. `mdl_prov` alone is not sufficient proof. Retain short-model behavior where all callbacks fit.
 3. Run this focused suite before pushing a checkpoint:
 
    ```bash


### PR DESCRIPTION
## Summary
- pin #92230 to its latest repair head
- require the Telegram regression to assert the real provider-scoped long-model selection callback

## Verification
- `npm run validate` (6,203 jobs)
- `git diff --check`