### PR TITLE
perf(executor): defer changed gate baselines

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -1159,10 +1159,7 @@ function editValidatePrepareMerge({
   allowedFixFiles = [],
   pushCheckpoint = null,
 }) {
-  const changedGateBaseline = captureChangedGateBaseline({ fixArtifact, targetDir, baseBranch });
-  if (changedGateBaseline) {
-    report.changed_gate_baseline = changedGateBaseline.report;
-  }
+  const changedGateBaseline = prepareChangedGateBaseline({ fixArtifact, targetDir, baseBranch });
   let producedChanges = allowExistingChanges;
   let editAttempts = 0;
   let previousSummary = "";
@@ -1253,6 +1250,9 @@ function editValidatePrepareMerge({
         refreshBaseBeforeReview,
         branch,
         changedGateBaseline,
+        onChangedGateBaseline: (baseline) => {
+          report.changed_gate_baseline = baseline.report;
+        },
         onReviewFix: (attempt, reviewFix) => {
           const checkpoint = commitCheckpointIfNeeded({
             targetDir,
@@ -1679,6 +1679,7 @@ function validateAndReviewLoop({
   refreshBaseBeforeReview = false,
   branch = null,
   changedGateBaseline = null,
+  onChangedGateBaseline = null,
   onReviewFix = null,
 }) {
   let lastReview = null;
@@ -1688,7 +1689,21 @@ function validateAndReviewLoop({
   while (reviewAttempts < maxReviewAttempts) {
     const attempt = reviewAttempts + 1;
     noteFixStage("validation_start", { mode, attempt, base_refreshes: baseRefreshes });
-    validationCommands = runAllowedValidationCommands(fixArtifact.validation_commands, targetDir, baseBranch, changedGateBaseline);
+    validationCommands = runAllowedValidationCommands(fixArtifact.validation_commands, targetDir, baseBranch, changedGateBaseline, {
+      onChangedGateBaseline,
+    });
+    if (changedGateBaseline?.status === "deferred") {
+      Object.assign(changedGateBaseline, {
+        status: "skipped_final_gate_passed",
+        report: {
+          command: `pnpm check:changed -- ${changedGateBaseline.paths.join(" ")}`,
+          status: "skipped_final_gate_passed",
+          pre_edit_head: changedGateBaseline.pre_edit_head,
+          paths: changedGateBaseline.paths,
+        },
+      });
+      onChangedGateBaseline?.(changedGateBaseline);
+    }
     runDiffCheck({ targetDir, baseBranch });
     noteFixStage("validation_complete", { mode, attempt, command_count: validationCommands.length, base_refreshes: baseRefreshes });
     if (refreshBaseBeforeReview && branch && refreshValidatedBranchBase({ targetDir, branch, baseBranch })) {
@@ -2535,7 +2550,13 @@ function setupGitIdentity(cwd) {
   run("git", ["config", "user.email", process.env.CLOWNFISH_GIT_USER_EMAIL ?? "projectclownfish@users.noreply.github.com"], { cwd });
 }
 
-function runAllowedValidationCommands(commands, cwd, baseBranch = DEFAULT_BASE_BRANCH, changedGateBaseline = null) {
+function runAllowedValidationCommands(
+  commands,
+  cwd,
+  baseBranch = DEFAULT_BASE_BRANCH,
+  changedGateBaseline = null,
+  { onChangedGateBaseline = null } = {},
+) {
   ensureMergeBaseAvailable({ targetDir: cwd, baseBranch });
   const validationEnv = targetValidationEnv();
   const executed = [];
@@ -2550,6 +2571,17 @@ function runAllowedValidationCommands(commands, cwd, baseBranch = DEFAULT_BASE_B
         executed.push(rendered);
         noteFixStage("validation_command_complete", { command: rendered });
       } catch (error) {
+        if (isDeferredChangedGateBaseline({ parts, error, changedGateBaseline })) {
+          try {
+            Object.assign(
+              changedGateBaseline,
+              captureChangedGateBaseline({ targetDir: cwd, baseBranch, changedGateBaseline }),
+            );
+          } catch (baselineError) {
+            Object.assign(changedGateBaseline, unavailableChangedGateBaseline({ changedGateBaseline, baselineError }));
+          }
+          onChangedGateBaseline?.(changedGateBaseline);
+        }
         const fallbackCommands = validationFallbackCommands({ parts, error, cwd, baseBranch, changedGateBaseline });
         if (fallbackCommands.length > 0) {
           for (const fallbackParts of fallbackCommands) {
@@ -2744,7 +2776,7 @@ function packageScriptRequirement(parts) {
   return { name: script, command: ["pnpm", script].join(" ") };
 }
 
-function captureChangedGateBaseline({ fixArtifact, targetDir, baseBranch = DEFAULT_BASE_BRANCH }) {
+function prepareChangedGateBaseline({ fixArtifact, targetDir, baseBranch = DEFAULT_BASE_BRANCH }) {
   if (strictTargetValidation) return null;
   const resolvedCommands = uniqueStrings(
     (fixArtifact.validation_commands ?? []).flatMap((command) =>
@@ -2755,16 +2787,71 @@ function captureChangedGateBaseline({ fixArtifact, targetDir, baseBranch = DEFAU
   const paths = changedGateBaselinePaths(fixArtifact, targetDir);
   if (paths.length === 0) return null;
 
+  return {
+    status: "deferred",
+    pre_edit_head: currentHead(targetDir),
+    paths,
+  };
+}
+
+function isDeferredChangedGateBaseline({ parts, error, changedGateBaseline }) {
+  return (
+    changedGateBaseline?.status === "deferred" &&
+    error?.validation_result?.kind === "exit_failure" &&
+    parts[0] === "pnpm" &&
+    parts[1] === "check:changed" &&
+    parts.length === 2
+  );
+}
+
+function captureChangedGateBaseline({ targetDir, baseBranch = DEFAULT_BASE_BRANCH, changedGateBaseline }) {
+  const { pre_edit_head: preEditHead, paths } = changedGateBaseline;
+  const changedDependencyFiles = changedDependencyManifestFiles({ targetDir, preEditHead });
+  if (changedDependencyFiles.length > 0) {
+    return {
+      status: "skipped_dependency_change",
+      report: {
+        command: `pnpm check:changed -- ${paths.join(" ")}`,
+        status: "skipped_dependency_change",
+        pre_edit_head: preEditHead,
+        paths,
+        changed_dependency_files: changedDependencyFiles,
+      },
+    };
+  }
   const command = ["pnpm", "check:changed", "--", ...paths];
   const rendered = command.join(" ");
-  noteFixStage("validation_baseline_start", { command: rendered, paths });
-  const outcome = runValidationCommand(command, {
-    cwd: targetDir,
-    env: targetValidationEnv(),
-    rendered,
-    phase: "baseline",
-    allowFailure: true,
-  });
+  const baselineDir = fs.mkdtempSync(path.join(workRoot, "changed-gate-baseline-"));
+  let addedWorktree = false;
+  let cleanupError = null;
+  noteFixStage("validation_baseline_start", { command: rendered, paths, pre_edit_head: preEditHead });
+  let outcome;
+  try {
+    run("git", ["worktree", "add", "--detach", baselineDir, preEditHead], { cwd: targetDir });
+    addedWorktree = true;
+    const sourceNodeModules = path.join(targetDir, "node_modules");
+    if (fs.existsSync(sourceNodeModules)) {
+      fs.symlinkSync(sourceNodeModules, path.join(baselineDir, "node_modules"), "dir");
+    }
+    outcome = runValidationCommand(command, {
+      cwd: baselineDir,
+      env: targetValidationEnv(),
+      rendered,
+      phase: "baseline",
+      allowFailure: true,
+    });
+  } finally {
+    if (addedWorktree) {
+      const removed = runStatus("git", ["worktree", "remove", "--force", baselineDir], { cwd: targetDir });
+      if (removed.status !== 0) {
+        cleanupError = compactText(`${removed.stderr ?? ""}\n${removed.stdout ?? ""}`, 600);
+        fs.rmSync(baselineDir, { recursive: true, force: true });
+        runStatus("git", ["worktree", "prune"], { cwd: targetDir });
+      }
+    } else {
+      fs.rmSync(baselineDir, { recursive: true, force: true });
+    }
+  }
   if (outcome.ok) {
     noteFixStage("validation_baseline_complete", { status: "passed" });
     return {
@@ -2773,8 +2860,10 @@ function captureChangedGateBaseline({ fixArtifact, targetDir, baseBranch = DEFAU
       report: {
         command: rendered,
         status: "passed",
+        pre_edit_head: preEditHead,
         paths,
         diagnostic_count: 0,
+        ...(cleanupError ? { cleanup_error: cleanupError } : {}),
       },
     };
   }
@@ -2795,13 +2884,36 @@ function captureChangedGateBaseline({ fixArtifact, targetDir, baseBranch = DEFAU
     report: {
       command: rendered,
       status: "failed",
+      pre_edit_head: preEditHead,
       paths,
       eligible,
       diagnostic_count: diagnostics.items.length,
       unparsed_failure_count: diagnostics.unparsed_failure_lines.length,
       has_test_failure: diagnostics.has_test_failure,
+      ...(cleanupError ? { cleanup_error: cleanupError } : {}),
     },
   };
+}
+
+function unavailableChangedGateBaseline({ changedGateBaseline, baselineError }) {
+  return {
+    status: "unavailable",
+    report: {
+      command: `pnpm check:changed -- ${changedGateBaseline.paths.join(" ")}`,
+      status: "unavailable",
+      pre_edit_head: changedGateBaseline.pre_edit_head,
+      paths: changedGateBaseline.paths,
+      error: compactText(baselineError?.message ?? baselineError, 600),
+    },
+  };
+}
+
+function changedDependencyManifestFiles({ targetDir, preEditHead }) {
+  const files = run("git", ["diff", "--name-only", preEditHead, "--"], { cwd: targetDir })
+    .split("\n")
+    .map((file) => file.trim())
+    .filter(Boolean);
+  return files.filter((file) => /(^|\/)(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|package-lock\.json|npm-shrinkwrap\.json|yarn\.lock)$/.test(file));
 }
 
 function changedGateBaselinePaths(fixArtifact, targetDir) {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -581,7 +581,7 @@ process.exit(9);
   const diagnostics = JSON.parse(
     fs.readFileSync(path.join(fixture.runDir, "fix-executor-debug", "validation-command-001.json"), "utf8"),
   );
-  assert.equal(diagnostics.command, "pnpm check:changed -- src/app.js");
+  assert.equal(diagnostics.command, "pnpm check:changed");
   assert.equal(diagnostics.exit_code, 9);
   assert.equal(diagnostics.timed_out, false);
   assert.match(diagnostics.stdout, /validation stdout token=\[redacted\]/);
@@ -692,7 +692,7 @@ process.exit(0);
   assert.match(prompt, /Expected \{ after 'if' condition/);
 });
 
-test("execute-fix-artifact tolerates unchanged baseline changed-gate diagnostics only after changed-test proof", () => {
+test("execute-fix-artifact defers unchanged baseline changed-gate diagnostics until the final gate fails", () => {
   const run = runBaselineChangedGateFixture({
     clusterId: "baseline-diagnostic-cluster",
     baselineOutput: "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
@@ -704,6 +704,7 @@ test("execute-fix-artifact tolerates unchanged baseline changed-gate diagnostics
   assert.deepEqual(run.report.changed_gate_baseline, {
     command: "pnpm check:changed -- src/app.js",
     status: "failed",
+    pre_edit_head: run.fixture.initialHead,
     paths: ["src/app.js"],
     eligible: true,
     diagnostic_count: 1,
@@ -713,14 +714,14 @@ test("execute-fix-artifact tolerates unchanged baseline changed-gate diagnostics
   assert.equal(fs.readFileSync(run.targetedTestMarker, "utf8").trim(), "test:serial src/app.test.js");
 
   const baselineDebug = JSON.parse(
-    fs.readFileSync(path.join(run.fixture.runDir, "fix-executor-debug", "validation-command-001.json"), "utf8"),
+    fs.readFileSync(path.join(run.fixture.runDir, "fix-executor-debug", "validation-command-002.json"), "utf8"),
   );
   assert.equal(baselineDebug.phase, "baseline");
   assert.deepEqual(baselineDebug.argv, ["pnpm", "check:changed", "--", "src/app.js"]);
   assert.equal(baselineDebug.exit_code, 1);
 });
 
-test("execute-fix-artifact gives eligible baseline diagnostics to the initial repair worker", () => {
+test("execute-fix-artifact does not give deferred baseline diagnostics to the initial repair worker", () => {
   const output = [
     "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
     "[ELIFECYCLE] Command failed with exit code 2.",
@@ -734,8 +735,57 @@ test("execute-fix-artifact gives eligible baseline diagnostics to the initial re
 
   assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
   const prompt = fs.readFileSync(run.initialPrompt, "utf8");
-  assert.match(prompt, /Existing changed-gate baseline diagnostics:/);
-  assert.match(prompt, /src\/web-search\/runtime\.ts\(374,10\): TS6133/);
+  assert.doesNotMatch(prompt, /Existing changed-gate baseline diagnostics:/);
+});
+
+test("execute-fix-artifact skips the baseline when the final changed gate passes", () => {
+  const run = runBaselineChangedGateFixture({
+    clusterId: "clean-changed-gate-cluster",
+    baselineOutput: "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+    postOutput: "",
+    postExitCode: 0,
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "planned");
+  assert.deepEqual(run.report.changed_gate_baseline, {
+    command: "pnpm check:changed -- src/app.js",
+    status: "skipped_final_gate_passed",
+    pre_edit_head: run.fixture.initialHead,
+    paths: ["src/app.js"],
+  });
+  assert.equal(fs.readFileSync(run.changedGateMarker, "utf8").trim(), "1");
+  const phases = fs
+    .readdirSync(path.join(run.fixture.runDir, "fix-executor-debug"))
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => JSON.parse(fs.readFileSync(path.join(run.fixture.runDir, "fix-executor-debug", file), "utf8")).phase);
+  assert.equal(phases.includes("baseline"), false);
+});
+
+test("execute-fix-artifact does not compare baseline diagnostics after dependency metadata changes", () => {
+  const run = runBaselineChangedGateFixture({
+    clusterId: "dependency-metadata-changed-cluster",
+    baselineOutput: "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+    postOutput: "src/web-search/runtime.ts(374,10): error TS6133: 'resolveWebSearchDefinition' is declared but its value is never read.",
+    dependencyManifestChange: true,
+    maxEditAttempts: 1,
+  });
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(run.report.status, "blocked");
+  assert.deepEqual(run.report.changed_gate_baseline, {
+    command: "pnpm check:changed -- src/app.js",
+    status: "skipped_dependency_change",
+    pre_edit_head: run.fixture.initialHead,
+    paths: ["src/app.js"],
+    changed_dependency_files: ["package.json"],
+  });
+  assert.equal(fs.readFileSync(run.changedGateMarker, "utf8").trim(), "1");
+  const phases = fs
+    .readdirSync(path.join(run.fixture.runDir, "fix-executor-debug"))
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => JSON.parse(fs.readFileSync(path.join(run.fixture.runDir, "fix-executor-debug", file), "utf8")).phase);
+  assert.equal(phases.includes("baseline"), false);
 });
 
 test("execute-fix-artifact tolerates unchanged baseline changed-gate diagnostics for source-only repairs", () => {
@@ -996,6 +1046,7 @@ test("execute-fix-artifact does not tolerate signaled changed-gate failures", ()
 
   assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
   assert.equal(run.report.status, "blocked");
+  assert.equal(run.report.changed_gate_baseline, undefined);
   assert.equal(fs.existsSync(run.targetedTestMarker), false);
   const signals = fs
     .readdirSync(path.join(run.fixture.runDir, "fix-executor-debug"))
@@ -1030,6 +1081,9 @@ function runBaselineChangedGateFixture({
   editedFile = "src/app.test.js",
   validationCommands = ["pnpm check:changed"],
   postSignal = null,
+  postExitCode = 1,
+  dependencyManifestChange = false,
+  maxEditAttempts = null,
 }) {
   const fixture = makeFixture();
   const resultPath = path.join(fixture.runDir, "result.json");
@@ -1064,6 +1118,12 @@ if (!fs.existsSync(${JSON.stringify(initialPrompt)})) {
   fs.writeFileSync(${JSON.stringify(initialPrompt)}, fs.readFileSync(0, "utf8"));
 }
 fs.writeFileSync(path.join(cd, ${JSON.stringify(editedFile)}), "export const fixture = true;\\n");
+if (${JSON.stringify(dependencyManifestChange)}) {
+  fs.writeFileSync(
+    path.join(cd, "package.json"),
+    JSON.stringify({ scripts: { "check:changed": "node scripts/check-changed.mjs", fixture: "true" } }, null, 2) + "\\n",
+  );
+}
 fs.writeFileSync(path.join(cd, ".clownfish-edited"), "true\\n");
 if (output) fs.writeFileSync(output, "edited\\n");
 `,
@@ -1085,7 +1145,7 @@ if (args[0] === "check:changed") {
   if (fs.existsSync(path.join(process.cwd(), ".clownfish-edited")) && ${JSON.stringify(postSignal)}) {
     process.kill(process.pid, ${JSON.stringify(postSignal)});
   }
-  process.exit(1);
+  process.exit(fs.existsSync(path.join(process.cwd(), ".clownfish-edited")) ? ${JSON.stringify(postExitCode)} : 1);
 }
 if (args[0] === "test:serial") {
   fs.writeFileSync(${JSON.stringify(targetedTestMarker)}, args.join(" "));
@@ -1124,6 +1184,7 @@ process.exit(0);
         CLOWNFISH_INSTALL_TARGET_DEPS: "0",
         CLOWNFISH_SKIP_CODEX_WRITE_PREFLIGHT: "1",
         CLOWNFISH_CODEX_REVIEW_ATTEMPTS: "1",
+        ...(maxEditAttempts ? { CLOWNFISH_FIX_EDIT_ATTEMPTS: String(maxEditAttempts) } : {}),
         ...(strict ? { CLOWNFISH_TARGET_VALIDATION_MODE: "strict" } : {}),
       },
     },
@@ -1178,12 +1239,14 @@ test "$2" = "94022"
   git(["push", "-u", "origin", "main"], { cwd: seedDir });
   git(["clone", originDir, targetDir], { cwd: root });
   git(["checkout", "main"], { cwd: targetDir });
+  const initialHead = git(["rev-parse", "HEAD"], { cwd: targetDir });
 
   return {
     root,
     binDir,
     runDir,
     workDir,
+    initialHead,
     originDir,
     targetDir,
     jobPath: path.join(root, "job.md"),


### PR DESCRIPTION
## Summary
- defer the pre-edit `pnpm check:changed` baseline until the final gate fails
- compare failures in an isolated worktree pinned to the exact pre-edit SHA
- retain original validation failures when baseline setup is unavailable
- skip comparison when dependency metadata changes, and record every skip/outcome in the result artifact

## Validation
- `node --test test/execute-fix-artifact.test.mjs`
- `npm test`
- `npm run validate`
- `git diff --check`