### PR TITLE
fix(planner): hydrate bulk intake context refs

### DIFF
--- a/schemas/job.schema.json
+++ b/schemas/job.schema.json
@@ -54,6 +54,18 @@
         "type": "string"
       }
     },
+    "existing_overlap_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "security_signal_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "allowed_fix_files": {
       "type": "array",
       "minItems": 1,

--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -155,6 +155,11 @@ function hydratedPreflightCloseRefs(resultPath, repo) {
   const planPath = path.join(path.dirname(resultPath), "cluster-plan.json");
   if (!fs.existsSync(planPath)) return new Set();
   const plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
+  const readOnlyContextRefs = new Set(
+    (plan.scope?.read_only_context_refs ?? [])
+      .map((ref) => normalizeIssueRef(ref, repo))
+      .filter(Boolean),
+  );
   return new Set(
     (plan.items ?? [])
       .filter(
@@ -165,7 +170,8 @@ function hydratedPreflightCloseRefs(resultPath, repo) {
           item.ref &&
           item.kind &&
           item.state &&
-          item.updated_at,
+          item.updated_at &&
+          !readOnlyContextRefs.has(normalizeIssueRef(item.ref, repo)),
       )
       .map((item) => normalizeIssueRef(item.ref, repo))
       .filter(Boolean),

--- a/scripts/import-gitcrawl-clusters.mjs
+++ b/scripts/import-gitcrawl-clusters.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
-import { hasSecuritySignalText, parseArgs, repoRoot } from "./lib.mjs";
+import { hasDeterministicSecuritySignal, hasSecuritySignalText, parseArgs, repoRoot } from "./lib.mjs";
 
 const DEFAULT_BLOCK_LABELS = [
   "proof:*",
@@ -127,7 +127,8 @@ for (const clusterId of clusterIds) {
   }
 
   const securitySensitiveMembers = members.filter((member) =>
-    hasSecuritySignalText(member.title, member.body, safeJson(member.labels_json)),
+    hasDeterministicSecuritySignal({ labels: safeJson(member.labels_json) }) ||
+    hasSecuritySignalText(member.title, member.body),
   );
   const targetMembers = overlapPolicy === "exclude-existing"
     ? members.filter((member) => !overlappingRefSet.has(Number(member.number)))
@@ -213,7 +214,7 @@ for (const clusterId of clusterIds) {
   const clusterSlug = suffix ? `gitcrawl-${clusterId}-${slugify(suffix)}` : `gitcrawl-${clusterId}-${slug}`;
   const targetRepresentative = targetMemberNumbers.has(Number(representative.number));
   const canonical = representative.number && targetRepresentative ? [`#${representative.number}`] : [];
-  const securityRefs = targetSecuritySensitiveMembers.map((member) => `#${member.number}`);
+  const securityRefs = securitySensitiveMembers.map((member) => `#${member.number}`);
   const overlapRefs = overlappingRefs.map((number) => `#${number}`);
 
   const markdown = [

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -5,7 +5,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 const SECURITY_SIGNAL_PATTERN =
   /\b(vulnerabilit(?:y|ies)|cve-\d+|ghsa|exploit|ssrf|xss|csrf|rce|(?:sql|command|code|prompt)\s*injection|auth(?:entication)?\s*bypass|privilege\s+escalation|sensitive\s+data|secrets?|security\s+(?:issue|bug|fix|patch|advisory|triage|review|re-evaluation|reclassification|flag|scan|scanner|surface|surfaces)|flagged\s+as\s+suspicious|(?:secretref|secret|credential|api[-_\s]?key|private[-_\s]?key|token).{0,80}(?:leak(?:ed|age)?|expos(?:e|ed|ure)|plaintext|plain[-_\s]?text)|(?:leak(?:ed|age)?|expos(?:e|ed|ure)|plaintext|plain[-_\s]?text).{0,80}(?:secretref|secret|credential|api[-_\s]?key|private[-_\s]?key|token))\b/i;
 const SECURITY_LABEL_PATTERN =
-  /^(?:security|security[-_: ]sensitive|security[:/].+|type:\s*security|kind:\s*security|impact:\s*security|clawsweeper:needs-security-review)$/i;
+  /^(?:security|security[-_: ]sensitive|security[:/].+|type:\s*security|kind:\s*security|impact:\s*security|clawsweeper:needs-security-review|merge-risk:\s*.*security[-_: ]boundary)$/i;
 const STRUCTURED_SECURITY_MARKER_PATTERN =
   /<!--\s*clawsweeper-(?:security|route|verdict)\s*:\s*(?:security|security-sensitive|sensitive|route-security|central-security)\b[^>]*-->/i;
 const PROMPT_ARTIFACT_MAX_CHARS = Number(process.env.CLOWNFISH_PROMPT_ARTIFACT_MAX_CHARS ?? 320_000);
@@ -329,6 +329,8 @@ export function validateJob(job) {
     "canonical",
     "candidates",
     "cluster_refs",
+    "existing_overlap_refs",
+    "security_signal_refs",
     "maintainer_close_refs",
     "allowed_fix_files",
   ]) {
@@ -346,9 +348,9 @@ export function validateJob(job) {
       errors.push(`candidate refs must look like #123: ${ref}`);
     }
   }
-  for (const ref of fm.cluster_refs ?? []) {
+  for (const ref of [...(fm.cluster_refs ?? []), ...(fm.existing_overlap_refs ?? []), ...(fm.security_signal_refs ?? [])]) {
     if (!isGithubRef(ref)) {
-      errors.push(`cluster_refs must look like #123 or a GitHub issue/PR URL: ${ref}`);
+      errors.push(`context refs must look like #123 or a GitHub issue/PR URL: ${ref}`);
     }
   }
   for (const ref of fm.maintainer_close_refs ?? []) {

--- a/scripts/plan-cluster.mjs
+++ b/scripts/plan-cluster.mjs
@@ -53,7 +53,15 @@ const primaryRefs = [
   ...(job.frontmatter.candidates ?? []),
 ].map((ref) => normalizeRef(job.frontmatter.repo, ref));
 const contextRefs = (job.frontmatter.cluster_refs ?? []).map((ref) => normalizeRef(job.frontmatter.repo, ref));
-const seedRefs = uniqueRefs(hydrateClusterRefs ? [...primaryRefs, ...contextRefs] : primaryRefs);
+const readOnlyContextRefs = [
+  ...(job.frontmatter.existing_overlap_refs ?? []),
+  ...(job.frontmatter.security_signal_refs ?? []),
+].map((ref) => normalizeRef(job.frontmatter.repo, ref));
+const seedRefs = uniqueRefs([
+  ...primaryRefs,
+  ...readOnlyContextRefs,
+  ...(hydrateClusterRefs ? contextRefs : []),
+]);
 
 const externalRefs = seedRefs.filter((ref) => ref.repo !== job.frontmatter.repo);
 const seedNumbers = seedRefs
@@ -129,6 +137,7 @@ const plan = {
     seed_refs: seedRefs.map(formatNormalizedRef),
     linked_refs: [...linkedRefs.values()].map(formatNormalizedRef).sort(),
     context_refs: uniqueRefs(contextRefs).map(formatNormalizedRef).sort(),
+    read_only_context_refs: uniqueRefs(readOnlyContextRefs).map(formatNormalizedRef).sort(),
     external_refs: externalRefs.map(formatNormalizedRef).sort(),
     expansion_policy:
       MAX_LINKED_REFS > 0

--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -171,6 +171,9 @@ function reviewResult(resultPath) {
       failures.push(`${target} security-sensitive target must use route_security`);
     }
     if (ROUTE_SECURITY_ACTIONS.has(name)) {
+      if (!item) {
+        failures.push(`${target} route_security target was not hydrated in preflight`);
+      }
       if (action.classification !== "security_sensitive") {
         failures.push(`${target} route_security action must use security_sensitive classification`);
       }

--- a/test/import-gitcrawl-clusters.test.mjs
+++ b/test/import-gitcrawl-clusters.test.mjs
@@ -10,7 +10,7 @@ const hasSqlite = spawnSync("sqlite3", ["--version"], { stdio: "ignore" }).statu
 
 test("cluster import can dedupe against published results without stale job id collisions", { skip: hasSqlite ? false : "sqlite3 missing" }, () => {
   const fixture = makeFixture();
-  seedPortableGitcrawlDb(fixture.db);
+  seedPortableGitcrawlDb(fixture.db, { firstLabels: ["merge-risk: 🚨 security-boundary"] });
   writeStaleJob(path.join(fixture.existing, "gitcrawl-1-old.md"));
   writePublishedResult(path.join(fixture.results, "processed.md"), ["#101"]);
 
@@ -31,6 +31,7 @@ test("cluster import can dedupe against published results without stale job id c
   assert.equal(payload.generated[0].source_cluster_id, 1);
   assert.deepEqual(payload.generated[0].cluster_refs, ["#102"]);
   assert.deepEqual(payload.generated[0].existing_overlap_refs, ["#101"]);
+  assert.deepEqual(payload.generated[0].security_signal_refs, ["#101"]);
 });
 
 test("cluster import skips maintainer-only risk labels by default", { skip: hasSqlite ? false : "sqlite3 missing" }, () => {

--- a/test/lib.test.mjs
+++ b/test/lib.test.mjs
@@ -43,6 +43,7 @@ test("deterministic security signals ignore prose credential wording", () => {
 
 test("deterministic security signals accept labels and structured ClawSweeper markers", () => {
   assert.equal(hasDeterministicSecuritySignal({ labels: ["security:sensitive"] }), true);
+  assert.equal(hasDeterministicSecuritySignal({ labels: ["merge-risk: 🚨 security-boundary"] }), true);
   assert.equal(
     hasDeterministicSecuritySignal({
       comments: ["<!-- clawsweeper-security:security-sensitive item=123 sha=abc -->"],

--- a/test/plan-cluster.test.mjs
+++ b/test/plan-cluster.test.mjs
@@ -109,4 +109,43 @@ canonical:
   assert.equal(candidate.kind, "pull_request");
   assert.match(candidate.hydration_error, /pull request #2: unexpected end of JSON input/);
   assert.match(candidate.pull_request.hydration_error, /pull request #2: unexpected end of JSON input/);
+
+  const contextJobPath = path.join(tmp, "context-job.md");
+  const contextRunDir = path.join(tmp, "context-run");
+  fs.writeFileSync(
+    contextJobPath,
+    `---
+repo: openclaw/openclaw
+cluster_id: mandatory-context-hydration
+mode: plan
+allowed_actions:
+  - comment
+candidates:
+  - "#1"
+canonical:
+  - "#1"
+existing_overlap_refs:
+  - "#2"
+security_signal_refs:
+  - "#2"
+---
+
+# Read-only context hydration
+`,
+  );
+  const contextResult = spawnSync("node", ["scripts/plan-cluster.mjs", contextJobPath, "--run-dir", contextRunDir], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      CLOWNFISH_HYDRATE_COMMENTS: "0",
+      CLOWNFISH_HYDRATE_CLUSTER_REFS: "0",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(contextResult.status, 0, contextResult.stderr || contextResult.stdout);
+  const contextPlan = JSON.parse(fs.readFileSync(path.join(contextRunDir, "cluster-plan.json"), "utf8"));
+  assert.deepEqual(contextPlan.scope.read_only_context_refs, ["#2"]);
+  assert.ok(contextPlan.items.some((item) => item.ref === "#2"));
 });

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -647,6 +647,29 @@ test("review-results allows unavailable security route when hydration was rate l
   assert.match(result.stdout, /route_security target was not marked security_sensitive in preflight/);
 });
 
+test("review-results rejects route_security without a hydrated preflight item", () => {
+  const dir = makeResultDir({
+    actions: [
+      {
+        target: "#89936",
+        action: "route_security",
+        status: "planned",
+        idempotency_key: "cluster-test:route_security:89936:missing",
+        classification: "security_sensitive",
+        target_kind: "unknown",
+        target_updated_at: null,
+        evidence: ["Imported metadata identified a security boundary."],
+        reason: "Route to central security handling.",
+      },
+    ],
+  });
+
+  const result = review(dir);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /route_security target was not hydrated in preflight/);
+});
+
 test("review-results allows non-security fix artifact with separately routed security ref", () => {
   const dir = makeResultDir(
     {


### PR DESCRIPTION
## Summary
- hydrate overlap and security-signal refs as read-only context even when broad cluster hydration is disabled
- recognize structured `merge-risk: security-boundary` labels
- prevent unhydrated security routes and read-only context from becoming close targets

## Validation
- `node --test test/lib.test.mjs test/import-gitcrawl-clusters.test.mjs test/review-results.test.mjs test/plan-cluster.test.mjs test/apply-result.test.mjs`
- `npm test`
- `npm run validate`
- `git diff --check`