### PR TITLE
fix(intake): ignore archived job references

### DIFF
--- a/scripts/import-github-pr-inventory.mjs
+++ b/scripts/import-github-pr-inventory.mjs
@@ -9,7 +9,7 @@ const args = parseArgs(process.argv.slice(2));
 const repo = String(args.repo ?? "openclaw/openclaw");
 const [owner, name] = repo.split("/");
 const outDir = path.resolve(String(args.out ?? path.join(repoRoot(), "jobs", owner, "inbox")));
-const existingDir = path.resolve(String(args["existing-dir"] ?? args.existing_dir ?? path.join(repoRoot(), "jobs", owner)));
+const existingDir = path.resolve(String(args["existing-dir"] ?? args.existing_dir ?? outDir));
 const existingResultsDir = path.resolve(
   String(args["existing-results-dir"] ?? args.existing_results_dir ?? path.join(repoRoot(), "results", owner)),
 );
@@ -293,11 +293,7 @@ function existingMentionedRefs(roots) {
   for (const root of roots) {
     if (!fs.existsSync(root) || visited.has(root)) continue;
     visited.add(root);
-    for (const file of markdownAndJsonFiles(root)) {
-      if (file.endsWith(".md")) addStructuredJobRefs(refs, file);
-      const text = fs.readFileSync(file, "utf8");
-      for (const match of text.matchAll(/#([1-9][0-9]{0,6})\b/g)) refs.add(`#${match[1]}`);
-    }
+    for (const file of markdownJobFiles(root)) addStructuredJobRefs(refs, file);
   }
   return refs;
 }
@@ -395,12 +391,12 @@ function escapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function markdownAndJsonFiles(root) {
+function markdownJobFiles(root) {
   const files = [];
   for (const entry of fs.readdirSync(root, { recursive: true })) {
     const file = path.join(root, String(entry));
     if (!fs.statSync(file).isFile()) continue;
-    if (file.endsWith(".md") || file.endsWith(".json")) files.push(file);
+    if (file.endsWith(".md")) files.push(file);
   }
   return files;
 }

--- a/test/import-github-pr-inventory.test.mjs
+++ b/test/import-github-pr-inventory.test.mjs
@@ -25,6 +25,21 @@ test("autonomous live PR inventory defaults to stale candidates and terminal res
   assert.deepEqual(JSON.parse(broad.stdout).candidates.map((candidate) => candidate.ref), ["#104", "#105", "#106", "#108"]);
 });
 
+test("live PR inventory protects active structured job refs but not archived or incidental references", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.gh);
+  writeExistingJob(path.join(fixture.out, "active.md"), "#101", "mentions #102 in notes");
+  writeExistingJob(path.join(fixture.root, "outbox", "finalized", "archived.md"), "#104");
+
+  const result = runImport(fixture, "--default-existing-dir", "--bucket", "all");
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const candidates = new Set(JSON.parse(result.stdout).candidates.map((candidate) => candidate.ref));
+  assert.equal(candidates.has("#101"), false);
+  assert.equal(candidates.has("#102"), true);
+  assert.equal(candidates.has("#104"), true);
+});
+
 test("remediation inventory is plan-only and enables finalization recommendations", () => {
   const fixture = makeFixture();
   writeFakeGh(fixture.gh);
@@ -67,7 +82,8 @@ test("remediation inventory is plan-only and enables finalization recommendation
 
 function runImport(fixture, ...extraArgs) {
   const write = extraArgs.includes("--write");
-  const args = extraArgs.filter((arg) => arg !== "--write");
+  const defaultExistingDir = extraArgs.includes("--default-existing-dir");
+  const args = extraArgs.filter((arg) => arg !== "--write" && arg !== "--default-existing-dir");
   return spawnSync(
     process.execPath,
     [
@@ -80,8 +96,7 @@ function runImport(fixture, ...extraArgs) {
       "all",
       "--batch-size",
       "10",
-      "--existing-dir",
-      fixture.existing,
+      ...(defaultExistingDir ? [] : ["--existing-dir", fixture.existing]),
       "--existing-results-dir",
       fixture.results,
       "--out",
@@ -226,6 +241,25 @@ result_status: "planned"
 | #101 | keep_independent | planned | independent | Non-terminal inventory classification. |
 | #102 | keep_closed | skipped | superseded | Already closed. |
 | #103 | close_duplicate | planned | duplicate | Planned close that executed. |
+`,
+  );
+}
+
+function writeExistingJob(filePath, ref, notes = "") {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    `---
+repo: openclaw/openclaw
+cluster_id: existing-${ref.slice(1)}
+mode: plan
+candidates:
+  - "${ref}"
+cluster_refs:
+  - "${ref}"
+---
+
+${notes}
 `,
   );
 }


### PR DESCRIPTION
## Summary
- dedupe fresh inventory against active inbox job refs rather than archived job history
- ignore incidental markdown references when determining active coverage
- retain terminal result-action exclusions

## Verification
- `npm test`
- `npm run validate`
- `git diff --check`