### PR TITLE
chore: enqueue ready PR plan wave 2

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-001.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-001
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#86279"
+  - "#87923"
+  - "#84728"
+  - "#94215"
+  - "#94567"
+cluster_refs:
+  - "#86279"
+  - "#87923"
+  - "#84728"
+  - "#94215"
+  - "#94567"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.312Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #86279 fix: keep media generation success on delivery failure
+
+- bucket: ready_for_maintainer
+- author: tianxiaochannel-oss88
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, stale, size: XS, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T05:05:54Z
+- live url: https://github.com/openclaw/openclaw/pull/86279
+
+### #87923 fix(thinking): keep explicit session thinkingLevel when runtime downgrades (#87740)
+
+- bucket: ready_for_maintainer
+- author: hoobnn
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T05:14:37Z
+- live url: https://github.com/openclaw/openclaw/pull/87923
+
+### #84728 Repair orphaned Codex custom tool outputs before resume
+
+- bucket: ready_for_maintainer
+- author: pfrederiksen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, extensions: codex, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-19T01:18:44Z
+- live url: https://github.com/openclaw/openclaw/pull/84728
+
+### #94215 fix(i18n): correct zh-CN theme/cron labels and translate Dreaming restart modal [AI-assisted]
+
+- bucket: ready_for_maintainer
+- author: eldar702
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T07:52:14Z
+- live url: https://github.com/openclaw/openclaw/pull/94215
+
+### #94567 Preserve aborted sessions across restart opt-in
+
+- bucket: ready_for_maintainer
+- author: tangtaizong666
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, agents, size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T08:22:26Z
+- live url: https://github.com/openclaw/openclaw/pull/94567

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-002.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-002
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93502"
+  - "#88925"
+  - "#89101"
+  - "#89172"
+  - "#93544"
+cluster_refs:
+  - "#93502"
+  - "#88925"
+  - "#89101"
+  - "#89172"
+  - "#93544"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.313Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 2
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #93502 docs: fix docs metadata spellcheck
+
+- bucket: ready_for_maintainer
+- author: harjothkhara
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, scripts, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, extensions: codex-supervisor
+- live updated: 2026-06-20T08:23:59Z
+- live url: https://github.com/openclaw/openclaw/pull/93502
+
+### #88925 Fix stuck-session recovery aborts for active reply runs
+
+- bucket: ready_for_maintainer
+- author: SnowSky1
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T08:47:07Z
+- live url: https://github.com/openclaw/openclaw/pull/88925
+
+### #89101 fix: add resumable field to prevent duplicate session spawns
+
+- bucket: ready_for_maintainer
+- author: w1ndcn
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-20T08:49:51Z
+- live url: https://github.com/openclaw/openclaw/pull/89101
+
+### #89172 fix(feishu): show voice message duration via upload duration
+
+- bucket: ready_for_maintainer
+- author: areslp
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: S, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-20T08:51:16Z
+- live url: https://github.com/openclaw/openclaw/pull/89172
+
+### #93544 docs: add direct Kubernetes manifest apply path
+
+- bucket: ready_for_maintainer
+- author: youngting520
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, scripts, size: M, proof: supplied, proof: sufficient, P3, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T08:52:22Z
+- live url: https://github.com/openclaw/openclaw/pull/93544

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-003.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-003
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94515"
+  - "#89576"
+  - "#89612"
+  - "#89648"
+  - "#54758"
+cluster_refs:
+  - "#94515"
+  - "#89576"
+  - "#89612"
+  - "#89648"
+  - "#54758"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.314Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 3
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94515 fix(codex): omit idle PreToolUse hook relays
+
+- bucket: ready_for_maintainer
+- author: mazmorra-oc
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, extensions: codex, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T08:53:21Z
+- live url: https://github.com/openclaw/openclaw/pull/94515
+
+### #89576 fix(browser): bring tab to foreground before screenshot capture
+
+- bucket: ready_for_maintainer
+- author: spencer2211
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T09:20:52Z
+- live url: https://github.com/openclaw/openclaw/pull/89576
+
+### #89612 fix: include persisted plugin contracts for migrations
+
+- bucket: ready_for_maintainer
+- author: zerone0x
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T09:22:13Z
+- live url: https://github.com/openclaw/openclaw/pull/89612
+
+### #89648 fix(agents): restore model-fetch info logs
+
+- bucket: ready_for_maintainer
+- author: xiaobao-k8s
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T09:23:23Z
+- live url: https://github.com/openclaw/openclaw/pull/89648
+
+### #54758 fix(ui): propagate connect errors to pending requests
+
+- bucket: ready_for_maintainer
+- author: ruanrrn
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T10:10:42Z
+- live url: https://github.com/openclaw/openclaw/pull/54758

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-004.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-004
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#85866"
+  - "#89110"
+  - "#89748"
+  - "#89790"
+  - "#89800"
+cluster_refs:
+  - "#85866"
+  - "#89110"
+  - "#89748"
+  - "#89790"
+  - "#89800"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.314Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 4
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #85866 [codex] Add WhatsApp phone-code login
+
+- bucket: ready_for_maintainer
+- author: VishalJ99
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: whatsapp-web, app: macos, cli, size: L, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T10:14:20Z
+- live url: https://github.com/openclaw/openclaw/pull/85866
+
+### #89110 fix(whatsapp): suppress typing for unmentioned group runs regardless of delivery mode
+
+- bucket: ready_for_maintainer
+- author: Bluetegu
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: whatsapp-web, size: XS, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T10:15:48Z
+- live url: https://github.com/openclaw/openclaw/pull/89110
+
+### #89748 fix: trim trailing whitespace from final text-chunking chunk
+
+- bucket: ready_for_maintainer
+- author: thanhtoantnt
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: matrix, size: XS, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T10:22:08Z
+- live url: https://github.com/openclaw/openclaw/pull/89748
+
+### #89790 fix(googlechat): preserve thread targets through reply delivery
+
+- bucket: ready_for_maintainer
+- author: clawsweeper
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: googlechat, size: XS, size: S, size: L, clawsweeper, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-20T10:23:46Z
+- live url: https://github.com/openclaw/openclaw/pull/89790
+
+### #89800 fix(agents): resolve webchat current session status
+
+- bucket: ready_for_maintainer
+- author: sweetcornna
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T10:24:39Z
+- live url: https://github.com/openclaw/openclaw/pull/89800

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-005.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-005
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89855"
+  - "#93374"
+  - "#93930"
+  - "#89981"
+  - "#90217"
+cluster_refs:
+  - "#89855"
+  - "#93374"
+  - "#93930"
+  - "#89981"
+  - "#90217"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.314Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 5
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89855 fix(telegram): avoid duplicate dm chat window context
+
+- bucket: ready_for_maintainer
+- author: sweetcornna
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T10:26:15Z
+- live url: https://github.com/openclaw/openclaw/pull/89855
+
+### #93374 fix(agents): suggest recovery for unknown tool ids
+
+- bucket: ready_for_maintainer
+- author: mushuiyu886
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-20T10:29:56Z
+- live url: https://github.com/openclaw/openclaw/pull/93374
+
+### #93930 fix(nodes): guard node catalog and pairing-list scalar fields against non-string entries
+
+- bucket: ready_for_maintainer
+- author: ly-wang19
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, cli, size: M, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-20T10:30:02Z
+- live url: https://github.com/openclaw/openclaw/pull/93930
+
+### #89981 fix(diagnostics-otel): keep full model id on spans instead of collapsing to "unknown"
+
+- bucket: ready_for_maintainer
+- author: mycarrysun
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: diagnostics-otel, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T11:25:04Z
+- live url: https://github.com/openclaw/openclaw/pull/89981
+
+### #90217 test: make doctor state integrity symlink test robust on Windows
+
+- bucket: ready_for_maintainer
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T11:28:53Z
+- live url: https://github.com/openclaw/openclaw/pull/90217

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-006.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-006
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90223"
+  - "#90280"
+  - "#90489"
+  - "#90537"
+  - "#90151"
+cluster_refs:
+  - "#90223"
+  - "#90280"
+  - "#90489"
+  - "#90537"
+  - "#90151"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.316Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 6
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #90223 test: make qqbot symlinked media helper test robust on Windows
+
+- bucket: ready_for_maintainer
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, channel: qqbot, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T11:29:04Z
+- live url: https://github.com/openclaw/openclaw/pull/90223
+
+### #90280 test: make zalo token resolver symlink test compatible with Windows
+
+- bucket: ready_for_maintainer
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: zalo, size: XS, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T11:30:10Z
+- live url: https://github.com/openclaw/openclaw/pull/90280
+
+### #90489 fix(sessions): clarify cross-agent visibility guidance
+
+- bucket: ready_for_maintainer
+- author: sahibzada-allahyar
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T11:33:56Z
+- live url: https://github.com/openclaw/openclaw/pull/90489
+
+### #90537 Warn on generated wrapper overwrites and status diagnostics
+
+- bucket: ready_for_maintainer
+- author: TurboTheTurtle
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, cli, commands, size: M, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-20T11:34:37Z
+- live url: https://github.com/openclaw/openclaw/pull/90537
+
+### #90151 docs: clarify OpenClaw vs Codex code mode
+
+- bucket: ready_for_maintainer
+- author: Pick-cat
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-20T11:50:16Z
+- live url: https://github.com/openclaw/openclaw/pull/90151

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-007.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-007.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-007
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#59920"
+  - "#80293"
+  - "#89992"
+  - "#90230"
+  - "#89962"
+cluster_refs:
+  - "#59920"
+  - "#80293"
+  - "#89992"
+  - "#90230"
+  - "#89962"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.316Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 7
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #59920 [codex] prefer terminal reply fields in CLI JSONL parser
+
+- bucket: ready_for_maintainer
+- author: mySebbe
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, clawsweeper, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T12:04:19Z
+- live url: https://github.com/openclaw/openclaw/pull/59920
+
+### #80293 fix: apply thread routing to plugin actions
+
+- bucket: ready_for_maintainer
+- author: artdaal
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: slack, size: S, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T12:11:35Z
+- live url: https://github.com/openclaw/openclaw/pull/80293
+
+### #89992 feat(config): write local editor schema
+
+- bucket: ready_for_maintainer
+- author: danhayman
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, cli, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T12:20:38Z
+- live url: https://github.com/openclaw/openclaw/pull/89992
+
+### #90230 test: run permission hardening backup test on Windows
+
+- bucket: ready_for_maintainer
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T12:24:44Z
+- live url: https://github.com/openclaw/openclaw/pull/90230
+
+### #89962 fix(discord): fall back to text when voice delivery fails
+
+- bucket: ready_for_maintainer
+- author: danhayman
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T12:35:59Z
+- live url: https://github.com/openclaw/openclaw/pull/89962

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-008.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-008.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-008
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94701"
+  - "#67432"
+  - "#93007"
+  - "#69707"
+  - "#71863"
+cluster_refs:
+  - "#94701"
+  - "#67432"
+  - "#93007"
+  - "#69707"
+  - "#71863"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.316Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 8
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94701 Fix embedded-run recovery after refreshed session activity
+
+- bucket: ready_for_maintainer
+- author: imadal1n
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: session-state, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-20T12:41:08Z
+- live url: https://github.com/openclaw/openclaw/pull/94701
+
+### #67432 fix(ui): add aria-label to pinned message Unpin button
+
+- bucket: ready_for_maintainer
+- author: akinshaywai
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T13:05:56Z
+- live url: https://github.com/openclaw/openclaw/pull/67432
+
+### #93007 feat(gateway): forward web_search_options through OpenAI-compatible chat completions
+
+- bucket: ready_for_maintainer
+- author: Lellansin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, agents, size: XL, extensions: openai, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T13:14:23Z
+- live url: https://github.com/openclaw/openclaw/pull/93007
+
+### #69707 fix(memory-lancedb): stop forwarding embedding dimensions upstream
+
+- bucket: ready_for_maintainer
+- author: badgerbees
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, extensions: memory-lancedb, size: L, triage: refactor-only, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-20T13:39:38Z
+- live url: https://github.com/openclaw/openclaw/pull/69707
+
+### #71863 fix(signal): await daemon shutdown on restart
+
+- bucket: ready_for_maintainer
+- author: ZHOUKAILIAN
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: signal, size: M, proof: supplied, proof: sufficient, P1, rating: diamond lobster, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-20T13:42:57Z
+- live url: https://github.com/openclaw/openclaw/pull/71863

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-009.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-009.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-009
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#86608"
+  - "#94323"
+  - "#93833"
+  - "#72314"
+  - "#91134"
+cluster_refs:
+  - "#86608"
+  - "#94323"
+  - "#93833"
+  - "#72314"
+  - "#91134"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.316Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 9
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #86608 docs: add existing-solutions preflight guardrail
+
+- bucket: ready_for_maintainer
+- author: cablackmon
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, scripts, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T13:44:57Z
+- live url: https://github.com/openclaw/openclaw/pull/86608
+
+### #94323 fix(cron): stop add/remove from dropping a due recurring job's pending run
+
+- bucket: ready_for_maintainer
+- author: yetval
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-20T14:06:15Z
+- live url: https://github.com/openclaw/openclaw/pull/94323
+
+### #93833 Fix Azure Responses model alias routing
+
+- bucket: ready_for_maintainer
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: diamond lobster, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-20T14:15:13Z
+- live url: https://github.com/openclaw/openclaw/pull/93833
+
+### #72314 fix(auto-reply): dedupe idless inbound retries
+
+- bucket: ready_for_maintainer
+- author: mjamiv
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T14:58:39Z
+- live url: https://github.com/openclaw/openclaw/pull/72314
+
+### #91134 ci: check bundled channel config metadata
+
+- bucket: ready_for_maintainer
+- author: luoyanglang
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T15:16:25Z
+- live url: https://github.com/openclaw/openclaw/pull/91134

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-010.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-010.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-010
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#91203"
+  - "#94562"
+  - "#89409"
+  - "#93587"
+  - "#94326"
+cluster_refs:
+  - "#91203"
+  - "#94562"
+  - "#89409"
+  - "#93587"
+  - "#94326"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.317Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 10
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #91203 fix(matrix): neutralize command progress failure labels
+
+- bucket: ready_for_maintainer
+- author: bdjben
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: matrix, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T15:17:16Z
+- live url: https://github.com/openclaw/openclaw/pull/91203
+
+### #94562 fix(workboard): hide archived cards in CLI list by default
+
+- bucket: ready_for_maintainer
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: S, proof: sufficient, P2, rating: diamond lobster, merge-risk: compatibility, status: ready for maintainer look, plugin: workboard
+- live updated: 2026-06-20T15:30:39Z
+- live url: https://github.com/openclaw/openclaw/pull/94562
+
+### #89409 [codex] docs(memory-wiki): clarify sources wrapper contract
+
+- bucket: ready_for_maintainer
+- author: spacegeologist
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T16:38:55Z
+- live url: https://github.com/openclaw/openclaw/pull/89409
+
+### #93587 fix(ui): avoid fallback main session parent in Control UI
+
+- bucket: ready_for_maintainer
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T16:50:55Z
+- live url: https://github.com/openclaw/openclaw/pull/93587
+
+### #94326 fix(memory-wiki): disambiguate the reserved index page stem for synthesis and ingest
+
+- bucket: ready_for_maintainer
+- author: yetval
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, extensions: memory-wiki, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T16:51:48Z
+- live url: https://github.com/openclaw/openclaw/pull/94326

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-011.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-011.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-011
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#65359"
+  - "#73079"
+  - "#76873"
+  - "#77432"
+  - "#84708"
+cluster_refs:
+  - "#65359"
+  - "#73079"
+  - "#76873"
+  - "#77432"
+  - "#84708"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.317Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 11
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #65359 fix(config): allow historyLimit: 0 in GroupChatSchema
+
+- bucket: ready_for_maintainer
+- author: maxreith
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T17:16:07Z
+- live url: https://github.com/openclaw/openclaw/pull/65359
+
+### #73079 fix(minimax): request hex TTS output explicitly
+
+- bucket: ready_for_maintainer
+- author: efe-arv
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, extensions: minimax, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T17:18:54Z
+- live url: https://github.com/openclaw/openclaw/pull/73079
+
+### #76873 fix(discord): preserve target intent during normalization
+
+- bucket: ready_for_maintainer
+- author: AScriver
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T17:20:52Z
+- live url: https://github.com/openclaw/openclaw/pull/76873
+
+### #77432 feat(doctor): warn about hidden provider catalog models
+
+- bucket: ready_for_maintainer
+- author: sercada
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T17:21:58Z
+- live url: https://github.com/openclaw/openclaw/pull/77432
+
+### #84708 fix(agents): recover message-tool mirror replay poison
+
+- bucket: ready_for_maintainer
+- author: anyech
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T17:25:03Z
+- live url: https://github.com/openclaw/openclaw/pull/84708

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-012.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-012.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-012
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93328"
+  - "#91049"
+  - "#78381"
+  - "#94149"
+  - "#78664"
+cluster_refs:
+  - "#93328"
+  - "#91049"
+  - "#78381"
+  - "#94149"
+  - "#78664"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.317Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 12
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #93328 fix(matrix): prevent double bootstrapCrossSigning reset in --force-reset-cross-signing
+
+- bucket: ready_for_maintainer
+- author: xialonglee
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: matrix, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T17:35:17Z
+- live url: https://github.com/openclaw/openclaw/pull/93328
+
+### #91049 fix: handle terminal chat send acknowledgements
+
+- bucket: ready_for_maintainer
+- author: nxmxbbd
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: android, app: ios, app: macos, app: web-ui, gateway, size: XL, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T17:40:48Z
+- live url: https://github.com/openclaw/openclaw/pull/91049
+
+### #78381 feat(embedded-runner): expose prep stage timings
+
+- bucket: ready_for_maintainer
+- author: guanbear
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: S, triage: blank-template, triage: dirty-candidate, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T18:00:51Z
+- live url: https://github.com/openclaw/openclaw/pull/78381
+
+### #94149 fix(status): bound systemd service probes so status cannot hang on a wedged systemctl (#84698)
+
+- bucket: ready_for_maintainer
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, commands, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T18:10:55Z
+- live url: https://github.com/openclaw/openclaw/pull/94149
+
+### #78664 perf(agents): cache provider tool schema normalization
+
+- bucket: ready_for_maintainer
+- author: guanbear
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: L, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T18:35:56Z
+- live url: https://github.com/openclaw/openclaw/pull/78664

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-013.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-013.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-013
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90750"
+  - "#91210"
+  - "#92328"
+  - "#92399"
+  - "#92649"
+cluster_refs:
+  - "#90750"
+  - "#91210"
+  - "#92328"
+  - "#92399"
+  - "#92649"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.317Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 13
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #90750 fix(diagnostics): evict orphaned tool/model activity on owner-less run end
+
+- bucket: ready_for_maintainer
+- author: 849261680
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, extensions: diagnostics-otel, size: M, extensions: diagnostics-prometheus, proof: supplied, proof: sufficient, P1, rating: diamond lobster, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T18:39:14Z
+- live url: https://github.com/openclaw/openclaw/pull/90750
+
+### #91210 fix(ui): localize skill workshop switcher
+
+- bucket: ready_for_maintainer
+- author: SYU8384
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: L, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T18:40:46Z
+- live url: https://github.com/openclaw/openclaw/pull/91210
+
+### #92328 Fix dashboard history projection and approval followups
+
+- bucket: ready_for_maintainer
+- author: Hidetsugu55
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T18:42:33Z
+- live url: https://github.com/openclaw/openclaw/pull/92328
+
+### #92399 fix(llm): collapse cumulative openai-responses message snapshots instead of concatenating [AI-assisted]
+
+- bucket: ready_for_maintainer
+- author: amersheeny
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: L, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T18:43:15Z
+- live url: https://github.com/openclaw/openclaw/pull/92399
+
+### #92649 feat(kimi): show code quota in usage status
+
+- bucket: ready_for_maintainer
+- author: litang9
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: M, extensions: kimi-coding, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-20T18:45:28Z
+- live url: https://github.com/openclaw/openclaw/pull/92649

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-014.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-014.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-014
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93025"
+  - "#75165"
+  - "#75371"
+  - "#80916"
+  - "#91828"
+cluster_refs:
+  - "#93025"
+  - "#75165"
+  - "#75371"
+  - "#80916"
+  - "#91828"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.317Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 14
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #93025 [codex] fix(provider): expose session identity to stream hooks
+
+- bucket: ready_for_maintainer
+- author: yu-xin-c
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T18:48:34Z
+- live url: https://github.com/openclaw/openclaw/pull/93025
+
+### #75165 feat(agents): composable termination algebra + GSAR grounding scorer
+
+- bucket: ready_for_maintainer
+- author: fede-kamel
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, agents, size: XL, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look, feature: showcase, merge-risk: other
+- live updated: 2026-06-20T19:21:39Z
+- live url: https://github.com/openclaw/openclaw/pull/75165
+
+### #75371 Gateway: guard session-run cancel requester in minimal tests
+
+- bucket: ready_for_maintainer
+- author: seoseo-ai
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, scripts, size: L, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T19:22:04Z
+- live url: https://github.com/openclaw/openclaw/pull/75371
+
+### #80916 fix(memory): skip empty dreaming placeholders
+
+- bucket: ready_for_maintainer
+- author: hyspacex
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T19:26:12Z
+- live url: https://github.com/openclaw/openclaw/pull/80916
+
+### #91828 Harden memory wiki bridge imports
+
+- bucket: ready_for_maintainer
+- author: mushuiyu886
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, extensions: memory-wiki, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T19:32:51Z
+- live url: https://github.com/openclaw/openclaw/pull/91828

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-015.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-015.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-015
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#91988"
+  - "#91559"
+  - "#78411"
+  - "#93149"
+  - "#93222"
+cluster_refs:
+  - "#91988"
+  - "#91559"
+  - "#78411"
+  - "#93149"
+  - "#93222"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.317Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 15
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #91988 fix: preserve BOOTSTRAP.md in preseeded workspaces (#91931)
+
+- bucket: ready_for_maintainer
+- author: LiuwqGit
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P1, rating: diamond lobster, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T19:33:58Z
+- live url: https://github.com/openclaw/openclaw/pull/91988
+
+### #91559 fix(agents): clean Gemini tool schemas by model id
+
+- bucket: ready_for_maintainer
+- author: Pick-cat
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T19:39:51Z
+- live url: https://github.com/openclaw/openclaw/pull/91559
+
+### #78411 docs(concepts): standardize active memory related heading
+
+- bucket: ready_for_maintainer
+- author: GGzili
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, triage: refactor-only, proof: supplied, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-20T20:08:26Z
+- live url: https://github.com/openclaw/openclaw/pull/78411
+
+### #93149 feat(cron): add add dry-run preview
+
+- bucket: ready_for_maintainer
+- author: rrrrrredy
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T20:17:31Z
+- live url: https://github.com/openclaw/openclaw/pull/93149
+
+### #93222 fix(discord): add configurable REST API timeout
+
+- bucket: ready_for_maintainer
+- author: geekhuashan
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: discord, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T20:19:05Z
+- live url: https://github.com/openclaw/openclaw/pull/93222

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-016.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-016.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-016
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93239"
+  - "#93356"
+  - "#91728"
+  - "#92892"
+  - "#93180"
+cluster_refs:
+  - "#93239"
+  - "#93356"
+  - "#91728"
+  - "#92892"
+  - "#93180"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.317Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 16
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #93239 docs: add ClickClack to supported channels index
+
+- bucket: ready_for_maintainer
+- author: milljer
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T20:19:22Z
+- live url: https://github.com/openclaw/openclaw/pull/93239
+
+### #93356 fix(plugins): cache plugin setup registry to kill the /models CPU storm
+
+- bucket: ready_for_maintainer
+- author: obuchowski
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T20:21:09Z
+- live url: https://github.com/openclaw/openclaw/pull/93356
+
+### #91728 test(github-copilot): cover live xhigh reasoning for non-Claude mini models (#59416)
+
+- bucket: ready_for_maintainer
+- author: saju01
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: sufficient, extensions: github-copilot, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T20:52:47Z
+- live url: https://github.com/openclaw/openclaw/pull/91728
+
+### #92892 fix(gateway): allow Gemini CLI image-capable models
+
+- bucket: ready_for_maintainer
+- author: YonganZhang
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: M, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T20:54:15Z
+- live url: https://github.com/openclaw/openclaw/pull/92892
+
+### #93180 fix(doctor): gate legacy Codex canonicalization on a migration plan
+
+- bucket: ready_for_maintainer
+- author: ooiuuii
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, commands, size: XL, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T20:54:37Z
+- live url: https://github.com/openclaw/openclaw/pull/93180

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-017.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-017.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-017
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93585"
+  - "#93689"
+  - "#93827"
+  - "#93841"
+  - "#93956"
+cluster_refs:
+  - "#93585"
+  - "#93689"
+  - "#93827"
+  - "#93841"
+  - "#93956"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.317Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 17
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #93585 fix(daemon): keep systemd gateway running after child OOM
+
+- bucket: ready_for_maintainer
+- author: snowzlm
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-20T20:56:05Z
+- live url: https://github.com/openclaw/openclaw/pull/93585
+
+### #93689 fix(zalo): accept string chat ids for outbound sends
+
+- bucket: ready_for_maintainer
+- author: goutamadwant
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: zalo, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T20:56:28Z
+- live url: https://github.com/openclaw/openclaw/pull/93689
+
+### #93827 fix(gateway): hot-reload browser profile config
+
+- bucket: ready_for_maintainer
+- author: goutamadwant
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T20:56:44Z
+- live url: https://github.com/openclaw/openclaw/pull/93827
+
+### #93841 fix(ui): render persisted history text blocks
+
+- bucket: ready_for_maintainer
+- author: mushuiyu886
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T20:57:00Z
+- live url: https://github.com/openclaw/openclaw/pull/93841
+
+### #93956 fix(ollama): skip auto-discovery for remote/cloud base URLs
+
+- bucket: ready_for_maintainer
+- author: jason-allen-oneal
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, extensions: ollama, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-20T20:57:42Z
+- live url: https://github.com/openclaw/openclaw/pull/93956

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-018.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-018.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-018
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93994"
+  - "#79811"
+  - "#80981"
+  - "#94022"
+  - "#94086"
+cluster_refs:
+  - "#93994"
+  - "#79811"
+  - "#80981"
+  - "#94022"
+  - "#94086"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.317Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 18
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #93994 fix(setup): point non-interactive health hints at onboard flags
+
+- bucket: ready_for_maintainer
+- author: zhouhe-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T20:58:42Z
+- live url: https://github.com/openclaw/openclaw/pull/93994
+
+### #79811 fix(cron): avoid delivered status for empty outbound receipts
+
+- bucket: ready_for_maintainer
+- author: indulgeback
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T21:23:19Z
+- live url: https://github.com/openclaw/openclaw/pull/79811
+
+### #80981 docs(cli): clarify strict json parsing
+
+- bucket: ready_for_maintainer
+- author: addu2612
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-20T21:25:58Z
+- live url: https://github.com/openclaw/openclaw/pull/80981
+
+### #94022 fix(cron): persist startup catch-up deferral ids in service state to prevent read-RPC clobber
+
+- bucket: ready_for_maintainer
+- author: Jah-xy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: M, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T21:30:29Z
+- live url: https://github.com/openclaw/openclaw/pull/94022
+
+### #94086 fix(doctor): archive superseded plugin install indexes
+
+- bucket: ready_for_maintainer
+- author: ooiuuii
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T21:31:20Z
+- live url: https://github.com/openclaw/openclaw/pull/94086

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-019.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-019.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-019
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94088"
+  - "#94112"
+  - "#94130"
+  - "#94134"
+  - "#94233"
+cluster_refs:
+  - "#94088"
+  - "#94112"
+  - "#94130"
+  - "#94134"
+  - "#94233"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.317Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 19
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94088 fix(heartbeat): keep private final reply off-channel in message_tool mode
+
+- bucket: ready_for_maintainer
+- author: Bartok9
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T21:31:35Z
+- live url: https://github.com/openclaw/openclaw/pull/94088
+
+### #94112 fix(reply): strip leaked current-message scaffolding and (no output) placeholders
+
+- bucket: ready_for_maintainer
+- author: SnowSky1
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: diamond lobster, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T21:32:25Z
+- live url: https://github.com/openclaw/openclaw/pull/94112
+
+### #94130 fix(anthropic): handle max_turns stop reason and surface retry-limit details to users
+
+- bucket: ready_for_maintainer
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T21:32:40Z
+- live url: https://github.com/openclaw/openclaw/pull/94130
+
+### #94134 feat(ios): auto-connect nearby gateways during onboarding
+
+- bucket: ready_for_maintainer
+- author: zats
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: ios, size: L, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look, proof: video
+- live updated: 2026-06-20T21:32:52Z
+- live url: https://github.com/openclaw/openclaw/pull/94134
+
+### #94233 fix(model-fallback): coalesce auth decision logs
+
+- bucket: ready_for_maintainer
+- author: goutamadwant
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T21:34:06Z
+- live url: https://github.com/openclaw/openclaw/pull/94233

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-020.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T091708-020.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T091708-020
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94238"
+  - "#80928"
+  - "#81471"
+  - "#82638"
+  - "#82718"
+cluster_refs:
+  - "#94238"
+  - "#80928"
+  - "#81471"
+  - "#82638"
+  - "#82718"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:17:08.318Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 20
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94238 fix(config): fail closed when configure runs without an interactive TTY (#93953)
+
+- bucket: ready_for_maintainer
+- author: ruomuxydt
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T21:34:12Z
+- live url: https://github.com/openclaw/openclaw/pull/94238
+
+### #80928 fix(telegram): suppress fallback reply when plugin command returns suppressReply: true
+
+- bucket: ready_for_maintainer
+- author: alexuser
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, size: XS, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-20T22:38:56Z
+- live url: https://github.com/openclaw/openclaw/pull/80928
+
+### #81471 fix(line): load accounts.default and default-enable named accounts
+
+- bucket: ready_for_maintainer
+- author: edenfunf
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: line, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T22:40:09Z
+- live url: https://github.com/openclaw/openclaw/pull/81471
+
+### #82638 fix(agents): skip implicit provider discovery when models.mode is 'replace' [AI-assisted]
+
+- bucket: ready_for_maintainer
+- author: eldar702
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T22:41:49Z
+- live url: https://github.com/openclaw/openclaw/pull/82638
+
+### #82718 docs(telegram): clarify account-local group config
+
+- bucket: ready_for_maintainer
+- author: hyjkimbot
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, gateway, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T22:41:53Z
+- live url: https://github.com/openclaw/openclaw/pull/82718


### PR DESCRIPTION
Adds 20 plan-only remediation clusters covering 100 fresh status: ready for maintainer look OpenClaw pull requests. Generated from current live inventory after terminal-result intake refresh; all GitHub mutations remain blocked at job level.