### PR TITLE
chore: enqueue ready PR plan wave 3

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-001.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-001
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93547"
+  - "#94204"
+  - "#94328"
+  - "#94437"
+  - "#94442"
+cluster_refs:
+  - "#93547"
+  - "#94204"
+  - "#94328"
+  - "#94437"
+  - "#94442"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.351Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #93547 fix(acp): recover stale persistent sessions by structured resume-required code [AI-assisted]
+
+- bucket: ready_for_maintainer
+- author: amersheeny
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P1, rating: diamond lobster, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T22:44:26Z
+- live url: https://github.com/openclaw/openclaw/pull/93547
+
+### #94204 fix(control-ui): rewrite manifest hrefs for configured base path
+
+- bucket: ready_for_maintainer
+- author: hugenshen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T22:46:14Z
+- live url: https://github.com/openclaw/openclaw/pull/94204
+
+### #94328 fix(agents): keep post-compaction user re-issue of a kept-tail prompt during compaction rotation
+
+- bucket: ready_for_maintainer
+- author: yetval
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T22:47:39Z
+- live url: https://github.com/openclaw/openclaw/pull/94328
+
+### #94437 fix(agents): render identity name in runtime prompt
+
+- bucket: ready_for_maintainer
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T22:48:54Z
+- live url: https://github.com/openclaw/openclaw/pull/94437
+
+### #94442 fix(imessage): strip leading echo corruption markers in the persisted echo cache
+
+- bucket: ready_for_maintainer
+- author: ly-wang19
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: imessage, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T22:48:58Z
+- live url: https://github.com/openclaw/openclaw/pull/94442

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-002.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-002
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94464"
+  - "#94483"
+  - "#81312"
+  - "#90450"
+  - "#92654"
+cluster_refs:
+  - "#94464"
+  - "#94483"
+  - "#81312"
+  - "#90450"
+  - "#92654"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.352Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 2
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94464 Stabilize OpenClaw frontier candidate checks
+
+- bucket: ready_for_maintainer
+- author: THESPRYGUY
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, scripts, agents, size: M, extensions: codex, triage: dirty-candidate, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T22:49:29Z
+- live url: https://github.com/openclaw/openclaw/pull/94464
+
+### #94483 feat(gateway-cli): scope usage-cost by agent
+
+- bucket: ready_for_maintainer
+- author: ly-wang19
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T22:49:47Z
+- live url: https://github.com/openclaw/openclaw/pull/94483
+
+### #81312 fix(plugins): preserve bundled capability manifest contracts
+
+- bucket: ready_for_maintainer
+- author: yfge
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T00:12:18Z
+- live url: https://github.com/openclaw/openclaw/pull/81312
+
+### #90450 fix(agents): preserve streamed assistant text when Claude CLI result event is empty
+
+- bucket: ready_for_maintainer
+- author: totobusnello
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: auth-provider, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T00:18:36Z
+- live url: https://github.com/openclaw/openclaw/pull/90450
+
+### #92654 feat(control-ui): add right-click Reply in Dashboard webchat
+
+- bucket: ready_for_maintainer
+- author: programmingWTF
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: M, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-21T00:20:05Z
+- live url: https://github.com/openclaw/openclaw/pull/92654

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-003.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-003
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94325"
+  - "#94361"
+  - "#94441"
+  - "#94443"
+  - "#94470"
+cluster_refs:
+  - "#94325"
+  - "#94361"
+  - "#94441"
+  - "#94443"
+  - "#94470"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.353Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 3
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94325 fix: UI glitch: config is not visible
+
+- bucket: ready_for_maintainer
+- author: sunlit-deng
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-21T00:22:14Z
+- live url: https://github.com/openclaw/openclaw/pull/94325
+
+### #94361 fix(ui): scroll to cron run history
+
+- bucket: ready_for_maintainer
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T00:22:57Z
+- live url: https://github.com/openclaw/openclaw/pull/94361
+
+### #94441 fix(exec): fail invalid explicit workdir before running
+
+- bucket: ready_for_maintainer
+- author: renaudcerrato
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T00:24:04Z
+- live url: https://github.com/openclaw/openclaw/pull/94441
+
+### #94443 fix(memory-wiki): retry transient source-page rewrite race instead of aborting wiki_status
+
+- bucket: ready_for_maintainer
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, extensions: memory-wiki, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-21T00:24:12Z
+- live url: https://github.com/openclaw/openclaw/pull/94443
+
+### #94470 chore: sync yuanbao plugin catalog to 2.15.0
+
+- bucket: ready_for_maintainer
+- author: jase-283
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T00:24:40Z
+- live url: https://github.com/openclaw/openclaw/pull/94470

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-004.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-004
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94508"
+  - "#94633"
+  - "#82909"
+  - "#82985"
+  - "#90923"
+cluster_refs:
+  - "#94508"
+  - "#94633"
+  - "#82909"
+  - "#82985"
+  - "#90923"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.353Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 4
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94508 build(deps): bump the android-deps group across 1 directory with 4 updates
+
+- bucket: ready_for_maintainer
+- author: dependabot
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: dependencies, app: android, size: XS, java, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T00:25:25Z
+- live url: https://github.com/openclaw/openclaw/pull/94508
+
+### #94633 fix(feishu): replace empty bitable record value schema rejected by strict validators
+
+- bucket: ready_for_maintainer
+- author: ZOOWH
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T00:25:55Z
+- live url: https://github.com/openclaw/openclaw/pull/94633
+
+### #82909 fix(telegram): repair message cache reply types
+
+- bucket: ready_for_maintainer
+- author: lidge-jun
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T00:55:11Z
+- live url: https://github.com/openclaw/openclaw/pull/82909
+
+### #82985 feat(plugins): pass engine candidates to MemoryCorpusSupplement.search
+
+- bucket: ready_for_maintainer
+- author: ubehera
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, extensions: memory-core, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T00:55:51Z
+- live url: https://github.com/openclaw/openclaw/pull/82985
+
+### #90923 fix(daemon): write LaunchAgent plist to boot volume when home is on external APFS
+
+- bucket: ready_for_maintainer
+- author: 849261680
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: macos, gateway, cli, size: M, proof: supplied, proof: sufficient, P1, rating: diamond lobster, merge-risk: compatibility, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-21T00:59:07Z
+- live url: https://github.com/openclaw/openclaw/pull/90923

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-005.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-005
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93699"
+  - "#93965"
+  - "#94062"
+  - "#94436"
+  - "#94510"
+cluster_refs:
+  - "#93699"
+  - "#93965"
+  - "#94062"
+  - "#94436"
+  - "#94510"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.353Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 5
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #93699 fix(control-ui): apply seamColor bootstrap config
+
+- bucket: ready_for_maintainer
+- author: goutamadwant
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: S, triage: blank-template, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T00:59:52Z
+- live url: https://github.com/openclaw/openclaw/pull/93699
+
+### #93965 [Bug]: opencode-go provider streaming API calls complete on provider side but gateway never receives stream termination signal
+
+- bucket: ready_for_maintainer
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XL, proof: supplied, proof: sufficient, extensions: opencode-go, P1, rating: diamond lobster, merge-risk: compatibility, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-21T01:01:04Z
+- live url: https://github.com/openclaw/openclaw/pull/93965
+
+### #94062 fix(agents): classify generic "LLM request failed." as transient time
+
+- bucket: ready_for_maintainer
+- author: hugenshen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T01:01:34Z
+- live url: https://github.com/openclaw/openclaw/pull/94062
+
+### #94436 docs(media): clarify legacy MEDIA line formatting
+
+- bucket: ready_for_maintainer
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T01:03:02Z
+- live url: https://github.com/openclaw/openclaw/pull/94436
+
+### #94510 docs(onboarding): normalize inline Info callout to block form
+
+- bucket: ready_for_maintainer
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T01:03:27Z
+- live url: https://github.com/openclaw/openclaw/pull/94510

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-006.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-006
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94578"
+  - "#94585"
+  - "#94697"
+  - "#93943"
+  - "#94148"
+cluster_refs:
+  - "#94578"
+  - "#94585"
+  - "#94697"
+  - "#93943"
+  - "#94148"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.353Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 6
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94578 Fix recent session resume with long headers
+
+- bucket: ready_for_maintainer
+- author: rohitjavvadi
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T01:04:57Z
+- live url: https://github.com/openclaw/openclaw/pull/94578
+
+### #94585 feat(xiaomi): add MiMo V2.5 models to the pay-as-you-go provider
+
+- bucket: ready_for_maintainer
+- author: idootop
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: S, extensions: xiaomi, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-21T01:05:08Z
+- live url: https://github.com/openclaw/openclaw/pull/94585
+
+### #94697 fix(kill-tree): verify process group leader before using group kill to prevent gateway SIGTERM (#76259)
+
+- bucket: ready_for_maintainer
+- author: xydigit-zt
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-21T01:06:35Z
+- live url: https://github.com/openclaw/openclaw/pull/94697
+
+### #93943 fix(provider-usage): honor proxy env for usage fetch
+
+- bucket: ready_for_maintainer
+- author: TurboTheTurtle
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T01:53:29Z
+- live url: https://github.com/openclaw/openclaw/pull/93943
+
+### #94148 fix(doctor): prevent non-interactive --fix from auto-restarting gateway
+
+- bucket: ready_for_maintainer
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T01:54:00Z
+- live url: https://github.com/openclaw/openclaw/pull/94148

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-007.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-007.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-007
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94560"
+  - "#93198"
+  - "#78395"
+  - "#84792"
+  - "#89604"
+cluster_refs:
+  - "#94560"
+  - "#93198"
+  - "#78395"
+  - "#84792"
+  - "#89604"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.354Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 7
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94560 fix(update): isolate post-core finalizer env
+
+- bucket: ready_for_maintainer
+- author: rohitjavvadi
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T01:55:05Z
+- live url: https://github.com/openclaw/openclaw/pull/94560
+
+### #93198 fix #80933: honor claude-cli contextTokens
+
+- bucket: ready_for_maintainer
+- author: mushuiyu886
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-21T02:08:47Z
+- live url: https://github.com/openclaw/openclaw/pull/93198
+
+### #78395 fix(agents): resolve bare alias fallbacks via alias index
+
+- bucket: ready_for_maintainer
+- author: AtelyPham
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-21T02:20:46Z
+- live url: https://github.com/openclaw/openclaw/pull/78395
+
+### #84792 Run memory flush before preflight compaction
+
+- bucket: ready_for_maintainer
+- author: TurboTheTurtle
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-21T02:27:39Z
+- live url: https://github.com/openclaw/openclaw/pull/84792
+
+### #89604 fix(gateway): skip pending reply drain on skip-deferral restart
+
+- bucket: ready_for_maintainer
+- author: SebTardif
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T02:31:08Z
+- live url: https://github.com/openclaw/openclaw/pull/89604

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-008.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-008.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-008
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93093"
+  - "#94369"
+  - "#94636"
+  - "#88504"
+  - "#93843"
+cluster_refs:
+  - "#93093"
+  - "#94369"
+  - "#94636"
+  - "#88504"
+  - "#93843"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.354Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 8
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #93093 docs(memory): warn about session memory overlap
+
+- bucket: ready_for_maintainer
+- author: ZengWen-DT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T02:31:39Z
+- live url: https://github.com/openclaw/openclaw/pull/93093
+
+### #94369 fix(memory-wiki): exclude durable reference pages from stale report
+
+- bucket: ready_for_maintainer
+- author: SunnyShu0925
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: memory-wiki, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T02:34:38Z
+- live url: https://github.com/openclaw/openclaw/pull/94369
+
+### #94636 fix(memory): skip raw snippets during promotion
+
+- bucket: ready_for_maintainer
+- author: tayoun
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T02:35:27Z
+- live url: https://github.com/openclaw/openclaw/pull/94636
+
+### #88504 feat(memory): add multi-slot memory role architecture
+
+- bucket: ready_for_maintainer
+- author: kklouzal
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, extensions: memory-lancedb, cli, scripts, commands, docker, agents, size: XL, extensions: qa-lab, extensions: memory-wiki, plugin: migrate-hermes, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: automation, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look, feature: showcase
+- live updated: 2026-06-21T02:57:46Z
+- live url: https://github.com/openclaw/openclaw/pull/88504
+
+### #93843 fix(memory-wiki): prevent distinct titles from silently overwriting each other
+
+- bucket: ready_for_maintainer
+- author: yetval
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, extensions: memory-wiki, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T03:11:32Z
+- live url: https://github.com/openclaw/openclaw/pull/93843

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-009.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-009.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-009
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94359"
+  - "#94416"
+  - "#84589"
+  - "#86233"
+  - "#93887"
+cluster_refs:
+  - "#94359"
+  - "#94416"
+  - "#84589"
+  - "#86233"
+  - "#93887"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.354Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 9
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94359 fix(sessions): use account names for direct display
+
+- bucket: ready_for_maintainer
+- author: leno23
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: L, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-21T03:13:20Z
+- live url: https://github.com/openclaw/openclaw/pull/94359
+
+### #94416 fix #93501: [Bug]: Matrix error decrypting event
+
+- bucket: ready_for_maintainer
+- author: mushuiyu886
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: matrix, size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T03:13:33Z
+- live url: https://github.com/openclaw/openclaw/pull/94416
+
+### #84589 fix(message): describe channel parameter as provider name
+
+- bucket: ready_for_maintainer
+- author: spacegeologist
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: automation, status: ready for maintainer look
+- live updated: 2026-06-21T03:50:14Z
+- live url: https://github.com/openclaw/openclaw/pull/84589
+
+### #86233 fix(codex): cap managed app-server trace logs
+
+- bucket: ready_for_maintainer
+- author: ghitafilali
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: L, extensions: codex, proof: supplied, proof: sufficient, P1, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T03:55:32Z
+- live url: https://github.com/openclaw/openclaw/pull/86233
+
+### #93887 fix(ssh): reject hostnames with stray leading or trailing colons in parseSshTarget
+
+- bucket: ready_for_maintainer
+- author: miorbnli
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T03:58:43Z
+- live url: https://github.com/openclaw/openclaw/pull/93887

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-010.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-010.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-010
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94411"
+  - "#85249"
+  - "#89017"
+  - "#93919"
+  - "#83842"
+cluster_refs:
+  - "#94411"
+  - "#85249"
+  - "#89017"
+  - "#93919"
+  - "#83842"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.354Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 10
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94411 fix(sandbox): use config-resolved workspace for skill sync fallback
+
+- bucket: ready_for_maintainer
+- author: wangmiao0668000666
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, docker, agents, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T04:00:18Z
+- live url: https://github.com/openclaw/openclaw/pull/94411
+
+### #85249 fix(cron): guard against undefined sourceDelivery in isolated executor
+
+- bucket: ready_for_maintainer
+- author: Jerry-Xin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: L, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T04:46:37Z
+- live url: https://github.com/openclaw/openclaw/pull/85249
+
+### #89017 fix #87700: [Bug]: Control UI webchat session silently resets after network disconnect / sleep previous session file renamed to .jsonl.reset.* and lost from sessions tab
+
+- bucket: ready_for_maintainer
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: web-ui, gateway, size: M, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-21T04:47:09Z
+- live url: https://github.com/openclaw/openclaw/pull/89017
+
+### #93919 perf(plugins): cache existence probes within bundle manifest scan [AI-assisted]
+
+- bucket: ready_for_maintainer
+- author: ml12580
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T04:48:43Z
+- live url: https://github.com/openclaw/openclaw/pull/93919
+
+### #83842 fix(discord): add native reply opt-out
+
+- bucket: ready_for_maintainer
+- author: reirei-agent
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T05:40:41Z
+- live url: https://github.com/openclaw/openclaw/pull/83842

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-011.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-011.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-011
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#85368"
+  - "#86730"
+  - "#86900"
+  - "#89154"
+  - "#93369"
+cluster_refs:
+  - "#85368"
+  - "#86730"
+  - "#86900"
+  - "#89154"
+  - "#93369"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.354Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 11
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #85368 fix(media): avoid eager provider startup for audio listing
+
+- bucket: ready_for_maintainer
+- author: FelixIsaac
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: M, extensions: senseaudio, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T05:43:35Z
+- live url: https://github.com/openclaw/openclaw/pull/85368
+
+### #86730 fix(agents): resolve /btw transcript to post-compaction file when stored entry points at checkpoint
+
+- bucket: ready_for_maintainer
+- author: 1052326311
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-21T05:47:20Z
+- live url: https://github.com/openclaw/openclaw/pull/86730
+
+### #86900 fix(compaction): add circuit breaker to stop token burn when summarizer unavailable
+
+- bucket: ready_for_maintainer
+- author: tanshanshan
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-21T05:48:20Z
+- live url: https://github.com/openclaw/openclaw/pull/86900
+
+### #89154 feat(hooks): add ACP turn transcript save hook
+
+- bucket: ready_for_maintainer
+- author: mantisai-bot
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: discord, channel: line, channel: msteams, channel: slack, channel: telegram, channel: voice-call, app: web-ui, gateway, cli, scripts, commands, agents, channel: feishu, channel: irc, size: XL, extensions: minimax, extensions: kimi-coding, extensions: kilocode, channel: qqbot, extensions: qa-lab, extensions: memory-wiki, extensions: codex, extensions: deepinfra, proof: supplied, proof: sufficient, extensions: amazon-bedrock, extensions: chutes, extensions: diffs, extensions: openrouter
+- live updated: 2026-06-21T05:50:11Z
+- live url: https://github.com/openclaw/openclaw/pull/89154
+
+### #93369 fix(cron): expose per-job fallbacks in CLI
+
+- bucket: ready_for_maintainer
+- author: 849261680
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: web-ui, gateway, cli, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-21T05:59:27Z
+- live url: https://github.com/openclaw/openclaw/pull/93369

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-012.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-012.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-012
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94412"
+  - "#77539"
+  - "#86759"
+  - "#86873"
+  - "#87831"
+cluster_refs:
+  - "#94412"
+  - "#77539"
+  - "#86759"
+  - "#86873"
+  - "#87831"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.354Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 12
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94412 fix(agent-core): stop loop after aborted tool run
+
+- bucket: ready_for_maintainer
+- author: szsip239
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P1, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-21T06:10:28Z
+- live url: https://github.com/openclaw/openclaw/pull/94412
+
+### #77539 fix(subagent): preserve steered task text on restart redispatch
+
+- bucket: ready_for_maintainer
+- author: amittell
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, agents, size: S, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-21T06:21:52Z
+- live url: https://github.com/openclaw/openclaw/pull/77539
+
+### #86759 fix(webchat): broadcast agent TTS media final payloads
+
+- bucket: ready_for_maintainer
+- author: spacegeologist
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, agents, size: L, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T06:26:50Z
+- live url: https://github.com/openclaw/openclaw/pull/86759
+
+### #86873 fix(line): add chunk-idle timeout to inbound media download
+
+- bucket: ready_for_maintainer
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: line, size: M, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T06:27:16Z
+- live url: https://github.com/openclaw/openclaw/pull/86873
+
+### #87831 perf: skip manifest normalization in status summary
+
+- bucket: ready_for_maintainer
+- author: ACSKamloops
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, agents, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T06:32:16Z
+- live url: https://github.com/openclaw/openclaw/pull/87831

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-013.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-013.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-013
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#87861"
+  - "#88061"
+  - "#88098"
+  - "#88103"
+  - "#88159"
+cluster_refs:
+  - "#87861"
+  - "#88061"
+  - "#88098"
+  - "#88103"
+  - "#88159"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.355Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 13
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #87861 fix(model-usage): coerce numeric-string costs and ignore non-finite values
+
+- bucket: ready_for_maintainer
+- author: coder999999999
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-21T06:32:29Z
+- live url: https://github.com/openclaw/openclaw/pull/87861
+
+### #88061 docs: fix accuracy drift across docs (config defaults, model aliases, anchors, terminology)
+
+- bucket: ready_for_maintainer
+- author: hoobnn
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, channel: tlon, channel: zalouser, app: android, app: macos, gateway, channel: feishu, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: gold shrimp, status: ready for maintainer look, extensions: copilot
+- live updated: 2026-06-21T06:36:45Z
+- live url: https://github.com/openclaw/openclaw/pull/88061
+
+### #88098 feat(onboard): add --custom-context-window flag for non-interactive setup
+
+- bucket: ready_for_maintainer
+- author: ericlevine
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, commands, size: S, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T06:37:31Z
+- live url: https://github.com/openclaw/openclaw/pull/88098
+
+### #88103 Update Teams CLI install command
+
+- bucket: ready_for_maintainer
+- author: heyitsaamir
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: msteams, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-21T06:37:38Z
+- live url: https://github.com/openclaw/openclaw/pull/88103
+
+### #88159 fix(cli): retry logs.tail after journal fallback in logs follow
+
+- bucket: ready_for_maintainer
+- author: anyech
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, size: M, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T06:38:27Z
+- live url: https://github.com/openclaw/openclaw/pull/88159

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-014.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-014.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-014
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94378"
+  - "#81731"
+  - "#87891"
+  - "#94219"
+  - "#18860"
+cluster_refs:
+  - "#94378"
+  - "#81731"
+  - "#87891"
+  - "#94219"
+  - "#18860"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.355Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 14
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94378 fix(image-gen): skip invalid entries in OpenAI-compatible image response parsing
+
+- bucket: ready_for_maintainer
+- author: zhiqiang26
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T06:46:57Z
+- live url: https://github.com/openclaw/openclaw/pull/94378
+
+### #81731 fix(cron): treat exact-second cron slots as valid in stale-future repair
+
+- bucket: ready_for_maintainer
+- author: yashkot007
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-21T07:04:30Z
+- live url: https://github.com/openclaw/openclaw/pull/81731
+
+### #87891 fix(telegram): expose spooled handler timeout config
+
+- bucket: ready_for_maintainer
+- author: khang-dogo
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, size: XS, triage: dirty-candidate, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look, triage: needs-pr-context
+- live updated: 2026-06-21T07:19:16Z
+- live url: https://github.com/openclaw/openclaw/pull/87891
+
+### #94219 fix(control-ui): restore provider usage quota pill in sidebar session switcher (fixes #93041)
+
+- bucket: ready_for_maintainer
+- author: Pick-cat
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T07:22:49Z
+- live url: https://github.com/openclaw/openclaw/pull/94219
+
+### #18860 feat(agents): expose tools and their schemas via new after_tools_resolved hook [AI-assisted]
+
+- bucket: ready_for_maintainer
+- author: lan17
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: M, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look, triage: needs-pr-context
+- live updated: 2026-06-21T08:13:56Z
+- live url: https://github.com/openclaw/openclaw/pull/18860

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-015.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-015.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-015
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#79702"
+  - "#85829"
+  - "#88400"
+  - "#88401"
+  - "#88681"
+cluster_refs:
+  - "#79702"
+  - "#85829"
+  - "#88400"
+  - "#88401"
+  - "#88681"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.355Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 15
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #79702 [AI-assisted] fix(openai): prefix instruction-aware embedding queries
+
+- bucket: ready_for_maintainer
+- author: kreucher
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: M, extensions: openai, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T08:15:56Z
+- live url: https://github.com/openclaw/openclaw/pull/79702
+
+### #85829 Avoid post-run auth success lane delay
+
+- bucket: ready_for_maintainer
+- author: TurboTheTurtle
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: auth-provider, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-21T08:17:13Z
+- live url: https://github.com/openclaw/openclaw/pull/85829
+
+### #88400 fix(config): accept overlays for bundled provider aliases
+
+- bucket: ready_for_maintainer
+- author: Pluviobyte
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: blank-template, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T08:19:17Z
+- live url: https://github.com/openclaw/openclaw/pull/88400
+
+### #88401 fix(agents): safely record non-json transport errors
+
+- bucket: ready_for_maintainer
+- author: Pluviobyte
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T08:19:21Z
+- live url: https://github.com/openclaw/openclaw/pull/88401
+
+### #88681 Make runtime plugin startup stalls name in-flight plugins
+
+- bucket: ready_for_maintainer
+- author: alexzhu0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T08:20:18Z
+- live url: https://github.com/openclaw/openclaw/pull/88681

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-016.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-016.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-016
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#88908"
+  - "#89152"
+  - "#89817"
+  - "#89818"
+  - "#89859"
+cluster_refs:
+  - "#88908"
+  - "#89152"
+  - "#89817"
+  - "#89818"
+  - "#89859"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.355Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 16
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #88908 fix(gateway): force exit on zombie shutdown + 503 healthz during shutdown
+
+- bucket: ready_for_maintainer
+- author: amittell
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, cli, size: L, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-21T08:21:45Z
+- live url: https://github.com/openclaw/openclaw/pull/88908
+
+### #89152 feat(hooks): add agent turn end hook
+
+- bucket: ready_for_maintainer
+- author: mantisai-bot
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: discord, channel: line, channel: msteams, channel: slack, channel: telegram, channel: voice-call, app: web-ui, gateway, cli, scripts, commands, agents, channel: feishu, channel: irc, size: XL, extensions: minimax, extensions: kimi-coding, extensions: kilocode, channel: qqbot, extensions: qa-lab, extensions: memory-wiki, extensions: codex, extensions: deepinfra, proof: supplied, proof: sufficient, extensions: amazon-bedrock, extensions: chutes, extensions: diffs, extensions: openrouter
+- live updated: 2026-06-21T08:22:35Z
+- live url: https://github.com/openclaw/openclaw/pull/89152
+
+### #89817 fix(commitments): preserve extraction batch on transient failure
+
+- bucket: ready_for_maintainer
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T08:22:56Z
+- live url: https://github.com/openclaw/openclaw/pull/89817
+
+### #89818 fix(providers): forward stop sequences in bundled Anthropic transports
+
+- bucket: ready_for_maintainer
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, extensions: amazon-bedrock, extensions: anthropic-vertex, P2, rating: diamond lobster, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T08:23:01Z
+- live url: https://github.com/openclaw/openclaw/pull/89818
+
+### #89859 fix(gateway): honor remote status probe timeout
+
+- bucket: ready_for_maintainer
+- author: mushuiyu886
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: compatibility, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-21T08:23:13Z
+- live url: https://github.com/openclaw/openclaw/pull/89859

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-017.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-017.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-017
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93087"
+  - "#93584"
+  - "#86224"
+  - "#89045"
+  - "#89287"
+cluster_refs:
+  - "#93087"
+  - "#93584"
+  - "#86224"
+  - "#89045"
+  - "#89287"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.355Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 17
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #93087 Reject unsupported diagnostics OTel grpc config
+
+- bucket: ready_for_maintainer
+- author: kiranmagic7
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, extensions: diagnostics-otel, commands, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T08:24:56Z
+- live url: https://github.com/openclaw/openclaw/pull/93087
+
+### #93584 fix(agents): repair orphaned tool_use pairs on compaction prune path
+
+- bucket: ready_for_maintainer
+- author: dolphinsboy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-21T08:25:36Z
+- live url: https://github.com/openclaw/openclaw/pull/93584
+
+### #86224 [AI-assisted] fix(agents): resolve CLI runtime in preflight + memory-flush gates
+
+- bucket: ready_for_maintainer
+- author: adele-with-a-b
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: L, proof: supplied, proof: sufficient, P1, rating: gold shrimp, merge-risk: auth-provider, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-21T08:40:34Z
+- live url: https://github.com/openclaw/openclaw/pull/86224
+
+### #89045 fix: recover terminal session status on visible inbound turns
+
+- bucket: ready_for_maintainer
+- author: Jerry-Xin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: L, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P1, rating: diamond lobster, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T08:46:24Z
+- live url: https://github.com/openclaw/openclaw/pull/89045
+
+### #89287 fix(agents): verify completion delivery target
+
+- bucket: ready_for_maintainer
+- author: anyech
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XL, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T08:47:51Z
+- live url: https://github.com/openclaw/openclaw/pull/89287

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-018.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-018.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-018
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#53467"
+  - "#81108"
+  - "#87601"
+  - "#83187"
+  - "#85308"
+cluster_refs:
+  - "#53467"
+  - "#81108"
+  - "#87601"
+  - "#83187"
+  - "#85308"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.355Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 18
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #53467 feat(slack): add ignoreOtherMentions channel config
+
+- bucket: ready_for_maintainer
+- author: hanamizuki
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: slack, size: M, triage: dirty-candidate, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-21T08:55:12Z
+- live url: https://github.com/openclaw/openclaw/pull/53467
+
+### #81108 fix(gateway): discover disk compaction checkpoints
+
+- bucket: ready_for_maintainer
+- author: luoyanglang
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XL, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-21T08:58:43Z
+- live url: https://github.com/openclaw/openclaw/pull/81108
+
+### #87601 fix(docs): render onboarding CLI info callout
+
+- bucket: ready_for_maintainer
+- author: Muggle-akko
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T08:59:05Z
+- live url: https://github.com/openclaw/openclaw/pull/87601
+
+### #83187 fix(heartbeat): clear pendingFinalDelivery* on send success
+
+- bucket: ready_for_maintainer
+- author: agocs
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P1, rating: diamond lobster, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T08:59:36Z
+- live url: https://github.com/openclaw/openclaw/pull/83187
+
+### #85308 fix(subagents): preserve requester wake on visible delivery failure
+
+- bucket: ready_for_maintainer
+- author: DolencLuka
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: gold shrimp, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T09:01:45Z
+- live url: https://github.com/openclaw/openclaw/pull/85308

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-019.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-019.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-019
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#88150"
+  - "#88437"
+  - "#88886"
+  - "#95183"
+  - "#94084"
+cluster_refs:
+  - "#88150"
+  - "#88437"
+  - "#88886"
+  - "#95183"
+  - "#94084"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.355Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 19
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #88150 fix(config): cap runtime session-store cache retention
+
+- bucket: ready_for_maintainer
+- author: yozakura-ava
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T09:07:50Z
+- live url: https://github.com/openclaw/openclaw/pull/88150
+
+### #88437 docs: clarify blank Control UI recovery
+
+- bucket: ready_for_maintainer
+- author: Freedomziko
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T09:09:09Z
+- live url: https://github.com/openclaw/openclaw/pull/88437
+
+### #88886 docs(agents): add recovery card handoff guidance
+
+- bucket: ready_for_maintainer
+- author: m4stanuj
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, stale, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T09:12:10Z
+- live url: https://github.com/openclaw/openclaw/pull/88886
+
+### #95183 fix(telegram): materialize streaming progress placeholders
+
+- bucket: ready_for_maintainer
+- author: snowzlmbot
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, size: M, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T09:15:34Z
+- live url: https://github.com/openclaw/openclaw/pull/95183
+
+### #94084 fix(cli): sync official plugins during update --all
+
+- bucket: ready_for_maintainer
+- author: ooiuuii
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, commands, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T09:16:13Z
+- live url: https://github.com/openclaw/openclaw/pull/94084

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-020.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092150-020.md
@@ -1,0 +1,68 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092150-020
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#87393"
+  - "#95508"
+cluster_refs:
+  - "#87393"
+  - "#95508"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:21:50.356Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 20
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #87393 fix(media): suppress local whisper progress transcripts
+
+- bucket: ready_for_maintainer
+- author: kesslerio
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: M, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T09:18:24Z
+- live url: https://github.com/openclaw/openclaw/pull/87393
+
+### #95508 fix #95489: [Bug]: claude-cli out-of-credits error bypasses model fallback chain error text delivered as final response
+
+- bucket: ready_for_maintainer
+- author: mikasa0818
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: sufficient, P1, rating: platinum hermit, merge-risk: auth-provider, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T09:19:28Z
+- live url: https://github.com/openclaw/openclaw/pull/95508


### PR DESCRIPTION
Adds 20 plan-only remediation clusters covering 97 fresh OpenClaw pull requests. The selection excludes the active 100-PR wave and keeps all GitHub mutations blocked at job level.