### PR TITLE
chore: enqueue open PR plan wave 4

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-001.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-001
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#59705"
+  - "#91609"
+  - "#40392"
+  - "#41275"
+  - "#46895"
+cluster_refs:
+  - "#59705"
+  - "#91609"
+  - "#40392"
+  - "#41275"
+  - "#46895"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.394Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #59705 [codex] improve parallels windows smoke logging
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: scripts, maintainer, size: M, P3, rating: unranked krab, merge-risk: automation, status: needs proof
+- live updated: 2026-05-24T19:10:39Z
+- live url: https://github.com/openclaw/openclaw/pull/59705
+
+### #91609 fix(docs): make check:docs work in native PowerShell on Windows
+
+- bucket: needs_proof
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-15T15:03:01Z
+- live url: https://github.com/openclaw/openclaw/pull/91609
+
+### #40392 config: use datetime suffix for config backup files instead of numeric rotation
+
+- bucket: needs_proof
+- author: davidxcli
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-16T04:24:54Z
+- live url: https://github.com/openclaw/openclaw/pull/40392
+
+### #41275 fix(cron): allow timeoutSeconds: 0 for no-timeout mode
+
+- bucket: needs_proof
+- author: JonathanJing
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-16T08:05:17Z
+- live url: https://github.com/openclaw/openclaw/pull/41275
+
+### #46895 fix(slash): handle /model status locally[AI-assisted]#46894
+
+- bucket: needs_proof
+- author: xiaoHEI-312
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-16T08:12:11Z
+- live url: https://github.com/openclaw/openclaw/pull/46895

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-002.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-002
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#48396"
+  - "#52236"
+  - "#55861"
+  - "#58367"
+  - "#16544"
+cluster_refs:
+  - "#48396"
+  - "#52236"
+  - "#55861"
+  - "#58367"
+  - "#16544"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.396Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 2
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #48396 feat(ui): add message preview to session list
+
+- bucket: needs_proof
+- author: SiriuSM00N
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-16T11:03:51Z
+- live url: https://github.com/openclaw/openclaw/pull/48396
+
+### #52236 fix(mattermost): persist threadId in delivery context for all session types
+
+- bucket: draft
+- author: teconomix
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: channel: mattermost, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-16T15:22:21Z
+- live url: https://github.com/openclaw/openclaw/pull/52236
+
+### #55861 fix(ui): prevent collapsed sidebar overlap in control UI
+
+- bucket: needs_proof
+- author: betamod
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-16T18:06:22Z
+- live url: https://github.com/openclaw/openclaw/pull/55861
+
+### #58367 Gateway: preserve approved scope baseline during pairing
+
+- bucket: maintainer_owned
+- author: jacobtomlinson
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: gateway, maintainer, size: M, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-17T20:01:39Z
+- live url: https://github.com/openclaw/openclaw/pull/58367
+
+### #16544 refactor(test): structural MockFn for harness exports
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: channel: imessage, channel: telegram, channel: whatsapp-web, maintainer, size: M, P3, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T00:38:53Z
+- live url: https://github.com/openclaw/openclaw/pull/16544

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-003.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-003
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#47087"
+  - "#43938"
+  - "#88300"
+  - "#50250"
+  - "#74402"
+cluster_refs:
+  - "#47087"
+  - "#43938"
+  - "#88300"
+  - "#50250"
+  - "#74402"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.396Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 3
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #47087 Attach provenance to spawned subagent tasks
+
+- bucket: draft
+- author: Christoffer91
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: agents, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-18T04:56:51Z
+- live url: https://github.com/openclaw/openclaw/pull/47087
+
+### #43938 fix(gateway): use account-scoped reload for channel account changes
+
+- bucket: needs_proof
+- author: coppynight
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: message-delivery, merge-risk: availability, status: needs proof
+- live updated: 2026-06-18T07:09:32Z
+- live url: https://github.com/openclaw/openclaw/pull/43938
+
+### #88300 fix(agents): strip leaked arg_value suffixes
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: M, P1, rating: unranked krab, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-19T05:12:16Z
+- live url: https://github.com/openclaw/openclaw/pull/88300
+
+### #50250 fix(health): show gateway probe duration in text output
+
+- bucket: needs_proof
+- author: JonathanJing
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-19T08:40:32Z
+- live url: https://github.com/openclaw/openclaw/pull/50250
+
+### #74402 fix(agents): route async media completions through wake media
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: agents, maintainer, size: XS, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-19T14:45:03Z
+- live url: https://github.com/openclaw/openclaw/pull/74402

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-004.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-004
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#95059"
+  - "#93950"
+  - "#94049"
+  - "#94069"
+  - "#95230"
+cluster_refs:
+  - "#95059"
+  - "#93950"
+  - "#94049"
+  - "#94069"
+  - "#95230"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.396Z; bucket=needs_proof; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 4
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #95059 fix(build): add explicit ESM format to nodeBuildConfig for type module package
+
+- bucket: needs_proof
+- author: mmyzwl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P1, rating: unranked krab, status: needs proof, merge-risk: other
+- live updated: 2026-06-19T18:20:50Z
+- live url: https://github.com/openclaw/openclaw/pull/95059
+
+### #93950 [codex] fix setup health hint command surface
+
+- bucket: needs_proof
+- author: NianJiuZst
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, commands, size: XS, proof: supplied, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-19T20:42:28Z
+- live url: https://github.com/openclaw/openclaw/pull/93950
+
+### #94049 fix(whatsapp): propagate steered inbound audio metadata for TTS dispatch
+
+- bucket: needs_proof
+- author: xialonglee
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P2, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-19T20:46:20Z
+- live url: https://github.com/openclaw/openclaw/pull/94049
+
+### #94069 feat(commands): switch gemini default model to gemini-3-flash-preview
+
+- bucket: needs_proof
+- author: woyzeck1978
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, extensions: google, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: auth-provider, status: waiting on author
+- live updated: 2026-06-19T20:46:51Z
+- live url: https://github.com/openclaw/openclaw/pull/94069
+
+### #95230 fix docs-list-mdx-pages
+
+- bucket: needs_proof
+- author: hugenshen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: XS, proof: sufficient, P2, rating: gold shrimp, merge-risk: automation, status: waiting on author
+- live updated: 2026-06-20T05:21:19Z
+- live url: https://github.com/openclaw/openclaw/pull/95230

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-005.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-005
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#95229"
+  - "#95237"
+  - "#93588"
+  - "#94952"
+  - "#95253"
+cluster_refs:
+  - "#95229"
+  - "#95237"
+  - "#93588"
+  - "#94952"
+  - "#95253"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.396Z; bucket=needs_proof; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 5
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #95229 fix(copilot): guard against undefined runtime.state during cli-metadata registration
+
+- bucket: needs_proof
+- author: sunlit-deng
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof, extensions: copilot
+- live updated: 2026-06-20T05:27:34Z
+- live url: https://github.com/openclaw/openclaw/pull/95229
+
+### #95237 fix(update): warn about stale gateway when version changes
+
+- bucket: needs_proof
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, P1, rating: unranked krab, status: needs proof, merge-risk: other, triage: needs-pr-context
+- live updated: 2026-06-20T05:42:44Z
+- live url: https://github.com/openclaw/openclaw/pull/95237
+
+### #93588 fix(agents): treat codex exec_command as exec-like
+
+- bucket: needs_proof
+- author: yu-xin-c
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-20T06:26:05Z
+- live url: https://github.com/openclaw/openclaw/pull/93588
+
+### #94952 fix(outbound): prevent internal sink from intercepting action-only pl
+
+- bucket: needs_proof
+- author: lakshitsoni26
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T06:32:15Z
+- live url: https://github.com/openclaw/openclaw/pull/94952
+
+### #95253 fix(scripts): warn when postinstall detects running gateway with stale module imports
+
+- bucket: needs_proof
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: S, proof: sufficient, P1, rating: unranked krab, merge-risk: compatibility, status: waiting on author, merge-risk: other
+- live updated: 2026-06-20T06:34:43Z
+- live url: https://github.com/openclaw/openclaw/pull/95253

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-006.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-006
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94945"
+  - "#95184"
+  - "#95260"
+  - "#95261"
+  - "#95264"
+cluster_refs:
+  - "#94945"
+  - "#95184"
+  - "#95260"
+  - "#95261"
+  - "#95264"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.396Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 6
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94945 fix(openai-completions): keep cache-boundary suffix out of DeepSeek's implicit prefix cache
+
+- bucket: maintainer_owned
+- author: ai-hpc
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: size: S, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: waiting on author
+- live updated: 2026-06-20T06:43:05Z
+- live url: https://github.com/openclaw/openclaw/pull/94945
+
+### #95184 fix(agents): return updatedInput instead of deprecated behavior:allow in canUseTool response
+
+- bucket: needs_proof
+- author: xzh-icenter
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, P1, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T06:58:43Z
+- live url: https://github.com/openclaw/openclaw/pull/95184
+
+### #95260 [codex] Honor active steering debounce
+
+- bucket: draft
+- author: yu-xin-c
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: agents, size: S, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T07:21:02Z
+- live url: https://github.com/openclaw/openclaw/pull/95260
+
+### #95261 fix(status): surface missing external channel plugins in summary
+
+- bucket: needs_proof
+- author: hugenshen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T07:24:32Z
+- live url: https://github.com/openclaw/openclaw/pull/95261
+
+### #95264 fix(tool-result-truncation): skip historical tool results in aggregate reduction to preserve prompt cache stability
+
+- bucket: needs_proof
+- author: mmyzwl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, P2, rating: unranked krab, merge-risk: session-state, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T07:35:18Z
+- live url: https://github.com/openclaw/openclaw/pull/95264

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-007.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-007.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-007
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89068"
+  - "#89213"
+  - "#94094"
+  - "#94151"
+  - "#94487"
+cluster_refs:
+  - "#89068"
+  - "#89213"
+  - "#94094"
+  - "#94151"
+  - "#94487"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.396Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 7
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89068 fix(codex): guard dynamic tool name filters
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, extensions: codex, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T08:04:22Z
+- live url: https://github.com/openclaw/openclaw/pull/89068
+
+### #89213 fix(agents): guard CLI loopback prompt tools
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T08:05:04Z
+- live url: https://github.com/openclaw/openclaw/pull/89213
+
+### #94094 fix(agents): strip leaked truncation sentinels from final replies (#82121)
+
+- bucket: needs_proof
+- author: MoerAI
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T08:07:10Z
+- live url: https://github.com/openclaw/openclaw/pull/94094
+
+### #94151 fix(slack): preserve custom identity on message edits
+
+- bucket: needs_proof
+- author: dwc1997
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: slack, size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T08:07:15Z
+- live url: https://github.com/openclaw/openclaw/pull/94151
+
+### #94487 fix: #94482 normalize cacheRetention 'standard' to 'short'
+
+- bucket: needs_proof
+- author: zhiqiang26
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T08:07:59Z
+- live url: https://github.com/openclaw/openclaw/pull/94487

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-008.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-008.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-008
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#95242"
+  - "#89946"
+  - "#50177"
+  - "#87300"
+  - "#88533"
+cluster_refs:
+  - "#95242"
+  - "#89946"
+  - "#50177"
+  - "#87300"
+  - "#88533"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.396Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 8
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #95242 fix(cron): don't classify a yielded isolated-cron turn as a fatal error
+
+- bucket: needs_proof
+- author: itsuzef
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, P2, rating: silver shellfish, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T08:10:22Z
+- live url: https://github.com/openclaw/openclaw/pull/95242
+
+### #89946 fix(plugins): guard provider policy metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: gold shrimp, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-20T08:15:37Z
+- live url: https://github.com/openclaw/openclaw/pull/89946
+
+### #50177 fix(webchat): slash menu clipped by overflow and missing keyboard scroll
+
+- bucket: needs_proof
+- author: RickyTong1
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, triage: refactor-only, proof: sufficient, P3, rating: gold shrimp, status: waiting on author, proof: video, merge-risk: other
+- live updated: 2026-06-20T08:38:29Z
+- live url: https://github.com/openclaw/openclaw/pull/50177
+
+### #87300 feat: group model select with collapsible panel in Control UI
+
+- bucket: needs_proof
+- author: newbie-yu
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XL, proof: sufficient, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: waiting on author, proof: screenshot
+- live updated: 2026-06-20T08:43:26Z
+- live url: https://github.com/openclaw/openclaw/pull/87300
+
+### #88533 test(core): align changed gate type fixtures
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: agents, maintainer, size: XS, P3, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-20T08:44:52Z
+- live url: https://github.com/openclaw/openclaw/pull/88533

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-009.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-009.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-009
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89006"
+  - "#89044"
+  - "#89076"
+  - "#89077"
+  - "#89078"
+cluster_refs:
+  - "#89006"
+  - "#89044"
+  - "#89076"
+  - "#89077"
+  - "#89078"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.396Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 9
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89006 fix(agents): quarantine invalid session custom tools
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: L, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T08:47:48Z
+- live url: https://github.com/openclaw/openclaw/pull/89006
+
+### #89044 [codex] Group sidebar recent sessions by channel
+
+- bucket: needs_proof
+- author: GimingRao
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, proof: sufficient, P3, rating: gold shrimp, status: waiting on author, merge-risk: other
+- live updated: 2026-06-20T08:48:17Z
+- live url: https://github.com/openclaw/openclaw/pull/89044
+
+### #89076 fix(agent-tools): guard system prompt tool reports
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T08:48:57Z
+- live url: https://github.com/openclaw/openclaw/pull/89076
+
+### #89077 fix(agent-runtime): guard provider schema diagnostics
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T08:49:02Z
+- live url: https://github.com/openclaw/openclaw/pull/89077
+
+### #89078 fix(tui): respect queue mode in sendMessage busy guard
+
+- bucket: maintainer_owned
+- author: SebTardif
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: gateway, size: M, proof: supplied, P2, rating: silver shellfish, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T08:49:10Z
+- live url: https://github.com/openclaw/openclaw/pull/89078

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-010.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-010.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-010
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89082"
+  - "#89119"
+  - "#89126"
+  - "#89136"
+  - "#89141"
+cluster_refs:
+  - "#89082"
+  - "#89119"
+  - "#89126"
+  - "#89136"
+  - "#89141"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.397Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 10
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89082 fix(agent-runtime): guard tool definition descriptors
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T08:49:21Z
+- live url: https://github.com/openclaw/openclaw/pull/89082
+
+### #89119 fix(agent-runtime): guard provider tool diagnostics
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: M, P2, rating: gold shrimp, status: waiting on author, merge-risk: other
+- live updated: 2026-06-20T08:50:14Z
+- live url: https://github.com/openclaw/openclaw/pull/89119
+
+### #89126 docs(contributing): add pnpm check:test-types to pre-PR checklist
+
+- bucket: needs_proof
+- author: Bluetegu
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: low-signal-docs, triage: mock-only-proof, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T08:50:17Z
+- live url: https://github.com/openclaw/openclaw/pull/89126
+
+### #89136 fix(agent-core): guard harness tool registry
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T08:50:27Z
+- live url: https://github.com/openclaw/openclaw/pull/89136
+
+### #89141 fix(agents): guard provider tool diagnostic names
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: XS, P2, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T08:50:33Z
+- live url: https://github.com/openclaw/openclaw/pull/89141

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-011.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-011.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-011
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89211"
+  - "#89422"
+  - "#89426"
+  - "#94116"
+  - "#94217"
+cluster_refs:
+  - "#89211"
+  - "#89422"
+  - "#89426"
+  - "#94116"
+  - "#94217"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.397Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 11
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89211 fix(sessions): rewrite first assistant flush
+
+- bucket: needs_proof
+- author: charles-openclaw
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: mock-only-proof, P2, rating: silver shellfish, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T08:51:27Z
+- live url: https://github.com/openclaw/openclaw/pull/89211
+
+### #89422 fix(plugins): surface tool contract gate rejections at warn level
+
+- bucket: needs_proof
+- author: LiLan0125
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, proof: supplied, P2, rating: silver shellfish, merge-risk: automation, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T08:51:45Z
+- live url: https://github.com/openclaw/openclaw/pull/89422
+
+### #89426 docs: document node capability policy contracts
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: gateway, agents, maintainer, size: XL, P3, rating: unranked krab, status: needs proof, merge-risk: other
+- live updated: 2026-06-20T08:51:50Z
+- live url: https://github.com/openclaw/openclaw/pull/89426
+
+### #94116 fix(cron): preserve isolated success on delivery failure
+
+- bucket: draft
+- author: yu-xin-c
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: size: S, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T08:52:44Z
+- live url: https://github.com/openclaw/openclaw/pull/94116
+
+### #94217 fix(agents): thread image attachments through embedded-agent steer queue [AI-assisted]
+
+- bucket: needs_proof
+- author: eldar702
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-20T08:52:49Z
+- live url: https://github.com/openclaw/openclaw/pull/94217

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-012.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-012.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-012
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94335"
+  - "#94514"
+  - "#94849"
+  - "#94859"
+  - "#94861"
+cluster_refs:
+  - "#94335"
+  - "#94514"
+  - "#94849"
+  - "#94859"
+  - "#94861"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.397Z; bucket=needs_proof; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 12
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94335 fix(subagent): reconcile child output before lost-context sweep
+
+- bucket: needs_proof
+- author: dwc1997
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, P2, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T08:52:55Z
+- live url: https://github.com/openclaw/openclaw/pull/94335
+
+### #94514 docs: add Windows pnpm fallback for Corepack EPERM
+
+- bucket: needs_proof
+- author: africoding
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T08:53:15Z
+- live url: https://github.com/openclaw/openclaw/pull/94514
+
+### #94849 fix(cron): detect recovered tool warnings without preferFinalAssistantVisibleText
+
+- bucket: needs_proof
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T08:53:35Z
+- live url: https://github.com/openclaw/openclaw/pull/94849
+
+### #94859 [codex] Use Executing for default progress label
+
+- bucket: needs_proof
+- author: 100yenadmin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, mantis: telegram-visible-proof, P3, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T08:53:40Z
+- live url: https://github.com/openclaw/openclaw/pull/94859
+
+### #94861 fix #94850: remove Lobstering from default progress draft labels
+
+- bucket: needs_proof
+- author: ztexydt-cqh
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: mock-only-proof, mantis: telegram-visible-proof, P3, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T08:53:46Z
+- live url: https://github.com/openclaw/openclaw/pull/94861

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-013.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-013.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-013
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#68236"
+  - "#88971"
+  - "#89098"
+  - "#89214"
+  - "#89270"
+cluster_refs:
+  - "#68236"
+  - "#88971"
+  - "#89098"
+  - "#89214"
+  - "#89270"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.397Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 13
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #68236 test(auth): add oauth e2e regression coverage
+
+- bucket: maintainer_owned
+- author: ngutman
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: gateway, maintainer, size: L, P2, rating: unranked krab, merge-risk: automation, status: waiting on author
+- live updated: 2026-06-20T09:13:56Z
+- live url: https://github.com/openclaw/openclaw/pull/68236
+
+### #88971 fix(agents): suppress EmbeddedAttemptSessionTakeoverError on user-ini
+
+- bucket: needs_proof
+- author: tanshanshan
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, scripts, agents, size: M, proof: supplied, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T09:14:25Z
+- live url: https://github.com/openclaw/openclaw/pull/88971
+
+### #89098 fix(gateway): guard tools catalog descriptors
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: gateway, maintainer, size: M, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T09:14:55Z
+- live url: https://github.com/openclaw/openclaw/pull/89098
+
+### #89214 whatsapp: expose connection watchdog tuning in account config
+
+- bucket: needs_proof
+- author: danashburn
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: whatsapp-web, size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T09:15:09Z
+- live url: https://github.com/openclaw/openclaw/pull/89214
+
+### #89270 fix(agents): sanitize provider tool schema logs
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: diamond lobster, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T09:15:31Z
+- live url: https://github.com/openclaw/openclaw/pull/89270

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-014.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-014.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-014
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89329"
+  - "#89579"
+  - "#89580"
+  - "#89582"
+  - "#89603"
+cluster_refs:
+  - "#89329"
+  - "#89579"
+  - "#89580"
+  - "#89582"
+  - "#89603"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.397Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 14
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89329 fix(auto-reply): guard exported session tool schemas
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T09:16:18Z
+- live url: https://github.com/openclaw/openclaw/pull/89329
+
+### #89579 fix(agents): harden code mode MCP schema docs
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-20T09:20:59Z
+- live url: https://github.com/openclaw/openclaw/pull/89579
+
+### #89580 perf: structuredClone instead of JSON.parse(stringify)
+
+- bucket: draft
+- author: dboone323
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T09:21:04Z
+- live url: https://github.com/openclaw/openclaw/pull/89580
+
+### #89582 fix(agents): harden tool search schema catalog
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T09:21:10Z
+- live url: https://github.com/openclaw/openclaw/pull/89582
+
+### #89603 fix(agents): quarantine unreadable tool schemas before normalization
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: commands, agents, maintainer, size: M, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T09:21:56Z
+- live url: https://github.com/openclaw/openclaw/pull/89603

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-015.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-015.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-015
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89632"
+  - "#89647"
+  - "#89673"
+  - "#94652"
+  - "#88962"
+cluster_refs:
+  - "#89632"
+  - "#89647"
+  - "#89673"
+  - "#94652"
+  - "#88962"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.397Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 15
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89632 fix(config): guard schema lookup traversal
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, P2, rating: gold shrimp, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-20T09:22:37Z
+- live url: https://github.com/openclaw/openclaw/pull/89632
+
+### #89647 fix(plugins): guard startup manifest channels
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T09:23:19Z
+- live url: https://github.com/openclaw/openclaw/pull/89647
+
+### #89673 fix(agents): reclaim session write-locks held past the holder's own maxHoldMs
+
+- bucket: maintainer_owned
+- author: openperf
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: docs, agents, size: XS, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T09:33:49Z
+- live url: https://github.com/openclaw/openclaw/pull/89673
+
+### #94652 fix: #77909 handle interactive card in feishu merge_forward sub-message
+
+- bucket: needs_proof
+- author: lzyyzznl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T09:51:24Z
+- live url: https://github.com/openclaw/openclaw/pull/94652
+
+### #88962 fix: complete preserveKeys implementation for session maintenance
+
+- bucket: needs_proof
+- author: AllynSheep
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T10:03:17Z
+- live url: https://github.com/openclaw/openclaw/pull/88962

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-016.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-016.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-016
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#51868"
+  - "#60445"
+  - "#61322"
+  - "#61329"
+  - "#61624"
+cluster_refs:
+  - "#51868"
+  - "#60445"
+  - "#61322"
+  - "#61329"
+  - "#61624"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.397Z; bucket=needs_proof; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 16
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #51868 UI: fix half-block art rendering for UTF-8 QR codes in web chat
+
+- bucket: needs_proof
+- author: emg110
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, proof: sufficient, P2, rating: gold shrimp, status: waiting on author, proof: screenshot, merge-risk: other
+- live updated: 2026-06-20T10:10:36Z
+- live url: https://github.com/openclaw/openclaw/pull/51868
+
+### #60445 fix(agents): add channelData marker to exec-approval-unavailable payloads
+
+- bucket: needs_proof
+- author: qualiobra
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: stale, size: L, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T10:11:09Z
+- live url: https://github.com/openclaw/openclaw/pull/60445
+
+### #61322 fix(sessions): remap stale same-agent paths into the current state dir
+
+- bucket: needs_proof
+- author: rbutera
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T10:11:18Z
+- live url: https://github.com/openclaw/openclaw/pull/61322
+
+### #61329 ui: default usage view to last 7 days instead of today-only
+
+- bucket: needs_proof
+- author: hacky193
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, stale, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T10:11:24Z
+- live url: https://github.com/openclaw/openclaw/pull/61329
+
+### #61624 feat(whatsapp): add dmRequireMention for DM trigger gating
+
+- bucket: needs_proof
+- author: mubbie
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: whatsapp-web, size: S, triage: dirty-candidate, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T10:11:30Z
+- live url: https://github.com/openclaw/openclaw/pull/61624

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-017.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-017.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-017
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#62841"
+  - "#85478"
+  - "#85727"
+  - "#85745"
+  - "#85747"
+cluster_refs:
+  - "#62841"
+  - "#85478"
+  - "#85727"
+  - "#85745"
+  - "#85747"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.397Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 17
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #62841 fix(auto-reply): accept /activate as alias for /activation command
+
+- bucket: needs_proof
+- author: pradeep7127
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T10:11:45Z
+- live url: https://github.com/openclaw/openclaw/pull/62841
+
+### #85478 fix(slack): soften benign search no-result progress
+
+- bucket: maintainer_owned
+- author: kesslerio
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: channel: discord, channel: matrix, channel: msteams, channel: slack, channel: telegram, agents, stale, size: L, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T10:12:43Z
+- live url: https://github.com/openclaw/openclaw/pull/85478
+
+### #85727 docs: add first run setup steps to CONTRIBUTING.md
+
+- bucket: needs_proof
+- author: Arvuno
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: low-signal-docs, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T10:13:25Z
+- live url: https://github.com/openclaw/openclaw/pull/85727
+
+### #85745 fix(discord): add configurable REST API timeout via channels.discord.apiTimeoutMs
+
+- bucket: needs_proof
+- author: AuroraBrain666
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T10:13:34Z
+- live url: https://github.com/openclaw/openclaw/pull/85745
+
+### #85747 fix(agents): add worker thread pool for event-loop isolation of model calls
+
+- bucket: needs_proof
+- author: AuroraBrain666
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, gateway, agents, size: L, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T10:13:42Z
+- live url: https://github.com/openclaw/openclaw/pull/85747

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-018.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-018.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-018
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#85748"
+  - "#85758"
+  - "#85828"
+  - "#86018"
+  - "#89067"
+cluster_refs:
+  - "#85748"
+  - "#85758"
+  - "#85828"
+  - "#86018"
+  - "#89067"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.397Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 18
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #85748 feat(doctor): warn early when session store size will slow doctor
+
+- bucket: needs_proof
+- author: joeyfrasier
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: M, proof: supplied, proof: sufficient, P2, rating: unranked krab, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-20T10:13:50Z
+- live url: https://github.com/openclaw/openclaw/pull/85748
+
+### #85758 feat: add retries field to HealthCheckRunContext for transient failure handling
+
+- bucket: needs_proof
+- author: Arvuno
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T10:13:55Z
+- live url: https://github.com/openclaw/openclaw/pull/85758
+
+### #85828 [codex] web_search: add Perplexity model override
+
+- bucket: needs_proof
+- author: NianJiuZst
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: M, proof: supplied, proof: sufficient, extensions: perplexity, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: auth-provider, status: waiting on author
+- live updated: 2026-06-20T10:14:04Z
+- live url: https://github.com/openclaw/openclaw/pull/85828
+
+### #86018 Clarify QQBot passive group event wording
+
+- bucket: needs_proof
+- author: asock
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, channel: qqbot, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T10:14:46Z
+- live url: https://github.com/openclaw/openclaw/pull/86018
+
+### #89067 fix(codex): harden diagnostic tool capture
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, extensions: codex, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T10:15:32Z
+- live url: https://github.com/openclaw/openclaw/pull/89067

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-019.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-019.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-019
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89072"
+  - "#89149"
+  - "#89171"
+  - "#89266"
+  - "#89272"
+cluster_refs:
+  - "#89072"
+  - "#89149"
+  - "#89171"
+  - "#89266"
+  - "#89272"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.398Z; bucket=maintainer_owned; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 19
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89072 fix(codex): guard prompt report tool metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, extensions: codex, P2, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-20T10:15:40Z
+- live url: https://github.com/openclaw/openclaw/pull/89072
+
+### #89149 fix(agents): validate extension tool names
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T10:16:10Z
+- live url: https://github.com/openclaw/openclaw/pull/89149
+
+### #89171 fix(agent-core): validate harness tool names
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T10:16:21Z
+- live url: https://github.com/openclaw/openclaw/pull/89171
+
+### #89266 fix(doctor): harden runtime tool schema findings
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T10:17:27Z
+- live url: https://github.com/openclaw/openclaw/pull/89266
+
+### #89272 fix(doctor): sanitize bundle MCP schema diagnostics
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: XS, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-20T10:17:32Z
+- live url: https://github.com/openclaw/openclaw/pull/89272

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-020.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-020.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-020
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89295"
+  - "#89693"
+  - "#89696"
+  - "#89726"
+  - "#89733"
+cluster_refs:
+  - "#89295"
+  - "#89693"
+  - "#89696"
+  - "#89726"
+  - "#89733"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.398Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 20
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89295 docs: document command auth compatibility contracts
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: maintainer, size: M, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T10:18:02Z
+- live url: https://github.com/openclaw/openclaw/pull/89295
+
+### #89693 fix(cron): ignore optional scanner search misses
+
+- bucket: needs_proof
+- author: henryyuen168-ship-it
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T10:19:42Z
+- live url: https://github.com/openclaw/openclaw/pull/89693
+
+### #89696 feat(tools): add low-memory tool guard
+
+- bucket: needs_proof
+- author: lily-oc
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T10:19:57Z
+- live url: https://github.com/openclaw/openclaw/pull/89696
+
+### #89726 fix(agents): guard deferred follow-up tool descriptors
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T10:20:51Z
+- live url: https://github.com/openclaw/openclaw/pull/89726
+
+### #89733 fix(agents): guard message provider tool name reads
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T10:21:04Z
+- live url: https://github.com/openclaw/openclaw/pull/89733

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-021.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-021.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-021
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#95299"
+  - "#89819"
+  - "#89857"
+  - "#89875"
+  - "#94883"
+cluster_refs:
+  - "#95299"
+  - "#89819"
+  - "#89857"
+  - "#89875"
+  - "#94883"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.398Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 21
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #95299 fix #95248: OpenClaw release_lane is a no-op when claim is held by a live worker; stuck Telegram inbound events block agent response until gateway restart
+
+- bucket: needs_proof
+- author: mikasa0818
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: S, mantis: telegram-visible-proof, P1, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T10:21:59Z
+- live url: https://github.com/openclaw/openclaw/pull/95299
+
+### #89819 fix(node-host): guard plugin command metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: gold shrimp, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-20T10:25:02Z
+- live url: https://github.com/openclaw/openclaw/pull/89819
+
+### #89857 fix(plugins): guard runtime lifecycle cleanup metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: gold shrimp, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-20T10:26:26Z
+- live url: https://github.com/openclaw/openclaw/pull/89857
+
+### #89875 fix(channels): guard loaded plugin metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: silver shellfish, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-20T10:27:05Z
+- live url: https://github.com/openclaw/openclaw/pull/89875
+
+### #94883 [AI-assisted] Filter soft-archived cards by default in workboard list CLI
+
+- bucket: needs_proof
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof, plugin: workboard
+- live updated: 2026-06-20T10:29:56Z
+- live url: https://github.com/openclaw/openclaw/pull/94883

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-022.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-022.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-022
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94216"
+  - "#94449"
+  - "#94822"
+  - "#94874"
+  - "#95265"
+cluster_refs:
+  - "#94216"
+  - "#94449"
+  - "#94822"
+  - "#94874"
+  - "#95265"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.398Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 22
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94216 fix(streaming): preserve paragraph separators across block-chunk deliveries [AI-assisted]
+
+- bucket: needs_proof
+- author: eldar702
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T10:30:20Z
+- live url: https://github.com/openclaw/openclaw/pull/94216
+
+### #94449 fix(exec): expand leading ~ in workdir to home directory
+
+- bucket: maintainer_owned
+- author: Pandah97
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T10:31:10Z
+- live url: https://github.com/openclaw/openclaw/pull/94449
+
+### #94822 fix(plugins): pin HTTP route registry during gateway plugin bootstrap
+
+- bucket: needs_proof
+- author: LiLan0125
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, proof: supplied, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T10:31:37Z
+- live url: https://github.com/openclaw/openclaw/pull/94822
+
+### #94874 build(deps): bump the actions group across 1 directory with 2 updates
+
+- bucket: needs_proof
+- author: dependabot
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: dependencies, size: XS, github_actions, P3, rating: silver shellfish, merge-risk: automation, status: waiting on author
+- live updated: 2026-06-20T10:32:33Z
+- live url: https://github.com/openclaw/openclaw/pull/94874
+
+### #95265 fix(anthropic): resolve claude-code version at runtime for OAuth user-agent
+
+- bucket: needs_proof
+- author: ruomuxydt
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-20T10:33:07Z
+- live url: https://github.com/openclaw/openclaw/pull/95265

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-023.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-023.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-023
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94000"
+  - "#87528"
+  - "#95167"
+  - "#95287"
+  - "#89899"
+cluster_refs:
+  - "#94000"
+  - "#87528"
+  - "#95167"
+  - "#95287"
+  - "#89899"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.398Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 23
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94000 fix(feishu): add pagination support for drive list and info
+
+- bucket: needs_proof
+- author: ajwan8998
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: M, triage: blank-template, proof: supplied, P2, rating: unranked krab, merge-risk: availability, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T10:37:00Z
+- live url: https://github.com/openclaw/openclaw/pull/94000
+
+### #87528 fix(webchat): add Content-Disposition header for assistant-media downloads
+
+- bucket: needs_proof
+- author: LPtrichor
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T10:48:31Z
+- live url: https://github.com/openclaw/openclaw/pull/87528
+
+### #95167 fix(config): allow Nix-mode doctor --fix and auth login for non-config writes
+
+- bucket: needs_proof
+- author: moguangyu5-design
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T10:55:02Z
+- live url: https://github.com/openclaw/openclaw/pull/95167
+
+### #95287 fix(failover): detect provider transport timeout in AbortError with 'This operation was aborted' message
+
+- bucket: needs_proof
+- author: crh-code
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T10:55:55Z
+- live url: https://github.com/openclaw/openclaw/pull/95287
+
+### #89899 fix #89425: [Bug]: Missing extensions/speech-core/ in npm tarball (v2026.5.28) "Unable to resolve bundled plugin public surface speech-core/runtime-api.js"
+
+- bucket: maintainer_owned
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: scripts, size: M, extensions: qa-lab, proof: supplied, proof: sufficient, P1, rating: diamond lobster, merge-risk: automation, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T11:03:36Z
+- live url: https://github.com/openclaw/openclaw/pull/89899

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-024.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-024.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-024
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#64436"
+  - "#64800"
+  - "#86013"
+  - "#89924"
+  - "#89979"
+cluster_refs:
+  - "#64436"
+  - "#64800"
+  - "#86013"
+  - "#89924"
+  - "#89979"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.398Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 24
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #64436 feat: expose model pricing to plugins via runtime.usage API
+
+- bucket: maintainer_owned
+- author: dodge1218
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: steipete
+- labels: docs, stale, size: XS, plugin: file-transfer, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T11:23:01Z
+- live url: https://github.com/openclaw/openclaw/pull/64436
+
+### #64800 fix(plugins): iterate all providers in wrapProviderStreamFn
+
+- bucket: needs_proof
+- author: klin3867
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-20T11:23:05Z
+- live url: https://github.com/openclaw/openclaw/pull/64800
+
+### #86013 fix(line): repair LINE message delivery table rendering, code blocks, payload validation, and 285 passing tests
+
+- bucket: needs_proof
+- author: samson1357924
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: line, size: M, proof: supplied, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T11:23:27Z
+- live url: https://github.com/openclaw/openclaw/pull/86013
+
+### #89924 fix(plugins): guard effective channel owner metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T11:24:51Z
+- live url: https://github.com/openclaw/openclaw/pull/89924
+
+### #89979 fix(config): isolate provider auto-enable rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: silver shellfish, status: waiting on author
+- live updated: 2026-06-20T11:25:01Z
+- live url: https://github.com/openclaw/openclaw/pull/89979

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-025.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T092949-025.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T092949-025
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89993"
+  - "#90032"
+  - "#90038"
+  - "#90039"
+  - "#90085"
+cluster_refs:
+  - "#89993"
+  - "#90032"
+  - "#90038"
+  - "#90039"
+  - "#90085"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:29:49.398Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 25
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89993 fix(plugins): isolate inspect gateway descriptor rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T11:25:07Z
+- live url: https://github.com/openclaw/openclaw/pull/89993
+
+### #90032 fix(plugins): isolate tool metadata projection
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: gateway, agents, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T11:25:13Z
+- live url: https://github.com/openclaw/openclaw/pull/90032
+
+### #90038 fix(discord): surface failed bulk reaction removals instead of false success
+
+- bucket: needs_proof
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: XS, triage: mock-only-proof, P2, rating: silver shellfish, status: needs proof, merge-risk: other
+- live updated: 2026-06-20T11:25:15Z
+- live url: https://github.com/openclaw/openclaw/pull/90038
+
+### #90039 fix(plugins): isolate command spec projection
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T11:25:19Z
+- live url: https://github.com/openclaw/openclaw/pull/90039
+
+### #90085 fix(gateway): guard model pricing metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: gateway, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T11:25:29Z
+- live url: https://github.com/openclaw/openclaw/pull/90085


### PR DESCRIPTION
Adds 25 plan-only remediation clusters covering 125 fresh non-security-labelled OpenClaw pull requests from the broader inventory. Jobs block all GitHub mutations at job level.