### PR TITLE
chore: enqueue 150 open PR plan jobs

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-001.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-001
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90090"
+  - "#90107"
+  - "#90125"
+  - "#90130"
+  - "#90143"
+cluster_refs:
+  - "#90090"
+  - "#90107"
+  - "#90125"
+  - "#90130"
+  - "#90143"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.655Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #90090 fix(plugins): guard runtime boundary manifest rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T11:25:32Z
+- live url: https://github.com/openclaw/openclaw/pull/90090
+
+### #90107 fix(commands): guard model provider aliases
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: commands, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T11:25:52Z
+- live url: https://github.com/openclaw/openclaw/pull/90107
+
+### #90125 fix(embedded-runner): distinguish model initialization errors from assistant execution errors
+
+- bucket: needs_proof
+- author: bladin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T11:26:20Z
+- live url: https://github.com/openclaw/openclaw/pull/90125
+
+### #90130 fix(auth): guard preferred provider metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: commands, maintainer, size: S, P2, rating: platinum hermit, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-20T11:26:25Z
+- live url: https://github.com/openclaw/openclaw/pull/90130
+
+### #90143 feat(doctor): add narrow deterministic gating check
+
+- bucket: needs_proof
+- author: ski3md
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P3, rating: silver shellfish, merge-risk: automation, status: needs proof
+- live updated: 2026-06-20T11:26:48Z
+- live url: https://github.com/openclaw/openclaw/pull/90143

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-002.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-002
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90194"
+  - "#90195"
+  - "#90204"
+  - "#90248"
+  - "#90268"
+cluster_refs:
+  - "#90194"
+  - "#90195"
+  - "#90204"
+  - "#90248"
+  - "#90268"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.656Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 2
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #90194 fix(cron): sweep isolated-target base cron sessions under sessionRetention
+
+- bucket: maintainer_owned
+- author: openperf
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: size: M, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T11:28:05Z
+- live url: https://github.com/openclaw/openclaw/pull/90194
+
+### #90195 fix(plugins): guard plugin tool descriptor reads
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: L, P2, rating: silver shellfish, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T11:28:10Z
+- live url: https://github.com/openclaw/openclaw/pull/90195
+
+### #90204 fix(windows): resolve compatibility, path redaction, symlink EPERM, and channel sorting issues
+
+- bucket: needs_proof
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof, merge-risk: other
+- live updated: 2026-06-20T11:28:34Z
+- live url: https://github.com/openclaw/openclaw/pull/90204
+
+### #90248 Add channel turn delivery and control-lane diagnostics
+
+- bucket: needs_proof
+- author: sbuchberger
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, gateway, extensions: diagnostics-otel, cli, commands, agents, size: XL, triage: dirty-candidate, proof: supplied, mantis: telegram-visible-proof, P1, rating: silver shellfish, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T11:29:34Z
+- live url: https://github.com/openclaw/openclaw/pull/90248
+
+### #90268 fix(trajectory): guard tool schema capture
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T11:29:56Z
+- live url: https://github.com/openclaw/openclaw/pull/90268

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-003.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-003
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90273"
+  - "#90308"
+  - "#90311"
+  - "#90386"
+  - "#95309"
+cluster_refs:
+  - "#90273"
+  - "#90308"
+  - "#90311"
+  - "#90386"
+  - "#95309"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.656Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 3
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #90273 test: make fs-safe hardlink tests compatible with Windows
+
+- bucket: needs_proof
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: sufficient, P3, rating: gold shrimp, status: waiting on author
+- live updated: 2026-06-20T11:30:03Z
+- live url: https://github.com/openclaw/openclaw/pull/90273
+
+### #90308 fix(diagnostics): reclaim zombie embedded-run counters left idle by handle-mismatch clears
+
+- bucket: maintainer_owned
+- author: openperf
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: size: M, P1, rating: platinum hermit, merge-risk: session-state, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-20T11:30:38Z
+- live url: https://github.com/openclaw/openclaw/pull/90308
+
+### #90311 fix(mcp): quarantine unreadable plugin tool schemas
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: M, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T11:30:44Z
+- live url: https://github.com/openclaw/openclaw/pull/90311
+
+### #90386 fix(mcp): skip unreadable plugin tools
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: gold shrimp, status: waiting on author
+- live updated: 2026-06-20T11:32:07Z
+- live url: https://github.com/openclaw/openclaw/pull/90386
+
+### #95309 [codex] route Telegram poll_answer updates
+
+- bucket: draft
+- author: liaoyl830
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: channel: telegram, size: L, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T11:44:15Z
+- live url: https://github.com/openclaw/openclaw/pull/95309

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-004.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-004
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#41067"
+  - "#55723"
+  - "#56720"
+  - "#59816"
+  - "#59986"
+cluster_refs:
+  - "#41067"
+  - "#55723"
+  - "#56720"
+  - "#59816"
+  - "#59986"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.656Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 4
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #41067 Fix dashboard chat run recovery across reconnects
+
+- bucket: needs_proof
+- author: Elysium-Seeker
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: macos, app: web-ui, gateway, size: L, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T11:59:17Z
+- live url: https://github.com/openclaw/openclaw/pull/41067
+
+### #55723 fix(agents): preserve ACP requester agent overrides
+
+- bucket: needs_proof
+- author: RichardCao
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T12:01:04Z
+- live url: https://github.com/openclaw/openclaw/pull/55723
+
+### #56720 fix(hooks): restore --exclude-labels in Gmail watcher args
+
+- bucket: needs_proof
+- author: Lidang-Jiang
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: S, triage: needs-real-behavior-proof, P1, rating: silver shellfish, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T12:01:48Z
+- live url: https://github.com/openclaw/openclaw/pull/56720
+
+### #59816 fix(discord): record history entry when dropping bot message in allowBots=mentions mode
+
+- bucket: needs_proof
+- author: Hou-Yufan
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: session-state, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T12:04:03Z
+- live url: https://github.com/openclaw/openclaw/pull/59816
+
+### #59986 refactor(plugins): add lane-oriented channel interface
+
+- bucket: maintainer_owned
+- author: huntharo
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: docs, channel: discord, channel: msteams, channel: slack, channel: telegram, maintainer, channel: feishu, size: XL, mantis: telegram-visible-proof, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-20T12:04:28Z
+- live url: https://github.com/openclaw/openclaw/pull/59986

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-005.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-005
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#60048"
+  - "#60922"
+  - "#61396"
+  - "#61464"
+  - "#62338"
+cluster_refs:
+  - "#60048"
+  - "#60922"
+  - "#61396"
+  - "#61464"
+  - "#62338"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.656Z; bucket=needs_proof; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 5
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #60048 docs(memory): add memory system deep dive guide
+
+- bucket: needs_proof
+- author: neyric
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: needs-real-behavior-proof, P3, rating: gold shrimp, status: waiting on author, merge-risk: other
+- live updated: 2026-06-20T12:04:35Z
+- live url: https://github.com/openclaw/openclaw/pull/60048
+
+### #60922 feat(agents): derive fallbacks from configured model catalog
+
+- bucket: needs_proof
+- author: 08820048
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, agents, size: M, triage: dirty-candidate, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-20T12:05:05Z
+- live url: https://github.com/openclaw/openclaw/pull/60922
+
+### #61396 fix(i18n): add device/node pairing terms to zh-CN glossary
+
+- bucket: needs_proof
+- author: zeuming
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, stale, size: XS, triage: low-signal-docs, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: automation, status: waiting on author
+- live updated: 2026-06-20T12:05:34Z
+- live url: https://github.com/openclaw/openclaw/pull/61396
+
+### #61464 Docker: add Mac migration and keep-awake helpers
+
+- bucket: needs_proof
+- author: ruslansv
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, scripts, docker, size: L, proof: supplied, P2, rating: silver shellfish, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T12:05:39Z
+- live url: https://github.com/openclaw/openclaw/pull/61464
+
+### #62338 doctor(memory): surface FTS5 unavailable state in doctor checks
+
+- bucket: needs_proof
+- author: ZanderH-code
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, commands, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: automation, status: needs proof
+- live updated: 2026-06-20T12:06:18Z
+- live url: https://github.com/openclaw/openclaw/pull/62338

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-006.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-006
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#62722"
+  - "#62822"
+  - "#64310"
+  - "#65058"
+  - "#65382"
+cluster_refs:
+  - "#62722"
+  - "#62822"
+  - "#64310"
+  - "#65058"
+  - "#65382"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.657Z; bucket=needs_proof; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 6
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #62722 fix(gateway): use already-aborted signal in stopChannel fallback
+
+- bucket: needs_proof
+- author: pruthvishetty
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, triage: refactor-only, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T12:06:40Z
+- live url: https://github.com/openclaw/openclaw/pull/62722
+
+### #62822 Speed up Discord permission audits
+
+- bucket: needs_proof
+- author: RONNYKHALIL
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T12:06:44Z
+- live url: https://github.com/openclaw/openclaw/pull/62822
+
+### #64310 fix: Replaced mutable module-global workspacePackagePaths
+
+- bucket: needs_proof
+- author: lucia-w
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, stale, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T12:08:02Z
+- live url: https://github.com/openclaw/openclaw/pull/64310
+
+### #65058 fix(googlechat): accept add-on space lifecycle payload variants
+
+- bucket: needs_proof
+- author: Yanhu007
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: googlechat, stale, size: XS, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T12:08:25Z
+- live url: https://github.com/openclaw/openclaw/pull/65058
+
+### #65382 fix(ui): format common cron intervals
+
+- bucket: needs_proof
+- author: OwenYWT
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof, merge-risk: other
+- live updated: 2026-06-20T12:08:34Z
+- live url: https://github.com/openclaw/openclaw/pull/65382

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-007.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-007.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-007
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#71503"
+  - "#72513"
+  - "#80110"
+  - "#80139"
+  - "#80246"
+cluster_refs:
+  - "#71503"
+  - "#72513"
+  - "#80110"
+  - "#80139"
+  - "#80246"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.657Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 7
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #71503 fix(gateway): prefer physical LAN addresses before bridge interfaces
+
+- bucket: needs_proof
+- author: deepkilo
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, extensions: device-pair, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T12:08:47Z
+- live url: https://github.com/openclaw/openclaw/pull/71503
+
+### #72513 fix(mattermost): handle post_edited websocket events (#71930)
+
+- bucket: needs_proof
+- author: Bojun-Vvibe
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: mattermost, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T12:09:02Z
+- live url: https://github.com/openclaw/openclaw/pull/72513
+
+### #80110 fix(agents): suppress raw subagent tool output
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: docs, agents, maintainer, size: S, proof: sufficient, mantis: telegram-visible-proof, P3, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T12:11:18Z
+- live url: https://github.com/openclaw/openclaw/pull/80110
+
+### #80139 fix: record cron delivery failures as warnings
+
+- bucket: needs_proof
+- author: HemantSudarshan
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: web-ui, gateway, cli, scripts, agents, size: L, extensions: qa-lab, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T12:11:26Z
+- live url: https://github.com/openclaw/openclaw/pull/80139
+
+### #80246 feat(cron): include event time in failure alerts
+
+- bucket: draft
+- author: haishmg
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: gateway, size: S, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look, proof: video
+- live updated: 2026-06-20T12:11:32Z
+- live url: https://github.com/openclaw/openclaw/pull/80246

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-008.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-008.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-008
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#87471"
+  - "#87694"
+  - "#87888"
+  - "#88175"
+  - "#88950"
+cluster_refs:
+  - "#87471"
+  - "#87694"
+  - "#87888"
+  - "#88175"
+  - "#88950"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.657Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 8
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #87471 fix(webchat): mirror visible tool status on replay
+
+- bucket: maintainer_owned
+- author: giodl73-repo
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: app: web-ui, gateway, maintainer, size: M, proof: sufficient, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-20T12:13:00Z
+- live url: https://github.com/openclaw/openclaw/pull/87471
+
+### #87694 fix(auth): tighten billing cooldown defaults to recover from multi-hour lockouts (#70903)
+
+- bucket: needs_proof
+- author: sweetcornna
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, commands, agents, size: L, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: session-state, status: waiting on author
+- live updated: 2026-06-20T12:13:12Z
+- live url: https://github.com/openclaw/openclaw/pull/87694
+
+### #87888 fix(agents): skip tool prep when models disable tools
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: no
+- assignees: vincentkoc
+- labels: agents, maintainer, size: XS, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T12:13:17Z
+- live url: https://github.com/openclaw/openclaw/pull/87888
+
+### #88175 fix(codex): omit tool controls without tools
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: no
+- assignees: vincentkoc
+- labels: maintainer, size: S, proof: sufficient, P2, rating: silver shellfish, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T12:13:31Z
+- live url: https://github.com/openclaw/openclaw/pull/88175
+
+### #88950 fix(plugins): ignore throwing provider policy hooks
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-20T12:14:39Z
+- live url: https://github.com/openclaw/openclaw/pull/88950

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-009.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-009.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-009
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89056"
+  - "#89061"
+  - "#89071"
+  - "#89263"
+  - "#89301"
+cluster_refs:
+  - "#89056"
+  - "#89061"
+  - "#89071"
+  - "#89263"
+  - "#89301"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.657Z; bucket=maintainer_owned; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 9
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89056 fix(mcp): validate plugin tool schemas
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: M, P2, rating: gold shrimp, merge-risk: compatibility, status: waiting on author, merge-risk: other
+- live updated: 2026-06-20T12:15:05Z
+- live url: https://github.com/openclaw/openclaw/pull/89056
+
+### #89061 fix(agent-core): skip unreadable tool names
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T12:15:10Z
+- live url: https://github.com/openclaw/openclaw/pull/89061
+
+### #89071 fix(agent-tools): skip unreadable tool names in policy
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T12:15:15Z
+- live url: https://github.com/openclaw/openclaw/pull/89071
+
+### #89263 fix(plugin-sdk): reject malformed static tool descriptors
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: docs, cli, scripts, maintainer, size: M, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T12:15:37Z
+- live url: https://github.com/openclaw/openclaw/pull/89263
+
+### #89301 fix(trajectory): skip unreadable tool descriptors
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T12:15:59Z
+- live url: https://github.com/openclaw/openclaw/pull/89301

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-010.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-010.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-010
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89327"
+  - "#89333"
+  - "#89688"
+  - "#89721"
+  - "#89763"
+cluster_refs:
+  - "#89327"
+  - "#89333"
+  - "#89688"
+  - "#89721"
+  - "#89763"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.657Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 10
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89327 fix(sessions): guard agent tool definition mirroring
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T12:16:18Z
+- live url: https://github.com/openclaw/openclaw/pull/89327
+
+### #89333 fix(tools): guard planner descriptor reads
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: silver shellfish, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T12:16:21Z
+- live url: https://github.com/openclaw/openclaw/pull/89333
+
+### #89688 fix: suppress duplicate Telegram plugin approvals
+
+- bucket: needs_proof
+- author: cyphercodes
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: S, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T12:17:09Z
+- live url: https://github.com/openclaw/openclaw/pull/89688
+
+### #89721 test(cron): cover cron base-session preservation during reaper sweep
+
+- bucket: needs_proof
+- author: xiaobao-k8s
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, proof: sufficient, P3, rating: unranked krab, status: waiting on author
+- live updated: 2026-06-20T12:17:36Z
+- live url: https://github.com/openclaw/openclaw/pull/89721
+
+### #89763 fix(gateway): guard plugin session action dispatch
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: gateway, maintainer, size: M, P2, rating: gold shrimp, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-20T12:17:43Z
+- live url: https://github.com/openclaw/openclaw/pull/89763

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-011.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-011.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-011
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89794"
+  - "#89852"
+  - "#89912"
+  - "#89929"
+  - "#89931"
+cluster_refs:
+  - "#89794"
+  - "#89852"
+  - "#89912"
+  - "#89929"
+  - "#89931"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.657Z; bucket=maintainer_owned; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 11
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89794 fix(gateway): guard plugin UI descriptors
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: gateway, maintainer, size: S, P2, rating: gold shrimp, status: ready for maintainer look
+- live updated: 2026-06-20T12:18:16Z
+- live url: https://github.com/openclaw/openclaw/pull/89794
+
+### #89852 fix(gateway): guard plugin session action lookups
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: gateway, maintainer, size: S, P2, rating: gold shrimp, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-20T12:18:28Z
+- live url: https://github.com/openclaw/openclaw/pull/89852
+
+### #89912 refactor: add transcript update identity contract
+
+- bucket: maintainer_owned
+- author: jalehman
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: docs, channel: telegram, gateway, extensions: memory-core, agents, maintainer, size: L, extensions: codex, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof, extensions: copilot
+- live updated: 2026-06-20T12:18:59Z
+- live url: https://github.com/openclaw/openclaw/pull/89912
+
+### #89929 fix(plugins): guard setup backend metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T12:19:14Z
+- live url: https://github.com/openclaw/openclaw/pull/89929
+
+### #89931 fix(plugins): guard manifest contract metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T12:19:21Z
+- live url: https://github.com/openclaw/openclaw/pull/89931

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-012.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-012.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-012
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89969"
+  - "#89977"
+  - "#89980"
+  - "#89983"
+  - "#90005"
+cluster_refs:
+  - "#89969"
+  - "#89977"
+  - "#89980"
+  - "#89983"
+  - "#90005"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.657Z; bucket=maintainer_owned; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 12
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89969 fix(plugins): isolate setup manifest rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T12:19:38Z
+- live url: https://github.com/openclaw/openclaw/pull/89969
+
+### #89977 fix(plugins): isolate bundle config rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T12:19:50Z
+- live url: https://github.com/openclaw/openclaw/pull/89977
+
+### #89980 fix(trajectory): isolate manifest metadata rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: unranked krab, status: waiting on author
+- live updated: 2026-06-20T12:19:55Z
+- live url: https://github.com/openclaw/openclaw/pull/89980
+
+### #89983 fix(agents): isolate provider attribution manifest rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: M, P2, rating: platinum hermit, merge-risk: auth-provider, status: ready for maintainer look
+- live updated: 2026-06-20T12:20:06Z
+- live url: https://github.com/openclaw/openclaw/pull/89983
+
+### #90005 fix(plugins): isolate captured CLI metadata rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T12:20:43Z
+- live url: https://github.com/openclaw/openclaw/pull/90005

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-013.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-013.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-013
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89932"
+  - "#89948"
+  - "#89963"
+  - "#89987"
+  - "#89989"
+cluster_refs:
+  - "#89932"
+  - "#89948"
+  - "#89963"
+  - "#89987"
+  - "#89989"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.657Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 13
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89932 docs: document Skill Workshop tool visibility rules
+
+- bucket: needs_proof
+- author: baskduf
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, docker, size: XS, proof: supplied, P3, rating: gold shrimp, status: waiting on author, merge-risk: other
+- live updated: 2026-06-20T12:35:40Z
+- live url: https://github.com/openclaw/openclaw/pull/89932
+
+### #89948 fix(plugins): guard plugin id alias metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T12:35:53Z
+- live url: https://github.com/openclaw/openclaw/pull/89948
+
+### #89963 fix(plugins): isolate bundled channel metadata rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T12:36:03Z
+- live url: https://github.com/openclaw/openclaw/pull/89963
+
+### #89987 fix(cron): suppress control diagnostics in delivery
+
+- bucket: needs_proof
+- author: bdjben
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T12:36:30Z
+- live url: https://github.com/openclaw/openclaw/pull/89987
+
+### #89989 fix(heartbeat): debounce requests-in-flight retries
+
+- bucket: needs_proof
+- author: sahibzada-allahyar
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P1, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T12:36:35Z
+- live url: https://github.com/openclaw/openclaw/pull/89989

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-014.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-014.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-014
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90002"
+  - "#90016"
+  - "#90052"
+  - "#90066"
+  - "#91786"
+cluster_refs:
+  - "#90002"
+  - "#90016"
+  - "#90052"
+  - "#90066"
+  - "#91786"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.657Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 14
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #90002 fix(plugins): isolate CLI metadata rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T12:36:45Z
+- live url: https://github.com/openclaw/openclaw/pull/90002
+
+### #90016 fix(plugins): isolate cached tool descriptor names
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T12:37:14Z
+- live url: https://github.com/openclaw/openclaw/pull/90016
+
+### #90052 fix(plugins): isolate capability provider rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, P2, rating: unranked krab, status: waiting on author
+- live updated: 2026-06-20T12:38:06Z
+- live url: https://github.com/openclaw/openclaw/pull/90052
+
+### #90066 fix(telegram): suppress reconnect drain re-entry while delivery is in-flight
+
+- bucket: needs_proof
+- author: SebTardif
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: M, proof: supplied, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T12:38:17Z
+- live url: https://github.com/openclaw/openclaw/pull/90066
+
+### #91786 fix(plugins): reconcile managed npm root overrides with managed peer pins
+
+- bucket: maintainer_owned
+- author: amknight
+- author association: MEMBER
+- draft: no
+- assignees: amknight
+- labels: maintainer, size: L, P1, rating: diamond lobster, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T12:39:43Z
+- live url: https://github.com/openclaw/openclaw/pull/91786

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-015.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-015.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-015
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94781"
+  - "#94855"
+  - "#95298"
+  - "#55851"
+  - "#64503"
+cluster_refs:
+  - "#94781"
+  - "#94855"
+  - "#95298"
+  - "#55851"
+  - "#64503"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.658Z; bucket=needs_proof; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 15
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94781 fix(copilot): tolerate missing runtime state API during plugin registration
+
+- bucket: needs_proof
+- author: ajwan8998
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P2, rating: silver shellfish, merge-risk: session-state, status: needs proof, extensions: copilot
+- live updated: 2026-06-20T12:41:18Z
+- live url: https://github.com/openclaw/openclaw/pull/94781
+
+### #94855 fix(cron): treat cron tool warnings as non-fatal when run recovered
+
+- bucket: needs_proof
+- author: LiLan0125
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T12:41:29Z
+- live url: https://github.com/openclaw/openclaw/pull/94855
+
+### #95298 fix(agents): seal deepseek reasoning before the answer (no discrete thinking_end)
+
+- bucket: needs_proof
+- author: Marvinthebored
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T12:43:57Z
+- live url: https://github.com/openclaw/openclaw/pull/95298
+
+### #55851 feat: include provider/model/profile/trigger context in overloaded and rate limit error messages
+
+- bucket: needs_proof
+- author: TinyTb
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: gold shrimp, merge-risk: auth-provider, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-20T13:03:41Z
+- live url: https://github.com/openclaw/openclaw/pull/55851
+
+### #64503 fix(msteams): forward messageBack card actions (Action.Submit) to agent (#60952)
+
+- bucket: needs_proof
+- author: ndholakia
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: msteams, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T13:05:02Z
+- live url: https://github.com/openclaw/openclaw/pull/64503

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-016.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-016.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-016
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#66257"
+  - "#68146"
+  - "#68196"
+  - "#68307"
+  - "#68503"
+cluster_refs:
+  - "#66257"
+  - "#68146"
+  - "#68196"
+  - "#68307"
+  - "#68503"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.658Z; bucket=needs_proof; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 16
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #66257 [codex] fix devices approve local fallback
+
+- bucket: needs_proof
+- author: SrJackCM
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, size: XS, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T13:05:13Z
+- live url: https://github.com/openclaw/openclaw/pull/66257
+
+### #68146 fix(gateway): hold startup-gated requests at server until post-attach (closes #67160)
+
+- bucket: needs_proof
+- author: sparkeros
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: M, proof: supplied, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T13:06:46Z
+- live url: https://github.com/openclaw/openclaw/pull/68146
+
+### #68196 fix(agents): post-timeout compensation in sessions_send
+
+- bucket: needs_proof
+- author: glfruit
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, P1, rating: silver shellfish, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T13:06:57Z
+- live url: https://github.com/openclaw/openclaw/pull/68196
+
+### #68307 fix(commands): emit WARN when bootstrap files are truncated
+
+- bucket: needs_proof
+- author: 1aifanatic
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T13:07:09Z
+- live url: https://github.com/openclaw/openclaw/pull/68307
+
+### #68503 status: reduce diagnosis noise in status --all
+
+- bucket: needs_proof
+- author: likewen-tech
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, commands, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-20T13:07:16Z
+- live url: https://github.com/openclaw/openclaw/pull/68503

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-017.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-017.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-017
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89945"
+  - "#90073"
+  - "#92099"
+  - "#95311"
+  - "#95334"
+cluster_refs:
+  - "#89945"
+  - "#90073"
+  - "#92099"
+  - "#95311"
+  - "#95334"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.658Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 17
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #89945 fix(plugins): guard provider discovery metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: waiting on author
+- live updated: 2026-06-20T13:10:05Z
+- live url: https://github.com/openclaw/openclaw/pull/89945
+
+### #90073 fix(plugins): guard metadata snapshot owner rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T13:10:24Z
+- live url: https://github.com/openclaw/openclaw/pull/90073
+
+### #92099 feat(active-memory): add messageMaxChars config to cap latest user message in message mode
+
+- bucket: needs_proof
+- author: bladin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: S, triage: mock-only-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T13:12:31Z
+- live url: https://github.com/openclaw/openclaw/pull/92099
+
+### #95311 feat: add disableBoundaryAwareCache compat option for prefix-matching prompt cache providers
+
+- bucket: needs_proof
+- author: sunlit-deng
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-20T13:16:33Z
+- live url: https://github.com/openclaw/openclaw/pull/95311
+
+### #95334 fix(workboard): hide archived cards by default in CLI list
+
+- bucket: needs_proof
+- author: maweibin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof, plugin: workboard
+- live updated: 2026-06-20T13:24:08Z
+- live url: https://github.com/openclaw/openclaw/pull/95334

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-018.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-018.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-018
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#95049"
+  - "#95176"
+  - "#95335"
+  - "#62727"
+  - "#65783"
+cluster_refs:
+  - "#95049"
+  - "#95176"
+  - "#95335"
+  - "#62727"
+  - "#65783"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.658Z; bucket=needs_proof; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 18
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #95049 fix: respect hook config model override in session-memory slug generation (#89551)
+
+- bucket: needs_proof
+- author: jincheng-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-20T13:25:39Z
+- live url: https://github.com/openclaw/openclaw/pull/95049
+
+### #95176 fix(anthropic): retry on UND_ERR_SOCKET keep-alive failures (#87407)
+
+- bucket: needs_proof
+- author: jincheng-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, P1, rating: silver shellfish, merge-risk: auth-provider, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T13:28:35Z
+- live url: https://github.com/openclaw/openclaw/pull/95176
+
+### #95335 feat(telegram): add isolatedIngress config switch
+
+- bucket: needs_proof
+- author: Cyb3rb1ade
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, size: S, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T13:35:45Z
+- live url: https://github.com/openclaw/openclaw/pull/95335
+
+### #62727 fix: parse descriptive identity avatar lines
+
+- bucket: needs_proof
+- author: onEnterFrame
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T13:37:12Z
+- live url: https://github.com/openclaw/openclaw/pull/62727
+
+### #65783 fix(memory): preserve surrogate pairs in chunker; sanitize embed inputs
+
+- bucket: needs_proof
+- author: jensenwang560-blip
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: sufficient, P1, rating: gold shrimp, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-20T13:37:21Z
+- live url: https://github.com/openclaw/openclaw/pull/65783

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-019.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-019.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-019
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#65936"
+  - "#67967"
+  - "#68116"
+  - "#68306"
+  - "#44143"
+cluster_refs:
+  - "#65936"
+  - "#67967"
+  - "#68116"
+  - "#68306"
+  - "#44143"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.658Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 19
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #65936 feat: add Asia/Shanghai to cron timezone suggestions
+
+- bucket: needs_proof
+- author: finallylly
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T13:37:27Z
+- live url: https://github.com/openclaw/openclaw/pull/65936
+
+### #67967 fix(minimax): disable tool call ID sanitization for Anthropic-compatible API
+
+- bucket: needs_proof
+- author: sebykrueger
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, extensions: minimax, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T13:37:59Z
+- live url: https://github.com/openclaw/openclaw/pull/67967
+
+### #68116 feat(memory-lancedb): support reindex and drop-index command
+
+- bucket: needs_proof
+- author: zhangyue19921010
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-lancedb, stale, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T13:38:05Z
+- live url: https://github.com/openclaw/openclaw/pull/68116
+
+### #68306 fix(telegram): reject zero and negative replyToMessageId values
+
+- bucket: needs_proof
+- author: 1aifanatic
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: S, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T13:38:10Z
+- live url: https://github.com/openclaw/openclaw/pull/68306
+
+### #44143 fix: serialize outbound deliveries per channel+recipient
+
+- bucket: draft
+- author: nicolasgrasset
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: size: M, proof: sufficient, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: message-delivery, merge-risk: availability, status: waiting on author, proof: screenshot, triage: needs-pr-context
+- live updated: 2026-06-20T13:38:27Z
+- live url: https://github.com/openclaw/openclaw/pull/44143

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-020.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-020.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-020
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#68685"
+  - "#86584"
+  - "#86649"
+  - "#89965"
+  - "#89970"
+cluster_refs:
+  - "#68685"
+  - "#86584"
+  - "#86649"
+  - "#89965"
+  - "#89970"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.658Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 20
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #68685 fix(config): strip obsolete memorySearch keys before schema validation (#68664)
+
+- bucket: needs_proof
+- author: Tmalone1250
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: S, triage: needs-real-behavior-proof, P1, rating: silver shellfish, merge-risk: compatibility, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T13:38:42Z
+- live url: https://github.com/openclaw/openclaw/pull/68685
+
+### #86584 fix(agents): gate owned-write publish on pre-append fingerprint (#86572)
+
+- bucket: maintainer_owned
+- author: ubehera
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: unranked krab, merge-risk: session-state, status: waiting on author
+- live updated: 2026-06-20T13:44:52Z
+- live url: https://github.com/openclaw/openclaw/pull/86584
+
+### #86649 fix: relay Claude CLI assistant partial messages as streaming deltas
+
+- bucket: needs_proof
+- author: SebTardif
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, P1, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T13:45:07Z
+- live url: https://github.com/openclaw/openclaw/pull/86649
+
+### #89965 fix(agents): emit user-visible notice when a turn exhausts its time budget
+
+- bucket: needs_proof
+- author: spencer2211
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, triage: needs-real-behavior-proof, P2, rating: silver shellfish, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T13:47:45Z
+- live url: https://github.com/openclaw/openclaw/pull/89965
+
+### #89970 fix(plugins): normalize setup probe reasons
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T13:47:51Z
+- live url: https://github.com/openclaw/openclaw/pull/89970

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-021.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-021.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-021
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94912"
+  - "#89999"
+  - "#90019"
+  - "#90048"
+  - "#90065"
+cluster_refs:
+  - "#94912"
+  - "#89999"
+  - "#90019"
+  - "#90048"
+  - "#90065"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.658Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 21
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94912 fix(nextcloud-talk): silently ignore non-message Talk events instead of returning 400
+
+- bucket: needs_proof
+- author: zhangqueping
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: nextcloud-talk, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T13:47:51Z
+- live url: https://github.com/openclaw/openclaw/pull/94912
+
+### #89999 fix(plugins): isolate CLI descriptor rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T13:48:15Z
+- live url: https://github.com/openclaw/openclaw/pull/89999
+
+### #90019 fix(memory-search): default periodic sync fallback
+
+- bucket: needs_proof
+- author: sahibzada-allahyar
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, extensions: memory-core, agents, size: S, proof: supplied, proof: sufficient, P1, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T13:48:24Z
+- live url: https://github.com/openclaw/openclaw/pull/90019
+
+### #90048 fix(plugins): isolate provider runtime rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: gold shrimp, status: waiting on author
+- live updated: 2026-06-20T13:48:48Z
+- live url: https://github.com/openclaw/openclaw/pull/90048
+
+### #90065 fix(agents): bound abort-path session lock release; force-release on unsettled retained writes
+
+- bucket: needs_proof
+- author: matin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: session-state, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T13:49:27Z
+- live url: https://github.com/openclaw/openclaw/pull/90065

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-022.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-022.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-022
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90265"
+  - "#90875"
+  - "#94311"
+  - "#94948"
+  - "#95301"
+cluster_refs:
+  - "#90265"
+  - "#90875"
+  - "#94311"
+  - "#94948"
+  - "#95301"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.658Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 22
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #90265 fix(agents): guard system prompt tool schema stats
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T13:49:57Z
+- live url: https://github.com/openclaw/openclaw/pull/90265
+
+### #90875 fix(clawdock-helpers): rename path name in loop to stop mutating PATH via zsh path<->PATH linkage
+
+- bucket: needs_proof
+- author: lshgdut
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: XS, triage: needs-real-behavior-proof, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-20T13:51:25Z
+- live url: https://github.com/openclaw/openclaw/pull/90875
+
+### #94311 fix: auto-grant lossless-claw model override from summaryModel config
+
+- bucket: needs_proof
+- author: lzyyzznl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T13:51:51Z
+- live url: https://github.com/openclaw/openclaw/pull/94311
+
+### #94948 fix(codex): preserve assistant text on post-turn compaction failure (#94688)
+
+- bucket: needs_proof
+- author: sunlit-deng
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, extensions: codex, proof: supplied, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T13:51:57Z
+- live url: https://github.com/openclaw/openclaw/pull/94948
+
+### #95301 fix: make post-turn compaction non-fatal
+
+- bucket: needs_proof
+- author: ajwan8998
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T13:52:30Z
+- live url: https://github.com/openclaw/openclaw/pull/95301

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-023.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-023.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-023
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#40782"
+  - "#69199"
+  - "#89944"
+  - "#89966"
+  - "#93889"
+cluster_refs:
+  - "#40782"
+  - "#69199"
+  - "#89944"
+  - "#89966"
+  - "#93889"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.658Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 23
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #40782 fix(feishu): use union_id as fallback for @mention detection in multi-bot groups
+
+- bucket: maintainer_owned
+- author: alaleiwang
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: channel: feishu, stale, size: S, clawsweeper:automerge, clawsweeper:human-review, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: automerge armed, triage: needs-pr-context
+- live updated: 2026-06-20T13:57:09Z
+- live url: https://github.com/openclaw/openclaw/pull/40782
+
+### #69199 fix(memory): improve error message when node:sqlite is unavailable
+
+- bucket: recent_active
+- author: rrrrrredy
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: supplied, P2
+- live updated: 2026-06-20T14:12:23Z
+- live url: https://github.com/openclaw/openclaw/pull/69199
+
+### #89944 Idr msteams adaptive card tables
+
+- bucket: needs_proof
+- author: rrajp
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: msteams, size: M, proof: sufficient, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: waiting on author, proof: screenshot
+- live updated: 2026-06-20T14:14:16Z
+- live url: https://github.com/openclaw/openclaw/pull/89944
+
+### #89966 docs: add firecrawl.dev links on the Firecrawl tool page
+
+- bucket: needs_proof
+- author: rakshith48
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, triage: needs-real-behavior-proof, P3, rating: silver shellfish, status: waiting on author, triage: needs-pr-context
+- live updated: 2026-06-20T14:14:30Z
+- live url: https://github.com/openclaw/openclaw/pull/89966
+
+### #93889 fix(ci): restore native release preparation gates
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: no
+- assignees: vincentkoc
+- labels: scripts, maintainer, size: S, P2, rating: unranked krab, merge-risk: automation, status: waiting on author
+- live updated: 2026-06-20T14:15:38Z
+- live url: https://github.com/openclaw/openclaw/pull/93889

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-024.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-024.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-024
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#54183"
+  - "#58993"
+  - "#63015"
+  - "#63375"
+  - "#67818"
+cluster_refs:
+  - "#54183"
+  - "#58993"
+  - "#63015"
+  - "#63375"
+  - "#67818"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.658Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 24
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #54183 WhatsApp: add configurable send retry for transient network errors
+
+- bucket: needs_proof
+- author: hassansys2
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: whatsapp-web, size: XL, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T14:51:24Z
+- live url: https://github.com/openclaw/openclaw/pull/54183
+
+### #58993 fix(googlechat): support spaceType field for DM vs Space detection
+
+- bucket: maintainer_owned
+- author: Starhappysh
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: channel: googlechat, stale, size: S, proof: override, P1, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look, merge-risk: other, triage: needs-pr-context
+- live updated: 2026-06-20T14:52:48Z
+- live url: https://github.com/openclaw/openclaw/pull/58993
+
+### #63015 fix: honor filePath/path/media fallbacks in outbound reply normalization
+
+- bucket: needs_proof
+- author: tombensim
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T14:53:31Z
+- live url: https://github.com/openclaw/openclaw/pull/63015
+
+### #63375 docs: add logging best practices for plugin developers
+
+- bucket: needs_proof
+- author: QuBenhao
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, triage: refactor-only, triage: blank-template, triage: needs-real-behavior-proof, P3, rating: silver shellfish, status: waiting on author, merge-risk: other, triage: needs-pr-context
+- live updated: 2026-06-20T14:54:02Z
+- live url: https://github.com/openclaw/openclaw/pull/63375
+
+### #67818 fix(whatsapp): add QR login result codes and preflight hook
+
+- bucket: maintainer_owned
+- author: mcaxtr
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: channel: whatsapp-web, gateway, maintainer, size: M, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-20T14:54:54Z
+- live url: https://github.com/openclaw/openclaw/pull/67818

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-025.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-025.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-025
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#69954"
+  - "#72025"
+  - "#72351"
+  - "#72510"
+  - "#72677"
+cluster_refs:
+  - "#69954"
+  - "#72025"
+  - "#72351"
+  - "#72510"
+  - "#72677"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.659Z; bucket=needs_proof; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 25
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #69954 fix: fall back to canonical session transcripts during cleanup
+
+- bucket: needs_proof
+- author: Blahdude
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: refactor-only, triage: needs-real-behavior-proof, P2, rating: silver shellfish, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T14:55:51Z
+- live url: https://github.com/openclaw/openclaw/pull/69954
+
+### #72025 fix(signal): enable inbound status reactions
+
+- bucket: needs_proof
+- author: Hua688
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: signal, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T14:58:00Z
+- live url: https://github.com/openclaw/openclaw/pull/72025
+
+### #72351 fix(tui): handle zero history limit
+
+- bucket: needs_proof
+- author: Stedyclaw
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T14:58:44Z
+- live url: https://github.com/openclaw/openclaw/pull/72351
+
+### #72510 fix(group-chat): wire multi-agent bot-targeting signals end-to-end (#56692)
+
+- bucket: needs_proof
+- author: Bojun-Vvibe
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: L, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T14:59:29Z
+- live url: https://github.com/openclaw/openclaw/pull/72510
+
+### #72677 fix(cron): warn on main heartbeat handoff ghost runs
+
+- bucket: needs_proof
+- author: liaoandi
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: matrix, app: web-ui, gateway, scripts, size: M, proof: supplied, P2, rating: gold shrimp, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T15:00:27Z
+- live url: https://github.com/openclaw/openclaw/pull/72677

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-026.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-026.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-026
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#72987"
+  - "#73159"
+  - "#73440"
+  - "#74068"
+  - "#74274"
+cluster_refs:
+  - "#72987"
+  - "#73159"
+  - "#73440"
+  - "#74068"
+  - "#74274"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.659Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 26
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #72987 docs(compaction): document reserveTokensFloor default (20,000 tokens)
+
+- bucket: needs_proof
+- author: ayesha-aziz123
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, stale, size: XS, triage: low-signal-docs, triage: needs-real-behavior-proof, P3, rating: gold shrimp, status: waiting on author
+- live updated: 2026-06-20T15:00:58Z
+- live url: https://github.com/openclaw/openclaw/pull/72987
+
+### #73159 Add tool-call failure guardrails
+
+- bucket: needs_proof
+- author: martins-oss
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, stale, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T15:01:03Z
+- live url: https://github.com/openclaw/openclaw/pull/73159
+
+### #73440 fix(gateway/command-auth): memoize ownerAllowFrom list per raw array (#50289)
+
+- bucket: needs_proof
+- author: eric-zachary077
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T15:02:54Z
+- live url: https://github.com/openclaw/openclaw/pull/73440
+
+### #74068 fix(cron): keep recurring backoff stable after reload
+
+- bucket: maintainer_owned
+- author: ai-hpc
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: size: XS, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T15:04:37Z
+- live url: https://github.com/openclaw/openclaw/pull/74068
+
+### #74274 fix(control-ui): download assistant markdown attachments
+
+- bucket: needs_proof
+- author: Neomail2
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, stale, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T15:05:30Z
+- live url: https://github.com/openclaw/openclaw/pull/74274

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-027.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-027.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-027
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94964"
+  - "#74509"
+  - "#74643"
+  - "#81164"
+  - "#85404"
+cluster_refs:
+  - "#94964"
+  - "#74509"
+  - "#74643"
+  - "#81164"
+  - "#85404"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.659Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 27
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94964 fix(reload): cancel deferred channel reload on in-process restart
+
+- bucket: needs_proof
+- author: lzyyzznl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T15:05:45Z
+- live url: https://github.com/openclaw/openclaw/pull/94964
+
+### #74509 fix(matrix): honor MSC3967 and surface MAS reset URL on cross-signing bootstrap
+
+- bucket: needs_proof
+- author: nklock
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: matrix, size: L, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T15:06:34Z
+- live url: https://github.com/openclaw/openclaw/pull/74509
+
+### #74643 config: accept per-agent elevatedDefault overrides and complete per-agent verbose/elevated flow (#73680)
+
+- bucket: needs_proof
+- author: lonexreb
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T15:06:41Z
+- live url: https://github.com/openclaw/openclaw/pull/74643
+
+### #81164 feat(context-engine): add interceptCompaction contract for context-engine plugins
+
+- bucket: maintainer_owned
+- author: 100yenadmin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: jalehman
+- labels: docs, agents, stale, size: XL, extensions: codex, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T15:06:51Z
+- live url: https://github.com/openclaw/openclaw/pull/81164
+
+### #85404 fix(agents): serialize new-session resolution per session key
+
+- bucket: maintainer_owned
+- author: openperf
+- author association: MEMBER
+- draft: no
+- assignees: osolmaz
+- labels: agents, stale, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-20T15:07:52Z
+- live url: https://github.com/openclaw/openclaw/pull/85404

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-028.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-028.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-028
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#85481"
+  - "#89923"
+  - "#89982"
+  - "#90219"
+  - "#90383"
+cluster_refs:
+  - "#85481"
+  - "#89923"
+  - "#89982"
+  - "#90219"
+  - "#90383"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.659Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 28
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #85481 Fix Feishu card action mention gating
+
+- bucket: maintainer_owned
+- author: googlerest
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: steipete
+- labels: channel: feishu, stale, size: XS, proof: supplied, P1, rating: silver shellfish, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T15:07:58Z
+- live url: https://github.com/openclaw/openclaw/pull/85481
+
+### #89923 fix(plugins): guard manifest command alias metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: gold shrimp, status: waiting on author
+- live updated: 2026-06-20T15:10:24Z
+- live url: https://github.com/openclaw/openclaw/pull/89923
+
+### #89982 fix(agents): use appropriate log levels in tools-manager and resource-loader
+
+- bucket: needs_proof
+- author: Kailigithub
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, merge-risk: compatibility, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T15:10:32Z
+- live url: https://github.com/openclaw/openclaw/pull/89982
+
+### #90219 fix(agents): preserve unreadable tool schemas through wrapping
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-20T15:11:22Z
+- live url: https://github.com/openclaw/openclaw/pull/90219
+
+### #90383 fix(ollama): skip unreadable tool schemas
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: L, extensions: ollama, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T15:12:03Z
+- live url: https://github.com/openclaw/openclaw/pull/90383

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-029.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-029.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-029
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90419"
+  - "#90625"
+  - "#90864"
+  - "#90867"
+  - "#91132"
+cluster_refs:
+  - "#90419"
+  - "#90625"
+  - "#90864"
+  - "#90867"
+  - "#91132"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.659Z; bucket=needs_proof; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 29
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #90419 fix: force-release session lock on dispose to prevent orphan locks
+
+- bucket: needs_proof
+- author: longkunbetter
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: session-state, merge-risk: availability, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T15:12:10Z
+- live url: https://github.com/openclaw/openclaw/pull/90419
+
+### #90625 docs: add supported iOS install path when public beta is full
+
+- bucket: needs_proof
+- author: tarsopsbot
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: ios, size: XS, triage: needs-real-behavior-proof, P3, rating: silver shellfish, status: waiting on author, merge-risk: other
+- live updated: 2026-06-20T15:13:02Z
+- live url: https://github.com/openclaw/openclaw/pull/90625
+
+### #90864 fix(tasks): accept completion summaries with result markers
+
+- bucket: needs_proof
+- author: moeedahmed
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: unranked krab, merge-risk: session-state, status: waiting on author
+- live updated: 2026-06-20T15:15:43Z
+- live url: https://github.com/openclaw/openclaw/pull/90864
+
+### #90867 fix(auto-reply): warn when /export-session only contains user messages (backend-delegated)
+
+- bucket: needs_proof
+- author: xydigit-sj
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, P2, rating: gold shrimp, status: needs proof
+- live updated: 2026-06-20T15:15:49Z
+- live url: https://github.com/openclaw/openclaw/pull/90867
+
+### #91132 feat(gateway): add first-output and completed latency phases to chat.send_timing
+
+- bucket: needs_proof
+- author: tanshanshan
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: M, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T15:16:13Z
+- live url: https://github.com/openclaw/openclaw/pull/91132

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-030.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T094459-030.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T094459-030
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#91157"
+  - "#89404"
+  - "#94018"
+  - "#72224"
+  - "#95173"
+cluster_refs:
+  - "#91157"
+  - "#89404"
+  - "#94018"
+  - "#72224"
+  - "#95173"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T09:44:59.659Z; bucket=mixed; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 30
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #91157 fix: stabilize claude-cli extraSystemPromptHash across group turns (#69118)
+
+- bucket: needs_proof
+- author: sumitaich1998
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P1, rating: unranked krab, merge-risk: automation, status: needs proof
+- live updated: 2026-06-20T15:16:36Z
+- live url: https://github.com/openclaw/openclaw/pull/91157
+
+### #89404 fix(agents): snapshot SDK custom tools safely
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: S, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T15:26:56Z
+- live url: https://github.com/openclaw/openclaw/pull/89404
+
+### #94018 fix(tools): add diagnostic callback for unavailable tool descriptors
+
+- bucket: needs_proof
+- author: mazhuima
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof, merge-risk: other
+- live updated: 2026-06-20T15:30:17Z
+- live url: https://github.com/openclaw/openclaw/pull/94018
+
+### #72224 fix gateway restart outside systemd
+
+- bucket: needs_proof
+- author: myagizmaktav
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: L, triage: needs-real-behavior-proof, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: availability, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T15:58:58Z
+- live url: https://github.com/openclaw/openclaw/pull/72224
+
+### #95173 fix(claude-cli): update PermissionResult to match Claude Code 2.1.x schema
+
+- bucket: needs_proof
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, P1, rating: unranked krab, merge-risk: compatibility, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T16:12:13Z
+- live url: https://github.com/openclaw/openclaw/pull/95173


### PR DESCRIPTION
## Summary
- enqueue 30 plan-only remediation clusters for 150 fresh open PRs
- block all direct GitHub mutations in every generated job

## Validation
- `npm run validate`