### PR TITLE
chore(queue): plan fresh maintainer-ready PRs

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T100702-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T100702-001.md
@@ -1,0 +1,94 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T100702-001
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93168"
+  - "#86893"
+  - "#95527"
+  - "#95534"
+cluster_refs:
+  - "#93168"
+  - "#86893"
+  - "#95527"
+  - "#95534"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T10:07:02.995Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #93168 fix(active-memory): exclude dreaming-narrative session keys from interactive eligibility gate
+
+- bucket: ready_for_maintainer
+- author: xialonglee
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T09:33:14Z
+- live url: https://github.com/openclaw/openclaw/pull/93168
+
+### #86893 Fix isolated cron cold runner setup timeout
+
+- bucket: ready_for_maintainer
+- author: dredozubov
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P1, rating: gold shrimp, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-21T09:55:01Z
+- live url: https://github.com/openclaw/openclaw/pull/86893
+
+### #95527 fix(scripts): type windows taskkill helper
+
+- bucket: ready_for_maintainer
+- author: ooiuuii
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: XS, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T10:05:53Z
+- live url: https://github.com/openclaw/openclaw/pull/95527
+
+### #95534 fix(scripts): route i18n formatter through pnpm runner
+
+- bucket: ready_for_maintainer
+- author: ooiuuii
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: XS, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T10:06:06Z
+- live url: https://github.com/openclaw/openclaw/pull/95534


### PR DESCRIPTION
Adds one plan-only remediation shard from live GitHub state for #93168, #86893, #95527, and #95534.

No target-repository mutation is permitted by this job; it refreshes merge/repair evidence before any later guarded action.