### PR TITLE
fix(executor): block live high-risk repair targets

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -3,7 +3,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
-import { assertAllowedOwner, parseArgs, parseJob, repoRoot, validateJob } from "./lib.mjs";
+import {
+  assertAllowedOwner,
+  hasDeterministicSecuritySignal,
+  parseArgs,
+  parseJob,
+  repoRoot,
+  validateJob,
+} from "./lib.mjs";
 import {
   automergeRepairOutcomeComment,
   externalMessageProvenance,
@@ -255,6 +262,22 @@ if (scopeBlock && !deferScopeBlockForRebaseOnlyRepair) {
     repair_strategy: fixArtifact.repair_strategy,
     reason: scopeBlock.reason,
     evidence: scopeBlock.evidence,
+  });
+  writeReport(report, resultPath);
+  process.exit(0);
+}
+const liveTargetPolicyBlock = validateLiveAutonomousTargetPolicy({ job, fixArtifact });
+if (liveTargetPolicyBlock) {
+  report.status = "blocked";
+  report.reason = liveTargetPolicyBlock.reason;
+  report.no_target_mutations = true;
+  report.actions.push({
+    action: "execute_fix",
+    status: "blocked",
+    code: liveTargetPolicyBlock.code,
+    repair_strategy: fixArtifact.repair_strategy,
+    reason: liveTargetPolicyBlock.reason,
+    evidence: liveTargetPolicyBlock.evidence,
   });
   writeReport(report, resultPath);
   process.exit(0);
@@ -2420,6 +2443,37 @@ function mutableFixSourceRefs(fixArtifact) {
   return [];
 }
 
+function validateLiveAutonomousTargetPolicy({ job, fixArtifact }) {
+  if (job.frontmatter.mode !== "autonomous") return null;
+
+  const sources =
+    fixArtifact.repair_strategy === "repair_contributor_branch"
+      ? [firstSourcePullRequest(fixArtifact)]
+      : fixArtifact.repair_strategy === "replace_uneditable_branch"
+        ? supersededReplacementSources(fixArtifact).map(parsePullRequestUrl).filter(Boolean)
+        : [];
+
+  for (const source of sources) {
+    const pull = fetchPullRequest(source.number);
+    const labels = (pull.labels ?? []).map((label) => String(label?.name ?? label)).filter(Boolean);
+    const normalizedLabels = labels.map((label) => label.toLowerCase());
+    const blockedSignals = [
+      ...(normalizedLabels.includes("clawsweeper:automerge") ? ["clawsweeper:automerge"] : []),
+      ...labels.filter((label) => /^merge-risk:/i.test(label)),
+      ...(hasDeterministicSecuritySignal({ labels }) ? ["security-sensitive"] : []),
+    ];
+    if (blockedSignals.length === 0) continue;
+
+    return {
+      code: "live_target_policy_block",
+      reason: `live source PR #${source.number} has blocked labels: ${blockedSignals.join(", ")}`,
+      evidence: [`source=#${source.number}`, `labels=${labels.join(", ") || "none"}`],
+    };
+  }
+
+  return null;
+}
+
 function validateAutonomousFixScope({ job, fixArtifact }) {
   if (allowBroadFixArtifacts || job.frontmatter.allow_broad_fix_artifacts === true) return null;
 
@@ -3953,6 +4007,10 @@ function appendAutomergeRepairOutcomeComment(report, resultPath) {
     action: "automerge_repair_outcome_comment",
     target: target ? `#${target}` : null,
   };
+  if (report.no_target_mutations === true) {
+    report.actions.push({ ...base, status: "skipped", reason: "live target policy blocks all target mutations" });
+    return;
+  }
   if (!jobAllowsAction("comment")) {
     report.actions.push({ ...base, status: "skipped", reason: "job blocks outcome comments" });
     return;

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -169,6 +169,83 @@ process.exit(99);
   ]);
 });
 
+test("execute-fix-artifact blocks live autonomous repair targets with risk labels before target mutation", () => {
+  for (const { label, expectedSignal, automerge, repairStrategy = "repair_contributor_branch" } of [
+    { label: "merge-risk: compatibility", expectedSignal: "merge-risk: compatibility", automerge: false },
+    {
+      label: "merge-risk: availability",
+      expectedSignal: "merge-risk: availability",
+      automerge: false,
+      repairStrategy: "replace_uneditable_branch",
+    },
+    { label: "security:sensitive", expectedSignal: "security-sensitive", automerge: false },
+    { label: "clawsweeper:automerge", expectedSignal: "clawsweeper:automerge", automerge: true },
+  ]) {
+    const fixture = makeFixture();
+    const clusterId = `live-target-policy-${label.replace(/[^a-z]+/gi, "-").replace(/^-|-$/g, "")}`;
+    const resultPath = path.join(fixture.runDir, "result.json");
+    const reportPath = path.join(fixture.runDir, "fix-execution-report.json");
+    const ghLog = path.join(fixture.root, "gh.log");
+
+    fs.writeFileSync(
+      fixture.jobPath,
+      `${jobFile(clusterId).replace(
+        "security_sensitive: false",
+        `${automerge ? "source: pr_automerge\n" : ""}security_sensitive: false`,
+      )}`,
+    );
+    const result = resultFile(clusterId);
+    result.actions = [{ action: "fix_needed", status: "planned", target: "#1" }];
+    result.fix_artifact.repair_strategy = repairStrategy;
+    result.fix_artifact.source_prs = ["https://github.com/openclaw/openclaw/pull/1"];
+    fs.writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`);
+    writeLiveTargetPolicyGhStub({ binDir: fixture.binDir, ghLog, labels: [label] });
+
+    const child = spawnSync(
+      process.execPath,
+      [
+        "scripts/execute-fix-artifact.mjs",
+        fixture.jobPath,
+        resultPath,
+        "--target-dir",
+        fixture.targetDir,
+        "--work-dir",
+        fixture.workDir,
+        "--report",
+        reportPath,
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+          CLOWNFISH_ALLOWED_OWNER: "openclaw",
+          CLOWNFISH_ALLOW_EXECUTE: "1",
+          CLOWNFISH_ALLOW_FIX_PR: "1",
+        },
+      },
+    );
+
+    assert.equal(child.status, 0, child.stderr || child.stdout);
+    assert.deepEqual(fs.readFileSync(ghLog, "utf8").trim().split("\n"), ["api repos/openclaw/openclaw/pulls/1"]);
+
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    assert.equal(report.status, "blocked");
+    assert.equal(report.no_target_mutations, true);
+    assert.equal(report.actions[0].code, "live_target_policy_block");
+    assert.match(report.reason, new RegExp(expectedSignal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    if (automerge) {
+      assert.deepEqual(report.actions.at(-1), {
+        action: "automerge_repair_outcome_comment",
+        target: "#1",
+        status: "skipped",
+        reason: "live target policy blocks all target mutations",
+      });
+    }
+  }
+});
+
 test("execute-fix-artifact ignores security-routed lineage that is not a mutable repair source", () => {
   const fixture = makeFixture();
   const resultPath = path.join(fixture.runDir, "result.json");
@@ -1314,6 +1391,23 @@ const [command, ...args] = process.argv.slice(2);
 if (command !== "pnpm") process.exit(2);
 const child = spawnSync("pnpm", args, { stdio: "inherit" });
 process.exit(child.status ?? 1);
+`,
+  );
+}
+
+function writeLiveTargetPolicyGhStub({ binDir, ghLog, labels }) {
+  writeExecutable(
+    path.join(binDir, "gh"),
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(ghLog)}, args.join(" ") + "\\n");
+if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/pulls/1") {
+  console.log(JSON.stringify({ labels: ${JSON.stringify(labels)}.map((name) => ({ name })) }));
+  process.exit(0);
+}
+console.error("unexpected gh call: " + args.join(" "));
+process.exit(2);
 `,
   );
 }


### PR DESCRIPTION
Rehydrates autonomous repair source PRs before checkout or GitHub mutation. Blocks live merge-risk, deterministic security, and ClawSweeper automerge labels; policy-blocked automerge jobs also skip the outcome comment.

Covers contributor and replacement repair paths with behavioral no-mutation tests.