### PR TITLE
chore: add live PR inventory wave

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T103126-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T103126-001.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T103126-001
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#70471"
+  - "#73199"
+  - "#88142"
+  - "#88793"
+  - "#89159"
+cluster_refs:
+  - "#70471"
+  - "#73199"
+  - "#88142"
+  - "#88793"
+  - "#89159"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T10:31:26.439Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 1
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #70471 Feishu: harden comment reply delivery and bot identity refresh
+
+- bucket: needs_proof
+- author: wittam-01
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: XL, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T16:34:54Z
+- live url: https://github.com/openclaw/openclaw/pull/70471
+
+### #73199 Add hook capability smoke gate
+
+- bucket: needs_proof
+- author: martins-oss
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: M, proof: sufficient, P3, rating: gold shrimp, merge-risk: automation, status: waiting on author
+- live updated: 2026-06-20T16:35:25Z
+- live url: https://github.com/openclaw/openclaw/pull/73199
+
+### #88142 perf(agents): skip tool prep for toolless models
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: no
+- assignees: vincentkoc
+- labels: agents, maintainer, size: XS, P3, rating: gold shrimp, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T16:38:16Z
+- live url: https://github.com/openclaw/openclaw/pull/88142
+
+### #88793 docs: document cli command path helpers
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: cli, maintainer, size: XL, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T16:38:24Z
+- live url: https://github.com/openclaw/openclaw/pull/88793
+
+### #89159 fix(plugin-sdk): validate tool plugin names
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T16:38:42Z
+- live url: https://github.com/openclaw/openclaw/pull/89159

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T103126-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T103126-002.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T103126-002
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#89518"
+  - "#89571"
+  - "#89940"
+  - "#89988"
+  - "#89991"
+cluster_refs:
+  - "#89518"
+  - "#89571"
+  - "#89940"
+  - "#89988"
+  - "#89991"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T10:31:26.441Z; bucket=maintainer_owned; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 2
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #89518 refactor: migrate plugin transcript mirrors
+
+- bucket: maintainer_owned
+- author: jalehman
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: docs, maintainer, size: L, extensions: codex, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof, extensions: copilot
+- live updated: 2026-06-20T16:39:02Z
+- live url: https://github.com/openclaw/openclaw/pull/89518
+
+### #89571 fix(provider): harden provider tool schema hooks
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: M, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T16:39:10Z
+- live url: https://github.com/openclaw/openclaw/pull/89571
+
+### #89940 fix(models): guard manifest model id metadata
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: silver shellfish, status: waiting on author, merge-risk: other
+- live updated: 2026-06-20T16:39:28Z
+- live url: https://github.com/openclaw/openclaw/pull/89940
+
+### #89988 fix(gateway): isolate control UI descriptor rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: gateway, maintainer, size: S, P2, rating: gold shrimp, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T16:39:40Z
+- live url: https://github.com/openclaw/openclaw/pull/89988
+
+### #89991 fix(gateway): isolate method list rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: gateway, maintainer, size: S, P2, rating: gold shrimp, status: waiting on author, merge-risk: other
+- live updated: 2026-06-20T16:39:44Z
+- live url: https://github.com/openclaw/openclaw/pull/89991

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T103126-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T103126-003.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T103126-003
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#90064"
+  - "#90831"
+  - "#91273"
+  - "#91276"
+  - "#91280"
+cluster_refs:
+  - "#90064"
+  - "#90831"
+  - "#91273"
+  - "#91276"
+  - "#91280"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T10:31:26.441Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 3
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #90064 fix(plugins): isolate unreadable tool registrations
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T16:39:56Z
+- live url: https://github.com/openclaw/openclaw/pull/90064
+
+### #90831 fix(control-ui): add tooltips for Reasoning and Thinking dropdowns (#90445)
+
+- bucket: needs_proof
+- author: lonexreb
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: M, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T16:40:50Z
+- live url: https://github.com/openclaw/openclaw/pull/90831
+
+### #91273 fix(windows): remove findstr from scheduled-task restart probe (Fixes #84600)
+
+- bucket: needs_proof
+- author: deepujain
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P2, rating: silver shellfish, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T16:41:11Z
+- live url: https://github.com/openclaw/openclaw/pull/91273
+
+### #91276 fix(tui): include pairing approval command in recovery hint (Fixes #67618)
+
+- bucket: needs_proof
+- author: deepujain
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T16:41:19Z
+- live url: https://github.com/openclaw/openclaw/pull/91276
+
+### #91280 fix(cli): add exec approval recovery guidance (Fixes #53250)
+
+- bucket: needs_proof
+- author: deepujain
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T16:41:26Z
+- live url: https://github.com/openclaw/openclaw/pull/91280

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T103126-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T103126-004.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T103126-004
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#91399"
+  - "#91444"
+  - "#91446"
+  - "#91477"
+  - "#91493"
+cluster_refs:
+  - "#91399"
+  - "#91444"
+  - "#91446"
+  - "#91477"
+  - "#91493"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T10:31:26.441Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 4
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #91399 fix(cron): keep no-channel implicit cron runs successful instead of failing delivery (#56078)
+
+- bucket: needs_proof
+- author: MoerAI
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T16:42:38Z
+- live url: https://github.com/openclaw/openclaw/pull/91399
+
+### #91444 fix(google): register 'google' alias for memory embedding provider
+
+- bucket: needs_proof
+- author: dwc1997
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, extensions: google, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-20T16:43:01Z
+- live url: https://github.com/openclaw/openclaw/pull/91444
+
+### #91446 fix(agents): expose sessions_spawn in TUI when subagents.allowAgents is configured
+
+- bucket: needs_proof
+- author: dwc1997
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T16:43:09Z
+- live url: https://github.com/openclaw/openclaw/pull/91446
+
+### #91477 feat(plugin-sdk): add optional CliBackendPlugin.estimateUsage hook for text-output backends
+
+- bucket: draft
+- author: Kirchlive
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: agents, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T16:43:54Z
+- live url: https://github.com/openclaw/openclaw/pull/91477
+
+### #91493 Add fail-on-tool-failure contract for isolated cron agent turns
+
+- bucket: needs_proof
+- author: cristbc
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, gateway, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T16:44:21Z
+- live url: https://github.com/openclaw/openclaw/pull/91493

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T103126-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T103126-005.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T103126-005
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#91511"
+  - "#91519"
+  - "#91544"
+  - "#91553"
+  - "#91570"
+cluster_refs:
+  - "#91511"
+  - "#91519"
+  - "#91544"
+  - "#91553"
+  - "#91570"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T10:31:26.441Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 5
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #91511 fix(ui): keep mobile composer above keyboard
+
+- bucket: needs_proof
+- author: stackingrockss
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, P2, rating: silver shellfish, status: needs proof, merge-risk: other
+- live updated: 2026-06-20T16:44:43Z
+- live url: https://github.com/openclaw/openclaw/pull/91511
+
+### #91519 feat(qa-lab): add Codex Slack approval scenarios
+
+- bucket: maintainer_owned
+- author: kevinslin
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: docs, maintainer, size: L, extensions: qa-lab, P2, rating: unranked krab, merge-risk: automation, status: needs proof
+- live updated: 2026-06-20T16:44:50Z
+- live url: https://github.com/openclaw/openclaw/pull/91519
+
+### #91544 [codex] fix Claude AskUserQuestion bridge
+
+- bucket: needs_proof
+- author: jsi-tross
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: L, proof: supplied, P1, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T16:45:10Z
+- live url: https://github.com/openclaw/openclaw/pull/91544
+
+### #91553 fix(tailscale): retry status json after serve startup
+
+- bucket: needs_proof
+- author: TUARAN
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T16:45:21Z
+- live url: https://github.com/openclaw/openclaw/pull/91553
+
+### #91570 fix(e2e): tighten installer and plugin QA assertions
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: scripts, docker, maintainer, size: XL, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T16:45:46Z
+- live url: https://github.com/openclaw/openclaw/pull/91570

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T103126-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T103126-006.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T103126-006
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#91603"
+  - "#91606"
+  - "#91610"
+  - "#91668"
+  - "#91673"
+cluster_refs:
+  - "#91603"
+  - "#91606"
+  - "#91610"
+  - "#91668"
+  - "#91673"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T10:31:26.441Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 6
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #91603 fix(acp): preserve structured error kinds
+
+- bucket: needs_proof
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T16:46:07Z
+- live url: https://github.com/openclaw/openclaw/pull/91603
+
+### #91606 fix(ui): prevent false busy state in Control UI webchat
+
+- bucket: needs_proof
+- author: bladin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T16:46:15Z
+- live url: https://github.com/openclaw/openclaw/pull/91606
+
+### #91610 ci(windows): add native PowerShell smoke coverage for contributor commands
+
+- bucket: needs_proof
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: automation, status: needs proof
+- live updated: 2026-06-20T16:46:21Z
+- live url: https://github.com/openclaw/openclaw/pull/91610
+
+### #91668 fix(agents): skip stale orphaned subagent sessions during restart recovery
+
+- bucket: needs_proof
+- author: chengzhichao-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: S, proof: supplied, P2, rating: silver shellfish, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T16:47:28Z
+- live url: https://github.com/openclaw/openclaw/pull/91668
+
+### #91673 fix(qqbot): read group toggle state from current config
+
+- bucket: maintainer_owned
+- author: sliverp
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: maintainer, size: M, channel: qqbot, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T16:47:34Z
+- live url: https://github.com/openclaw/openclaw/pull/91673


### PR DESCRIPTION
## Summary
- add six plan-only inventory shards for 30 currently open OpenClaw PRs
- preserve the existing no-mutation triage policy
- use `ubuntu-latest` for this planning wave while Blacksmith is unavailable

## Validation
- `npm run validate` (`6,324` jobs)