### PR TITLE
fix(apply): block high-risk close targets

### DIFF
--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -329,6 +329,15 @@ function applyCloseAction({
       live_state: live.state,
     };
   }
+  const blockedLabel = findHighRiskMutationLabel(live.labels);
+  if (blockedLabel) {
+    return {
+      ...base,
+      status: "blocked",
+      reason: `target has blocked live label: ${blockedLabel}`,
+      live_state: live.state,
+    };
+  }
   if (classification === "low_signal") {
     const lowSignalBlock = validateLowSignalLiveState(result.repo, target, live, kind);
     if (lowSignalBlock) {
@@ -570,6 +579,12 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
     merge_method: "squash",
     expected_head_sha: expectedHeadSha,
   };
+}
+
+function findHighRiskMutationLabel(labels) {
+  return (labels ?? [])
+    .map((label) => String(label?.name ?? label).trim())
+    .find((label) => /^merge-risk:/i.test(label) || label.toLowerCase() === "clawsweeper:automerge");
 }
 
 function validateClosePolicy({ job, actionName }) {

--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -219,6 +219,8 @@ function reviewResult(resultPath) {
       closeActions.push(action);
       if (!item) failures.push(`${target} close action missing preflight item`);
       if (item && item.state !== "open") failures.push(`${target} close action targets ${item.state} item`);
+      const blockedLabel = findHighRiskMutationLabel(item?.labels);
+      if (blockedLabel) failures.push(`${target} close action targets high-risk label: ${blockedLabel}`);
       if (action.status !== "planned" && !isFixFirstBlockedCloseAction(action, hasFixPath)) {
         failures.push(`${target} close action status must be planned or fix-first blocked`);
       }
@@ -687,14 +689,14 @@ function validateExecutableFixTargetLabels({ fixActions, fixArtifact, itemByRef,
 
   for (const ref of refs) {
     const item = itemByRef.get(ref);
-    const blockedLabel = findExecutableFixBlockedLabel(item?.labels);
+    const blockedLabel = findHighRiskMutationLabel(item?.labels);
     if (blockedLabel) {
       failures.push(`${ref} executable repair target has blocked label: ${blockedLabel}`);
     }
   }
 }
 
-function findExecutableFixBlockedLabel(labels) {
+function findHighRiskMutationLabel(labels) {
   return (labels ?? []).map(String).find((label) => /^merge-risk:/i.test(label) || label.toLowerCase() === "clawsweeper:automerge");
 }
 

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -198,6 +198,46 @@ test("apply-result blocks MEMBER-owned close targets before close-comment handli
   assert.equal(ghCalls.some((args) => args[1].includes("/comments")), false);
 });
 
+test("apply-result blocks high-risk close targets before comment or close mutation", () => {
+  for (const label of ["merge-risk: availability", "clawsweeper:automerge"]) {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+    const binDir = path.join(tmp, "bin");
+    const callLogPath = path.join(tmp, "gh-calls.jsonl");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(callLogPath, "");
+    writeGhStub(binDir, { labels: [label] });
+
+    const jobPath = path.join(tmp, "job.md");
+    const resultPath = path.join(tmp, "result.json");
+    const reportPath = path.join(tmp, "apply-report.json");
+    fs.writeFileSync(jobPath, jobMarkdown({ allowUnmergedFixClose: true }));
+    fs.writeFileSync(resultPath, `${JSON.stringify(resultJson(), null, 2)}\n`);
+
+    const result = apply(jobPath, resultPath, reportPath, binDir, { dryRun: false, callLogPath });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "blocked");
+    assert.equal(report.actions[0].reason, `target has blocked live label: ${label}`);
+    const ghCalls = fs
+      .readFileSync(callLogPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    assert.equal(
+      ghCalls.some((args) => args[1].includes("/comments") && args.includes("POST")),
+      false,
+      JSON.stringify(ghCalls),
+    );
+    assert.equal(
+      ghCalls.some((args) => args[0] === "pr" && args[1] === "close"),
+      false,
+      JSON.stringify(ghCalls),
+    );
+  }
+});
+
 test("apply-result retains prior reports as apply attempts", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");
@@ -362,7 +402,7 @@ function apply(jobPath, resultPath, reportPath, binDir, { dryRun = true, callLog
 
 function writeGhStub(
   binDir,
-  { issueState = "open", includeExistingMarker = false, authorAssociation = "NONE", ansi = false } = {},
+  { issueState = "open", includeExistingMarker = false, authorAssociation = "NONE", ansi = false, labels = [] } = {},
 ) {
   const ghPath = path.join(binDir, "gh");
   const ansiPrefix = ansi ? "\u001b[1;32m" : "";
@@ -385,7 +425,7 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
     state: ${JSON.stringify(issueState)},
     title: "streaming fix",
     updated_at: ${JSON.stringify(issueState === "open" ? "2026-06-11T05:07:30Z" : "2026-06-11T12:38:26Z")},
-    labels: [],
+    labels: ${JSON.stringify(labels)},
     author_association: ${JSON.stringify(authorAssociation)},
     pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/60063" }
   });

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -1074,6 +1074,59 @@ test("review-results rejects executable repair paths bound to risk-labeled prefl
   }
 });
 
+test("review-results rejects close actions targeting risk-labeled preflight PRs", () => {
+  for (const label of ["merge-risk: availability", "clawsweeper:automerge"]) {
+    const dir = makeResultDir(
+      {
+        mode: "autonomous",
+        actions: [
+          {
+            target: "#91286",
+            action: "close_superseded",
+            status: "planned",
+            idempotency_key: "cluster-test:close-superseded:91286:risk-label",
+            classification: "superseded",
+            target_kind: "pull_request",
+            target_updated_at: "2026-06-15T10:00:00Z",
+            canonical: "#91287",
+            candidate_fix: "#91287",
+            comment: "Thanks @contributor; the canonical path preserves contributor credit.",
+            evidence: ["#91287 is the hydrated canonical path."],
+            reason: "The contributor PR is superseded by the canonical path.",
+          },
+        ],
+      },
+      {
+        plan: {
+          items: [
+            {
+              ref: "#91286",
+              kind: "pull_request",
+              state: "open",
+              labels: [label],
+              updated_at: "2026-06-15T10:00:00Z",
+              security_sensitive: false,
+            },
+            {
+              ref: "#91287",
+              kind: "pull_request",
+              state: "open",
+              labels: [],
+              updated_at: "2026-06-15T10:00:01Z",
+              security_sensitive: false,
+            },
+          ],
+        },
+      },
+    );
+
+    const result = review(dir);
+
+    assert.notEqual(result.status, 0, result.stdout || result.stderr);
+    assert.match(result.stdout, new RegExp(`#91286 close action targets high-risk label: ${label}`));
+  }
+});
+
 test("review-results allows unavailable non-mutating plan classifications", () => {
   const dir = makeResultDir(
     {


### PR DESCRIPTION
## Summary
- reject planned close actions that target hydrated `merge-risk:*` or `clawsweeper:automerge` PRs
- re-check those labels immediately before an applicator comment or close mutation
- retain normal plan-only `keep_*` classification

## Validation
- `npm test` (`234/234`)
- `npm run validate` (`6,324` jobs)
- reviewed batch 27901628359: #91444 and #91446 are now rejected