### PR TITLE
chore: add next live PR inventory wave

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T105424-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T105424-001.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T105424-001
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#91680"
+  - "#91698"
+  - "#91721"
+  - "#91724"
+  - "#91770"
+cluster_refs:
+  - "#91680"
+  - "#91698"
+  - "#91721"
+  - "#91724"
+  - "#91770"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T10:54:24.149Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 1
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #91680 fix(ui): keep composer on Send when run-status toast expires (#88033)
+
+- bucket: needs_proof
+- author: tiffanychum
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T16:47:43Z
+- live url: https://github.com/openclaw/openclaw/pull/91680
+
+### #91698 fix(feishu): accumulate streamed final delta chunks (#91562)
+
+- bucket: needs_proof
+- author: draix
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T16:47:50Z
+- live url: https://github.com/openclaw/openclaw/pull/91698
+
+### #91721 fix(logging): prune non-idle stale diagnostic session states
+
+- bucket: needs_proof
+- author: chengzhichao-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T16:48:11Z
+- live url: https://github.com/openclaw/openclaw/pull/91721
+
+### #91724 fix(agents): infer runtime provider from qualified model ids
+
+- bucket: maintainer_owned
+- author: yu-xin-c
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: agents, size: S, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T16:48:16Z
+- live url: https://github.com/openclaw/openclaw/pull/91724
+
+### #91770 fix(memory): abort search embeddings on tool timeout
+
+- bucket: maintainer_owned
+- author: ai-hpc
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: M, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: auth-provider, status: waiting on author
+- live updated: 2026-06-20T16:48:27Z
+- live url: https://github.com/openclaw/openclaw/pull/91770

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T105424-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T105424-002.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T105424-002
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#91877"
+  - "#91878"
+  - "#91906"
+  - "#92774"
+  - "#93640"
+cluster_refs:
+  - "#91877"
+  - "#91878"
+  - "#91906"
+  - "#92774"
+  - "#93640"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T10:54:24.150Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 2
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #91877 fix(discord): prime voice receive with op-5 Speaking burst on join
+
+- bucket: needs_proof
+- author: gabrielexito-stack
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: M, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T16:49:21Z
+- live url: https://github.com/openclaw/openclaw/pull/91877
+
+### #91878 fix(codex): validate maintained app-server types
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: no
+- assignees: kevinslin
+- labels: scripts, maintainer, size: M, extensions: codex, P3, rating: platinum hermit, merge-risk: automation, status: ready for maintainer look
+- live updated: 2026-06-20T16:49:25Z
+- live url: https://github.com/openclaw/openclaw/pull/91878
+
+### #91906 perf: skip subagent live stream parsing
+
+- bucket: maintainer_owned
+- author: lanzhi-lee
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: mock-only-proof, P2, rating: silver shellfish, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T16:49:43Z
+- live url: https://github.com/openclaw/openclaw/pull/91906
+
+### #92774 fix: drop retained session fence text after prompt lock reacquire
+
+- bucket: needs_proof
+- author: markus-lassfolk
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T16:50:27Z
+- live url: https://github.com/openclaw/openclaw/pull/92774
+
+### #93640 fix: add stream stall guard for lost stream termination signal (opencode-go)
+
+- bucket: maintainer_owned
+- author: blindjoy23
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: vincentkoc
+- labels: agents, size: S, proof: supplied, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T16:51:02Z
+- live url: https://github.com/openclaw/openclaw/pull/93640

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T105424-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T105424-003.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T105424-003
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#93826"
+  - "#63347"
+  - "#69059"
+  - "#69355"
+  - "#70002"
+cluster_refs:
+  - "#93826"
+  - "#63347"
+  - "#69059"
+  - "#69355"
+  - "#70002"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T10:54:24.151Z; bucket=needs_proof; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 3
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #93826 fix(agents): skip A2A announce flow for isolated cron sessions_send
+
+- bucket: needs_proof
+- author: LiLan0125
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, P2, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T16:51:20Z
+- live url: https://github.com/openclaw/openclaw/pull/93826
+
+### #63347 feat(msteams): support webhook host binding
+
+- bucket: needs_proof
+- author: sharkqwy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: msteams, size: S, triage: needs-real-behavior-proof, P2, rating: silver shellfish, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T17:15:51Z
+- live url: https://github.com/openclaw/openclaw/pull/63347
+
+### #69059 fix: retry sqlite-vec load without .dll suffix on Windows
+
+- bucket: needs_proof
+- author: JustInCache
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P2, rating: unranked krab, merge-risk: compatibility, status: waiting on author
+- live updated: 2026-06-20T17:16:47Z
+- live url: https://github.com/openclaw/openclaw/pull/69059
+
+### #69355 feat(doctor): detect local rebuild vs pristine npm release
+
+- bucket: needs_proof
+- author: mikaeldiakhate-cell
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, commands, size: L, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T17:16:59Z
+- live url: https://github.com/openclaw/openclaw/pull/69355
+
+### #70002 ci: skip docs sync & translate-trigger workflows in forks
+
+- bucket: needs_proof
+- author: xudaiyanzi
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: risky-infra, triage: needs-real-behavior-proof, proof: sufficient, P2, rating: platinum hermit, merge-risk: automation, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-20T17:17:15Z
+- live url: https://github.com/openclaw/openclaw/pull/70002

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T105424-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T105424-004.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T105424-004
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#70056"
+  - "#71563"
+  - "#72055"
+  - "#72254"
+  - "#72771"
+cluster_refs:
+  - "#70056"
+  - "#71563"
+  - "#72055"
+  - "#72254"
+  - "#72771"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T10:54:24.151Z; bucket=needs_proof; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 4
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #70056 fix(gateway): clean up store and set running=false on stop timeout
+
+- bucket: needs_proof
+- author: garnetlyx
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, triage: refactor-only, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T17:17:25Z
+- live url: https://github.com/openclaw/openclaw/pull/70056
+
+### #71563 fix(telegram): route /new, /reset to control lane to bypass queue
+
+- bucket: needs_proof
+- author: kiranvk-2011
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XS, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T17:17:36Z
+- live url: https://github.com/openclaw/openclaw/pull/71563
+
+### #72055 feat(bonjour): add instanceName plugin config to override mDNS service name [AI-assisted]
+
+- bucket: needs_proof
+- author: jeffjhunter
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: S, plugin: bonjour, triage: needs-real-behavior-proof, P2, rating: silver shellfish, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T17:17:51Z
+- live url: https://github.com/openclaw/openclaw/pull/72055
+
+### #72254 fix(skills): clean up partially-copied skill dirs after sync failure
+
+- bucket: needs_proof
+- author: fancymatt
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, stale, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T17:18:02Z
+- live url: https://github.com/openclaw/openclaw/pull/72254
+
+### #72771 feat(gateway): emit agent.run.status events for run observability
+
+- bucket: needs_proof
+- author: chinadbo
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, agents, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T17:18:40Z
+- live url: https://github.com/openclaw/openclaw/pull/72771

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T105424-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T105424-005.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T105424-005
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#73122"
+  - "#95380"
+  - "#73746"
+  - "#76975"
+  - "#77232"
+cluster_refs:
+  - "#73122"
+  - "#95380"
+  - "#73746"
+  - "#76975"
+  - "#77232"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T10:54:24.151Z; bucket=needs_proof; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 5
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #73122 test claude-cli backend registration guardrails
+
+- bucket: needs_proof
+- author: szupzj18
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: anthropic, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T17:19:03Z
+- live url: https://github.com/openclaw/openclaw/pull/73122
+
+### #95380 refactor(dispatch): gate reasoning delivery on a channel capability (follow-up to #95051)
+
+- bucket: needs_proof
+- author: Marvinthebored
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: S, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T17:19:17Z
+- live url: https://github.com/openclaw/openclaw/pull/95380
+
+### #73746 feat(tasks): improve task state transitions and lifecycle formatting
+
+- bucket: needs_proof
+- author: neofdezf-cloud
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XL, triage: refactor-only, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T17:19:46Z
+- live url: https://github.com/openclaw/openclaw/pull/73746
+
+### #76975 fix(telegram): allow callback acknowledgement text
+
+- bucket: needs_proof
+- author: hyspacex
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, size: S, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T17:21:12Z
+- live url: https://github.com/openclaw/openclaw/pull/76975
+
+### #77232 docs(agent-loop): document idle-timeout cost-runaway circuit breaker
+
+- bucket: needs_proof
+- author: adhirajhangal
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: needs-real-behavior-proof, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T17:21:47Z
+- live url: https://github.com/openclaw/openclaw/pull/77232

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T105424-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T105424-006.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T105424-006
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#77415"
+  - "#77442"
+  - "#80955"
+  - "#85358"
+  - "#86670"
+cluster_refs:
+  - "#77415"
+  - "#77442"
+  - "#80955"
+  - "#85358"
+  - "#86670"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T10:54:24.151Z; bucket=needs_proof; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 6
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #77415 fix(subagents): report startup and completion lifecycle edges
+
+- bucket: needs_proof
+- author: neilofneils404
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, agents, size: L, proof: supplied, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T17:21:53Z
+- live url: https://github.com/openclaw/openclaw/pull/77415
+
+### #77442 fix(session): persist delivery context for inbound non-direct sessions
+
+- bucket: needs_proof
+- author: Beandon13
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T17:22:04Z
+- live url: https://github.com/openclaw/openclaw/pull/77442
+
+### #80955 ui(i18n): localize chat page slash commands and composer for zh-CN
+
+- bucket: needs_proof
+- author: git-jxj
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XL, proof: supplied, P2, rating: unranked krab, status: needs proof, proof: screenshot, merge-risk: other
+- live updated: 2026-06-20T17:24:27Z
+- live url: https://github.com/openclaw/openclaw/pull/80955
+
+### #85358 fix(#85334): prevent bundled plugin load paths from being injected into config
+
+- bucket: needs_proof
+- author: samson1357924
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: supplied, P2, rating: silver shellfish, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-20T17:25:27Z
+- live url: https://github.com/openclaw/openclaw/pull/85358
+
+### #86670 Add Eden AI provider plugin
+
+- bucket: needs_proof
+- author: DinaAlSb
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: L, proof: supplied, proof: sufficient, dependencies-changed, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: auth-provider, status: waiting on author, feature: showcase
+- live updated: 2026-06-20T17:25:31Z
+- live url: https://github.com/openclaw/openclaw/pull/86670


### PR DESCRIPTION
## Summary
- add six plan-only inventory shards for 30 more open OpenClaw PRs
- retain the no-mutation triage policy
- continue using `ubuntu-latest` while Blacksmith is unavailable

## Validation
- `npm run validate` (`6,330` jobs)