### PR TITLE
fix: record terminal review rejections

### DIFF
--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -110,8 +110,13 @@ jobs:
               --review-report artifacts/review-results.json \
               --runs-json artifacts/runs.json
             if node -e 'const fs=require("node:fs"); const rows=JSON.parse(fs.readFileSync("artifacts/runs.json","utf8")); process.exit(rows.length === 0 ? 0 : 1)'; then
-              echo "has_results=false" >> "$GITHUB_OUTPUT"
-              echo "No review-passing cluster results to publish"
+              if node -e 'const fs=require("node:fs"); const rows=JSON.parse(fs.readFileSync("artifacts/review-terminal.json","utf8")).rejections; process.exit(Array.isArray(rows) && rows.length > 0 ? 1 : 0)'; then
+                echo "has_results=false" >> "$GITHUB_OUTPUT"
+                echo "No review-passing cluster results or terminal rejections to publish"
+                exit 0
+              fi
+              echo "has_results=true" >> "$GITHUB_OUTPUT"
+              echo "Publishing terminal review rejections without normal result artifacts"
               exit 0
             fi
             set +e
@@ -124,9 +129,11 @@ jobs:
             fi
           fi
           if node -e 'const fs=require("node:fs"); const rows=JSON.parse(fs.readFileSync("artifacts/runs.json","utf8")); process.exit(rows.length === 0 ? 0 : 1)'; then
-            echo "has_results=false" >> "$GITHUB_OUTPUT"
-            echo "No review-passing cluster results to publish"
-            exit 0
+            if node -e 'const fs=require("node:fs"); const rows=fs.existsSync("artifacts/review-terminal.json") ? JSON.parse(fs.readFileSync("artifacts/review-terminal.json","utf8")).rejections : []; process.exit(Array.isArray(rows) && rows.length > 0 ? 1 : 0)'; then
+              echo "has_results=false" >> "$GITHUB_OUTPUT"
+              echo "No review-passing cluster results or terminal rejections to publish"
+              exit 0
+            fi
           fi
           echo "has_results=true" >> "$GITHUB_OUTPUT"
 
@@ -142,7 +149,7 @@ jobs:
 
           git fetch origin main
           git checkout -B main origin/main
-          publish_args=(artifacts --runs-json artifacts/runs.json)
+          publish_args=(artifacts --runs-json artifacts/runs.json --review-terminal artifacts/review-terminal.json)
           if [ "$PUBLISH_AGGREGATE" != "true" ]; then
             publish_args+=(--skip-aggregate)
           fi

--- a/scripts/backfill-cluster-results.mjs
+++ b/scripts/backfill-cluster-results.mjs
@@ -313,13 +313,45 @@ function selectedRunAttempt(run) {
 
 function readPublishedRunIds() {
   const dir = path.join(repoRoot(), "results", "runs");
-  if (!fs.existsSync(dir)) return new Set();
-  return new Set(
-    fs
-      .readdirSync(dir)
-      .filter((name) => name.endsWith(".json"))
-      .map((name) => path.basename(name, ".json")),
-  );
+  const resultRuns = !fs.existsSync(dir)
+    ? []
+    : fs
+        .readdirSync(dir)
+        .filter((name) => name.endsWith(".json"))
+        .map((name) => path.basename(name, ".json"));
+  return new Set([...resultRuns, ...readTerminalRejectionIds()]);
+}
+
+function readTerminalRejectionIds() {
+  const directory = path.join(repoRoot(), "results", "review-rejections");
+  if (!fs.existsSync(directory)) return new Set();
+  const ids = new Set();
+  for (const name of fs.readdirSync(directory)) {
+    if (!name.endsWith(".json")) continue;
+    try {
+      const runId = validTerminalRejectionRunId(JSON.parse(fs.readFileSync(path.join(directory, name), "utf8")));
+      if (runId === path.basename(name, ".json")) ids.add(runId);
+    } catch {
+      continue;
+    }
+  }
+  return ids;
+}
+
+function validTerminalRejectionRunId(value) {
+  const runId = String(value?.run_id ?? "");
+  const workflowRunId = String(value?.workflow_run_id ?? "");
+  const runAttempt = String(value?.run_attempt ?? "");
+  const matrixIndex = value?.matrix_index === null ? null : String(value?.matrix_index ?? "");
+  const targets = Array.isArray(value?.targets) ? value.targets.map(String) : [];
+  if (!/^\d+(?:-\d+-\d+)?$/.test(runId)) return null;
+  if (!/^\d+$/.test(workflowRunId) || !/^\d+$/.test(runAttempt)) return null;
+  if (matrixIndex !== null && !/^\d+$/.test(matrixIndex)) return null;
+  if (runId !== workflowRunId && runId !== `${workflowRunId}-${runAttempt}-${matrixIndex}`) return null;
+  if (value?.code !== "high_risk_close_target" || targets.length === 0 || !targets.every((target) => /^#\d+$/.test(target))) {
+    return null;
+  }
+  return runId;
 }
 
 function summarizeRun(run) {

--- a/scripts/filter-reviewed-artifacts.mjs
+++ b/scripts/filter-reviewed-artifacts.mjs
@@ -2,12 +2,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import { parseArgs, repoRoot } from "./lib.mjs";
+import { inferResultRunIdentity } from "./result-run-identity.mjs";
 
 const args = parseArgs(process.argv.slice(2));
 const artifactDir = path.resolve(String(args._[0] ?? "artifacts"));
 const reviewReportPath = path.resolve(String(args["review-report"] ?? path.join(artifactDir, "review-results.json")));
 const runsJsonPath = path.resolve(String(args["runs-json"] ?? path.join(artifactDir, "runs.json")));
 const quarantinePath = path.resolve(String(args.quarantine ?? path.join(artifactDir, "review-quarantine.json")));
+const terminalPath = path.resolve(String(args.terminal ?? path.join(artifactDir, "review-terminal.json")));
 
 if (!fs.existsSync(reviewReportPath)) throw new Error(`review report not found: ${reviewReportPath}`);
 if (!fs.existsSync(runsJsonPath)) throw new Error(`runs json not found: ${runsJsonPath}`);
@@ -17,11 +19,14 @@ const reports = Array.isArray(reviewReport.reports) ? reviewReport.reports : [];
 const failedReports = reports.filter((report) => report.status === "failed");
 const quarantined = [];
 const failedRunIds = new Set();
+const terminalRejections = [];
 
 for (const report of failedReports) {
-  const resultPath = resolveReportPath(report.result);
+  const resultPath = resolveReportPath(report.result ?? report.input);
   const runId = inferRunId(resultPath);
   if (runId) failedRunIds.add(runId);
+  const terminalRejection = terminalRejectionFor(report, resultPath);
+  if (terminalRejection) terminalRejections.push(terminalRejection);
 
   const quarantinedPath = `${resultPath}.failed`;
   if (fs.existsSync(resultPath)) {
@@ -62,6 +67,21 @@ fs.writeFileSync(
   )}\n`,
   "utf8",
 );
+fs.writeFileSync(
+  terminalPath,
+  `${JSON.stringify(
+    {
+      version: 1,
+      generated_at: new Date().toISOString(),
+      artifact_dir: artifactDir,
+      review_report: reviewReportPath,
+      rejections: uniqueTerminalRejections(terminalRejections),
+    },
+    null,
+    2,
+  )}\n`,
+  "utf8",
+);
 
 console.log(
   JSON.stringify(
@@ -72,6 +92,8 @@ console.log(
       runs_before: rows.length,
       runs_after: filteredRows.length,
       quarantine: quarantinePath,
+      terminal_rejections: terminalRejections.length,
+      terminal: terminalPath,
     },
     null,
     2,
@@ -85,8 +107,7 @@ function resolveReportPath(value) {
 }
 
 function inferRunId(filePath) {
-  const match = String(filePath).match(/projectclownfish(?:-worker)?-(\d+)-\d+/);
-  return match?.[1] ?? null;
+  return inferResultRunIdentity(filePath)?.workflow_run_id ?? null;
 }
 
 function remainingResultRunIds(root) {
@@ -99,6 +120,33 @@ function remainingResultRunIds(root) {
     if (runId) ids.add(runId);
   }
   return ids;
+}
+
+function terminalRejectionFor(report, resultPath) {
+  const rejection = report?.terminal_rejection;
+  const identity = inferResultRunIdentity(resultPath);
+  if (!identity || !rejection || rejection.code !== "high_risk_close_target") return null;
+  if (!Array.isArray(rejection.targets) || rejection.targets.length === 0) return null;
+  const targets = [...new Set(rejection.targets.map(String))].sort();
+  if (!targets.every((target) => /^#\d+$/.test(target))) return null;
+  return {
+    run_id: identity.run_id,
+    workflow_run_id: identity.workflow_run_id,
+    run_attempt: identity.run_attempt,
+    matrix_index: identity.matrix_index,
+    code: rejection.code,
+    targets,
+  };
+}
+
+function uniqueTerminalRejections(rejections) {
+  return [
+    ...new Map(
+      rejections
+        .sort((left, right) => left.run_id.localeCompare(right.run_id))
+        .map((rejection) => [rejection.run_id, rejection]),
+    ).values(),
+  ];
 }
 
 function readJson(filePath) {

--- a/scripts/publish-backlog.mjs
+++ b/scripts/publish-backlog.mjs
@@ -87,24 +87,89 @@ function listWorkflowRuns() {
 }
 
 function readPublishedRunIds() {
-  const fromOrigin = execFileSync("git", ["ls-tree", "-r", "--name-only", "origin/main", "results/runs"], {
+  const fromOrigin = execFileSync(
+    "git",
+    ["ls-tree", "-r", "--name-only", "origin/main", "results/runs", "results/review-rejections"],
+    {
+      cwd: repoRoot(),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  )
+    .split("\n")
+    .filter(Boolean)
+    .filter((file) => file.startsWith("results/runs/"))
+    .map((file) => path.basename(file, ".json"));
+  const terminalRejections = readTerminalRejectionIdsFromGit("origin/main");
+  if (fromOrigin.length > 0 || terminalRejections.size > 0) return new Set([...fromOrigin, ...terminalRejections]);
+
+  const dir = path.join(repoRoot(), "results", "runs");
+  const resultRuns = !fs.existsSync(dir)
+    ? []
+    : fs
+        .readdirSync(dir)
+        .filter((name) => name.endsWith(".json"))
+        .map((name) => path.basename(name, ".json"));
+  return new Set([...resultRuns, ...readTerminalRejectionIdsFromDirectory()]);
+}
+
+function readTerminalRejectionIdsFromGit(ref) {
+  const files = execFileSync("git", ["ls-tree", "-r", "--name-only", ref, "results/review-rejections"], {
     cwd: repoRoot(),
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   })
     .split("\n")
-    .filter(Boolean)
-    .map((file) => path.basename(file, ".json"));
-  if (fromOrigin.length > 0) return new Set(fromOrigin);
+    .filter((file) => file.startsWith("results/review-rejections/") && file.endsWith(".json"));
+  const ids = new Set();
+  for (const file of files) {
+    try {
+      const rejection = JSON.parse(
+        execFileSync("git", ["show", `${ref}:${file}`], {
+          cwd: repoRoot(),
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      );
+      const runId = validTerminalRejectionRunId(rejection);
+      if (runId === path.basename(file, ".json")) ids.add(runId);
+    } catch {
+      continue;
+    }
+  }
+  return ids;
+}
 
-  const dir = path.join(repoRoot(), "results", "runs");
-  if (!fs.existsSync(dir)) return new Set();
-  return new Set(
-    fs
-      .readdirSync(dir)
-      .filter((name) => name.endsWith(".json"))
-      .map((name) => path.basename(name, ".json")),
-  );
+function readTerminalRejectionIdsFromDirectory() {
+  const directory = path.join(repoRoot(), "results", "review-rejections");
+  if (!fs.existsSync(directory)) return new Set();
+  const ids = new Set();
+  for (const name of fs.readdirSync(directory)) {
+    if (!name.endsWith(".json")) continue;
+    try {
+      const runId = validTerminalRejectionRunId(JSON.parse(fs.readFileSync(path.join(directory, name), "utf8")));
+      if (runId === path.basename(name, ".json")) ids.add(runId);
+    } catch {
+      continue;
+    }
+  }
+  return ids;
+}
+
+function validTerminalRejectionRunId(value) {
+  const runId = String(value?.run_id ?? "");
+  const workflowRunId = String(value?.workflow_run_id ?? "");
+  const runAttempt = String(value?.run_attempt ?? "");
+  const matrixIndex = value?.matrix_index === null ? null : String(value?.matrix_index ?? "");
+  const targets = Array.isArray(value?.targets) ? value.targets.map(String) : [];
+  if (!/^\d+(?:-\d+-\d+)?$/.test(runId)) return null;
+  if (!/^\d+$/.test(workflowRunId) || !/^\d+$/.test(runAttempt)) return null;
+  if (matrixIndex !== null && !/^\d+$/.test(matrixIndex)) return null;
+  if (runId !== workflowRunId && runId !== `${workflowRunId}-${runAttempt}-${matrixIndex}`) return null;
+  if (value?.code !== "high_risk_close_target" || targets.length === 0 || !targets.every((target) => /^#\d+$/.test(target))) {
+    return null;
+  }
+  return runId;
 }
 
 function isPublishedRun(run, publishedRunIds) {

--- a/scripts/publish-result.mjs
+++ b/scripts/publish-result.mjs
@@ -31,6 +31,7 @@ const metadataByRunId = readRunMetadata(args["runs-json"]);
 const skipAggregate = Boolean(args["skip-aggregate"]);
 const noRunUrl = Boolean(args["no-run-url"]);
 const published = [];
+const terminalPublished = publishTerminalRejections(args["review-terminal"]);
 
 for (const input of inputs) {
   for (const resultPath of findResultPaths(path.resolve(input))) {
@@ -44,7 +45,63 @@ if (!skipAggregate) {
   updateDashboard();
 }
 
-console.log(JSON.stringify({ published: published.length, aggregate: !skipAggregate, records: published }, null, 2));
+console.log(
+  JSON.stringify(
+    {
+      published: published.length,
+      terminal_rejections: terminalPublished.length,
+      aggregate: !skipAggregate,
+      records: published,
+      terminal_records: terminalPublished,
+    },
+    null,
+    2,
+  ),
+);
+
+function publishTerminalRejections(filePath) {
+  if (!filePath || typeof filePath !== "string" || !fs.existsSync(filePath)) return [];
+  const rows = readJson(filePath)?.rejections;
+  if (!Array.isArray(rows)) return [];
+  const published = [];
+  const outputDir = path.join(repoRoot(), "results", "review-rejections");
+  for (const row of rows) {
+    const rejection = sanitizeTerminalRejection(row);
+    if (!rejection) continue;
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(outputDir, `${rejection.run_id}.json`),
+      `${JSON.stringify({ version: 1, ...rejection, published_at: new Date().toISOString() }, null, 2)}\n`,
+      "utf8",
+    );
+    published.push(rejection);
+  }
+  return published;
+}
+
+function sanitizeTerminalRejection(value) {
+  if (!isObject(value)) return null;
+  const runId = String(value.run_id ?? "");
+  const workflowRunId = String(value.workflow_run_id ?? "");
+  const runAttempt = String(value.run_attempt ?? "");
+  const matrixIndex = value.matrix_index === null ? null : String(value.matrix_index ?? "");
+  const targets = [...new Set((Array.isArray(value.targets) ? value.targets : []).map(String))].sort();
+  if (!/^\d+(?:-\d+-\d+)?$/.test(runId)) return null;
+  if (!/^\d+$/.test(workflowRunId) || !/^\d+$/.test(runAttempt)) return null;
+  if (matrixIndex !== null && !/^\d+$/.test(matrixIndex)) return null;
+  if (runId !== workflowRunId && runId !== `${workflowRunId}-${runAttempt}-${matrixIndex}`) return null;
+  if (value.code !== "high_risk_close_target" || targets.length === 0 || !targets.every((target) => /^#\d+$/.test(target))) {
+    return null;
+  }
+  return {
+    run_id: runId,
+    workflow_run_id: workflowRunId,
+    run_attempt: runAttempt,
+    matrix_index: matrixIndex,
+    code: value.code,
+    targets,
+  };
+}
 
 function publishResult(resultPath) {
   const runDir = path.dirname(resultPath);

--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -94,6 +94,7 @@ function reviewResult(resultPath) {
   const warnings = [];
   const itemByRef = buildItemMap(plan, result.repo);
   const actionCounts = {};
+  const terminalRejectionTargets = [];
 
   if (!Array.isArray(result.actions)) failures.push("result.actions must be an array");
   if (!result.repo) failures.push("result.repo is required");
@@ -220,7 +221,10 @@ function reviewResult(resultPath) {
       if (!item) failures.push(`${target} close action missing preflight item`);
       if (item && item.state !== "open") failures.push(`${target} close action targets ${item.state} item`);
       const blockedLabel = findHighRiskMutationLabel(item?.labels);
-      if (blockedLabel) failures.push(`${target} close action targets high-risk label: ${blockedLabel}`);
+      if (blockedLabel) {
+        failures.push(`${target} close action targets high-risk label: ${blockedLabel}`);
+        terminalRejectionTargets.push(normalizeRef(target));
+      }
       if (action.status !== "planned" && !isFixFirstBlockedCloseAction(action, hasFixPath)) {
         failures.push(`${target} close action status must be planned or fix-first blocked`);
       }
@@ -334,6 +338,13 @@ function reviewResult(resultPath) {
     action_counts: actionCounts,
     failures,
     warnings,
+    terminal_rejection:
+      failures.length > 0 && failures.length === terminalRejectionTargets.length
+        ? {
+            code: "high_risk_close_target",
+            targets: [...new Set(terminalRejectionTargets)].sort(),
+          }
+        : null,
   };
 }
 

--- a/test/dispatch-jobs-publish-backlog.test.mjs
+++ b/test/dispatch-jobs-publish-backlog.test.mjs
@@ -82,6 +82,62 @@ test("publish backlog keeps a partial cluster batch missing", () => {
   assert.deepEqual(summary.missing_run_ids, ["200"]);
 });
 
+test("publish backlog accepts a terminal review rejection for a missing batch child", () => {
+  const result = runPublishBacklog({
+    workflow: "cluster-batch.yml",
+    runs: [completedRun(200, 3)],
+    artifactsByRunId: {
+      200: [
+        "projectclownfish-200-3-0",
+        "projectclownfish-200-3-1",
+        "projectclownfish-200-3-2",
+      ],
+    },
+    publishedRunIds: ["200-3-0", "200-3-2"],
+    terminalRejections: [
+      {
+        run_id: "200-3-1",
+        workflow_run_id: "200",
+        run_attempt: "3",
+        matrix_index: "1",
+        code: "high_risk_close_target",
+        targets: ["#91444"],
+      },
+    ],
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(JSON.parse(result.stdout).missing_count, 0);
+});
+
+test("publish backlog ignores malformed terminal review rejections", () => {
+  const result = runPublishBacklog({
+    workflow: "cluster-batch.yml",
+    runs: [completedRun(200, 3)],
+    artifactsByRunId: {
+      200: [
+        "projectclownfish-200-3-0",
+        "projectclownfish-200-3-1",
+        "projectclownfish-200-3-2",
+      ],
+    },
+    publishedRunIds: ["200-3-0", "200-3-2"],
+    terminalRejections: [
+      {
+        run_id: "200-3-1",
+        workflow_run_id: "200",
+        run_attempt: "3",
+        matrix_index: "1",
+        code: "high_risk_close_target",
+        targets: [],
+      },
+    ],
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(JSON.parse(result.stdout).missing_count, 1);
+});
+
 test("publish backlog keeps exact IDs for single cluster workers", () => {
   const result = runPublishBacklog({
     workflow: "cluster-worker.yml",
@@ -103,7 +159,14 @@ function makeFixture() {
   };
 }
 
-function runPublishBacklog({ workflow, runs, artifactsByRunId = {}, runAttemptsByRunId = {}, publishedRunIds }) {
+function runPublishBacklog({
+  workflow,
+  runs,
+  artifactsByRunId = {},
+  runAttemptsByRunId = {},
+  publishedRunIds,
+  terminalRejections = [],
+}) {
   const fixture = makeFixture();
   writeFakeGhx(fixture);
   writeFakeGit(fixture);
@@ -138,6 +201,7 @@ function runPublishBacklog({ workflow, runs, artifactsByRunId = {}, runAttemptsB
         FAKE_GHX_ARTIFACTS: JSON.stringify(artifactsByRunId),
         FAKE_GHX_RUN_ATTEMPTS: JSON.stringify(runAttemptsByRunId),
         FAKE_GIT_PUBLISHED_RUN_IDS: JSON.stringify(publishedRunIds),
+        FAKE_GIT_TERMINAL_REJECTIONS: JSON.stringify(terminalRejections),
       },
     },
   );
@@ -210,8 +274,27 @@ function writeFakeGit(fixture) {
 const args = process.argv.slice(2);
 if (args[0] === "ls-tree") {
   const runIds = JSON.parse(process.env.FAKE_GIT_PUBLISHED_RUN_IDS ?? "[]");
-  process.stdout.write(runIds.map((runId) => \`results/runs/\${runId}.json\`).join("\\n"));
+  const terminalRejections = JSON.parse(process.env.FAKE_GIT_TERMINAL_REJECTIONS ?? "[]");
+  const wantsRuns = args.includes("results/runs");
+  const wantsTerminal = args.includes("results/review-rejections");
+  const files = [
+    ...(wantsRuns ? runIds.map((runId) => \`results/runs/\${runId}.json\`) : []),
+    ...(wantsTerminal ? terminalRejections.map((rejection) => \`results/review-rejections/\${rejection.run_id}.json\`) : []),
+  ];
+  process.stdout.write(files.join("\\n"));
   process.exit(0);
+}
+if (args[0] === "show") {
+  const terminalRejections = JSON.parse(process.env.FAKE_GIT_TERMINAL_REJECTIONS ?? "[]");
+  const file = String(args[1] ?? "").split(":").at(-1);
+  const runId = file.split("/").at(-1).replace(/\\.json$/, "");
+  const rejection = terminalRejections.find((candidate) => candidate.run_id === runId);
+  if (rejection) {
+    process.stdout.write(JSON.stringify(rejection));
+    process.exit(0);
+  }
+  process.stderr.write("missing terminal rejection: " + file + "\\n");
+  process.exit(1);
 }
 process.stderr.write("unexpected git invocation: " + args.join(" ") + "\\n");
 process.exit(1);

--- a/test/publish-result.test.mjs
+++ b/test/publish-result.test.mjs
@@ -164,6 +164,48 @@ test("publish-result leaves reports unchanged when fix-artifact.json is absent",
   assert.doesNotMatch(fs.readFileSync(reportPath, "utf8"), /## Repair Candidate/);
 });
 
+test("publish-result records validated terminal review rejections separately from normal results", (t) => {
+  const fixture = makeFixture();
+  const runId = "27901628359-1-3";
+  const recordPath = path.join(repoRoot, "results", "review-rejections", `${runId}.json`);
+  const previousRecord = readIfExists(recordPath);
+  t.after(() => {
+    restore(recordPath, previousRecord);
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  });
+
+  const terminalPath = path.join(fixture.root, "review-terminal.json");
+  fs.writeFileSync(
+    terminalPath,
+    `${JSON.stringify(
+      {
+        rejections: [
+          {
+            run_id: runId,
+            workflow_run_id: "27901628359",
+            run_attempt: "1",
+            matrix_index: "3",
+            code: "high_risk_close_target",
+            targets: ["#91444", "#91446"],
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/publish-result.mjs", fixture.root, "--review-terminal", terminalPath, "--skip-aggregate", "--no-run-url"],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  assert.deepEqual(JSON.parse(fs.readFileSync(recordPath, "utf8")).targets, ["#91444", "#91446"]);
+  assert.match(child.stdout, /"terminal_rejections": 1/);
+});
+
 test("publish-result preserves executed apply actions across later apply attempts", (t) => {
   const fixture = makeFixture();
   const runId = `publish-result-apply-attempts-${process.pid}-${Date.now()}`;

--- a/test/publisher-artifact-recovery.test.mjs
+++ b/test/publisher-artifact-recovery.test.mjs
@@ -84,6 +84,60 @@ test("filter retains only runs with a surviving result artifact", () => {
   assert.equal(run.status, 0, run.stderr || run.stdout);
   assert.deepEqual(JSON.parse(fs.readFileSync(fixture.runsJson, "utf8")), [{ run_id: "100" }]);
   assert.equal(fs.existsSync(`${failedResult}.failed`), true);
+  assert.deepEqual(JSON.parse(fs.readFileSync(path.join(fixture.artifacts, "review-terminal.json"), "utf8")).rejections, []);
+});
+
+test("filter records a validated terminal review rejection by exact matrix child run id", () => {
+  const fixture = makeFixture();
+  const failedResult = path.join(fixture.artifacts, "projectclownfish-200-1-3", "result.json");
+  fs.mkdirSync(path.dirname(failedResult), { recursive: true });
+  fs.writeFileSync(failedResult, "{}\n");
+  fs.writeFileSync(fixture.runsJson, `${JSON.stringify([{ run_id: "200" }], null, 2)}\n`);
+  fs.writeFileSync(
+    fixture.reviewReport,
+    `${JSON.stringify(
+      {
+        reports: [
+          {
+            status: "failed",
+            result: failedResult,
+            terminal_rejection: {
+              code: "high_risk_close_target",
+              targets: ["#91444", "#91446"],
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const run = spawnSync(
+    process.execPath,
+    [
+      "scripts/filter-reviewed-artifacts.mjs",
+      fixture.artifacts,
+      "--review-report",
+      fixture.reviewReport,
+      "--runs-json",
+      fixture.runsJson,
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+
+  assert.equal(run.status, 0, run.stderr || run.stdout);
+  assert.deepEqual(JSON.parse(fs.readFileSync(fixture.runsJson, "utf8")), []);
+  assert.deepEqual(JSON.parse(fs.readFileSync(path.join(fixture.artifacts, "review-terminal.json"), "utf8")).rejections, [
+    {
+      run_id: "200-1-3",
+      workflow_run_id: "200",
+      run_attempt: "1",
+      matrix_index: "3",
+      code: "high_risk_close_target",
+      targets: ["#91444", "#91446"],
+    },
+  ]);
 });
 
 test("publisher defaults to successful runs and exits before reviewing an empty filtered set", () => {
@@ -93,8 +147,9 @@ test("publisher defaults to successful runs and exits before reviewing an empty 
   assert.match(workflow, /BACKFILL_CONCLUSION: \${{ github\.event\.inputs\.conclusion \|\| 'success' }}/);
   assert.match(
     workflow,
-    /filter-reviewed-artifacts[\s\S]*No review-passing cluster results to publish[\s\S]*review-results\.filtered\.json/,
+    /filter-reviewed-artifacts[\s\S]*No review-passing cluster results or terminal rejections to publish/,
   );
+  assert.match(workflow, /Publishing terminal review rejections without normal result artifacts/);
 });
 
 function makeFixture() {

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -1127,6 +1127,113 @@ test("review-results rejects close actions targeting risk-labeled preflight PRs"
   }
 });
 
+test("review-results marks an otherwise-valid high-risk close rejection as terminal", () => {
+  const dir = makeResultDir(
+    {
+      mode: "autonomous",
+      actions: [
+        {
+          target: "#91286",
+          action: "close_superseded",
+          status: "planned",
+          idempotency_key: "cluster-test:close-superseded:91286:terminal-rejection",
+          classification: "superseded",
+          target_kind: "pull_request",
+          target_updated_at: "2026-06-15T10:00:00Z",
+          canonical: "#91287",
+          candidate_fix: "#91287",
+          comment: "Thanks @contributor; the canonical path preserves contributor credit.",
+          evidence: ["#91287 is the hydrated canonical path."],
+          reason: "The contributor PR is superseded by the canonical path.",
+        },
+      ],
+    },
+    {
+      plan: {
+        items: [
+          {
+            ref: "#91286",
+            kind: "pull_request",
+            state: "open",
+            labels: ["merge-risk: availability"],
+            updated_at: "2026-06-15T10:00:00Z",
+            security_sensitive: false,
+          },
+          {
+            ref: "#91287",
+            kind: "pull_request",
+            state: "open",
+            labels: [],
+            updated_at: "2026-06-15T10:00:01Z",
+            security_sensitive: false,
+          },
+        ],
+      },
+    },
+  );
+
+  const result = review(dir);
+  const report = JSON.parse(result.stdout);
+
+  assert.notEqual(result.status, 0);
+  assert.deepEqual(report.reports[0].terminal_rejection, {
+    code: "high_risk_close_target",
+    targets: ["#91286"],
+  });
+});
+
+test("review-results does not terminalize mixed high-risk close failures", () => {
+  const dir = makeResultDir(
+    {
+      mode: "autonomous",
+      actions: [
+        {
+          target: "#91286",
+          action: "close_superseded",
+          status: "planned",
+          idempotency_key: "",
+          classification: "superseded",
+          target_kind: "pull_request",
+          target_updated_at: "2026-06-15T10:00:00Z",
+          canonical: "#91287",
+          candidate_fix: "#91287",
+          comment: "Thanks @contributor; the canonical path preserves contributor credit.",
+          evidence: ["#91287 is the hydrated canonical path."],
+          reason: "The contributor PR is superseded by the canonical path.",
+        },
+      ],
+    },
+    {
+      plan: {
+        items: [
+          {
+            ref: "#91286",
+            kind: "pull_request",
+            state: "open",
+            labels: ["merge-risk: availability"],
+            updated_at: "2026-06-15T10:00:00Z",
+            security_sensitive: false,
+          },
+          {
+            ref: "#91287",
+            kind: "pull_request",
+            state: "open",
+            labels: [],
+            updated_at: "2026-06-15T10:00:01Z",
+            security_sensitive: false,
+          },
+        ],
+      },
+    },
+  );
+
+  const result = review(dir);
+  const report = JSON.parse(result.stdout);
+
+  assert.notEqual(result.status, 0);
+  assert.equal(report.reports[0].terminal_rejection, null);
+});
+
 test("review-results allows unavailable non-mutating plan classifications", () => {
   const dir = makeResultDir(
     {


### PR DESCRIPTION
Records reviewer-blocked high-risk close actions in a separate, validated ledger.

This keeps complete batch accounting without publishing a rejected child as a normal worker result. Mixed or malformed review failures remain quarantined.

Validation:
- npm test
- npm run validate