### PR TITLE
chore: add next live PR inventory wave

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T111106-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T111106-001.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T111106-001
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#89990"
+  - "#90226"
+  - "#90723"
+  - "#90779"
+  - "#90828"
+cluster_refs:
+  - "#89990"
+  - "#90226"
+  - "#90723"
+  - "#90779"
+  - "#90828"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T11:11:06.809Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 1
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #89990 fix(gateway): isolate web login descriptor rows
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: gateway, maintainer, size: S, P2, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T17:26:12Z
+- live url: https://github.com/openclaw/openclaw/pull/89990
+
+### #90226 [AI-assisted] Preserve thread sessions across daily reset by default
+
+- bucket: needs_proof
+- author: simplyclever914
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: discord, gateway, commands, agents, size: M, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P2, rating: gold shrimp, merge-risk: compatibility, merge-risk: session-state, status: waiting on author
+- live updated: 2026-06-20T17:26:20Z
+- live url: https://github.com/openclaw/openclaw/pull/90226
+
+### #90723 feat(hooks): add Gmail Pub/Sub pull delivery mode
+
+- bucket: maintainer_owned
+- author: joshp123
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: docs, gateway, cli, maintainer, size: L, triage:blocked, proof: sufficient, P2, rating: diamond lobster, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look, feature: showcase
+- live updated: 2026-06-20T17:27:54Z
+- live url: https://github.com/openclaw/openclaw/pull/90723
+
+### #90779 fix(channels): restart gateway when channels.start fails for unloaded plugin
+
+- bucket: needs_proof
+- author: joelnishanth
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, proof: supplied, P2, rating: silver shellfish, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T17:28:24Z
+- live url: https://github.com/openclaw/openclaw/pull/90779
+
+### #90828 fix(mac-gateway): write launchd stderr to a log file and surface it in diagnostics (#90711)
+
+- bucket: needs_proof
+- author: lonexreb
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, cli, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T17:28:54Z
+- live url: https://github.com/openclaw/openclaw/pull/90828

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T111106-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T111106-002.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T111106-002
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#90833"
+  - "#90834"
+  - "#90887"
+  - "#90908"
+  - "#90970"
+cluster_refs:
+  - "#90833"
+  - "#90834"
+  - "#90887"
+  - "#90908"
+  - "#90970"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T11:11:06.810Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 2
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #90833 feat(control-ui): rename sessions from the sidebar via the server label patch (#90655)
+
+- bucket: needs_proof
+- author: lonexreb
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T17:29:02Z
+- live url: https://github.com/openclaw/openclaw/pull/90833
+
+### #90834 fix(matrix): guard against missing channel.inbound runtime (#90325)
+
+- bucket: needs_proof
+- author: lonexreb
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: matrix, size: S, proof: supplied, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T17:29:07Z
+- live url: https://github.com/openclaw/openclaw/pull/90834
+
+### #90887 fix(cron): route failure alerts to thread ids
+
+- bucket: draft
+- author: azhangd
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: docs, app: web-ui, gateway, cli, agents, size: L, proof: supplied, mantis: telegram-visible-proof, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T17:29:33Z
+- live url: https://github.com/openclaw/openclaw/pull/90887
+
+### #90908 fix(model-fallback): don't rethrow provider-side AbortErrors as user cancellations
+
+- bucket: maintainer_owned
+- author: shengting
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: altaywtf
+- labels: agents, size: S, proof: supplied, P1, rating: unranked krab, merge-risk: automation, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T17:29:40Z
+- live url: https://github.com/openclaw/openclaw/pull/90908
+
+### #90970 i18n(fr): expand French glossary with page titles and common terms
+
+- bucket: needs_proof
+- author: notadev99
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, triage: needs-real-behavior-proof, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-20T17:30:13Z
+- live url: https://github.com/openclaw/openclaw/pull/90970

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T111106-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T111106-003.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T111106-003
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#91177"
+  - "#91250"
+  - "#91271"
+  - "#91277"
+  - "#91279"
+cluster_refs:
+  - "#91177"
+  - "#91250"
+  - "#91271"
+  - "#91277"
+  - "#91279"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T11:11:06.811Z; bucket=needs_proof; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 3
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #91177 fix(tui): persist canonical provider in session modelProvider
+
+- bucket: needs_proof
+- author: Kirchlive
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, P2, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T17:31:15Z
+- live url: https://github.com/openclaw/openclaw/pull/91177
+
+### #91250 fix(agents): rename timezone-only prompt section (Fixes #63181)
+
+- bucket: needs_proof
+- author: deepujain
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: XS, triage: needs-real-behavior-proof, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-20T17:31:34Z
+- live url: https://github.com/openclaw/openclaw/pull/91250
+
+### #91271 fix(agents): include requester identity in sessions_send context (Fixes #38570)
+
+- bucket: needs_proof
+- author: deepujain
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T17:31:46Z
+- live url: https://github.com/openclaw/openclaw/pull/91271
+
+### #91277 docs(ios): clarify official app availability (Fixes #90835)
+
+- bucket: needs_proof
+- author: deepujain
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, app: ios, size: XS, triage: needs-real-behavior-proof, P3, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-20T17:32:01Z
+- live url: https://github.com/openclaw/openclaw/pull/91277
+
+### #91279 fix(ui): show config path in overview snapshot (Fixes #53958)
+
+- bucket: needs_proof
+- author: deepujain
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-20T17:32:06Z
+- live url: https://github.com/openclaw/openclaw/pull/91279

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T111106-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T111106-004.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T111106-004
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#95370"
+  - "#91291"
+  - "#91393"
+  - "#91466"
+  - "#94564"
+cluster_refs:
+  - "#95370"
+  - "#91291"
+  - "#91393"
+  - "#91466"
+  - "#94564"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T11:11:06.811Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 4
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #95370 fix #94919: [Bug]: Z.AI Coding-Plan: ECONNRESET triggers model fallback fallback notice is invisible to the user in async contexts (cron jobs, sub-agents, isolated runs)
+
+- bucket: needs_proof
+- author: mikasa0818
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, P1, rating: silver shellfish, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T17:32:25Z
+- live url: https://github.com/openclaw/openclaw/pull/95370
+
+### #91291 fix(plugins): stabilize plugin tool schemas
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: maintainer, size: XL, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-20T17:32:33Z
+- live url: https://github.com/openclaw/openclaw/pull/91291
+
+### #91393 fix(embedded-runner): refresh compaction retry diagnostics
+
+- bucket: needs_proof
+- author: fangkaigedaima
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, P1, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T17:33:06Z
+- live url: https://github.com/openclaw/openclaw/pull/91393
+
+### #91466 Gateway: server-side WebSocket keepalive + close-on-timeout
+
+- bucket: needs_proof
+- author: hoangsaga123
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T17:33:16Z
+- live url: https://github.com/openclaw/openclaw/pull/91466
+
+### #94564 fix(memory-core): bound zero-hit forced sync so memory_search can't hang the whole deadline
+
+- bucket: needs_proof
+- author: esqandil
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: line, channel: voice-call, gateway, extensions: memory-core, cli, scripts, commands, agents, channel: irc, size: L, extensions: kimi-coding, extensions: kilocode, channel: qqbot, extensions: qa-lab, extensions: codex, extensions: deepinfra, triage: needs-real-behavior-proof, extensions: chutes, extensions: diffs, extensions: openrouter, P2, rating: unranked krab, merge-risk: availability, status: needs proof, merge-risk: other, extensions: copilot
+- live updated: 2026-06-20T17:47:45Z
+- live url: https://github.com/openclaw/openclaw/pull/94564

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T111106-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T111106-005.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T111106-005
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#68112"
+  - "#69346"
+  - "#77318"
+  - "#77325"
+  - "#81039"
+cluster_refs:
+  - "#68112"
+  - "#69346"
+  - "#77318"
+  - "#77325"
+  - "#81039"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T11:11:06.811Z; bucket=needs_proof; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 5
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #68112 fix(cron): prevent scheduler death when startup catch-up fails
+
+- bucket: needs_proof
+- author: alexanderxfgl-bit
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: L, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T17:58:03Z
+- live url: https://github.com/openclaw/openclaw/pull/68112
+
+### #69346 fix(embedded-runner): actionable diagnostic for empty-stream config errors
+
+- bucket: needs_proof
+- author: abajirao
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: sufficient, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-20T17:58:25Z
+- live url: https://github.com/openclaw/openclaw/pull/69346
+
+### #77318 fix(loop-detection): block run-scoped consecutive cross-tool error cascades
+
+- bucket: needs_proof
+- author: Shockang
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, agents, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T17:59:40Z
+- live url: https://github.com/openclaw/openclaw/pull/77318
+
+### #77325 fix(auto-reply): deliver text-prefix slash command replies visibly in groups (#77260)
+
+- bucket: needs_proof
+- author: jeffrey701
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-20T17:59:48Z
+- live url: https://github.com/openclaw/openclaw/pull/77325
+
+### #81039 fix(cli-runner): emit trajectory events from CLI executor path
+
+- bucket: needs_proof
+- author: 0xghost42
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: L, proof: supplied, P2, rating: silver shellfish, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T18:00:56Z
+- live url: https://github.com/openclaw/openclaw/pull/81039

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T111106-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T111106-006.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T111106-006
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#90626"
+  - "#91473"
+  - "#92128"
+  - "#95051"
+  - "#94785"
+cluster_refs:
+  - "#90626"
+  - "#91473"
+  - "#92128"
+  - "#95051"
+  - "#94785"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T11:11:06.811Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 6
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #90626 fix(cron): default isolated agentTurn delivery to none, don't fail run on delivery error
+
+- bucket: needs_proof
+- author: olveww-dot
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: sufficient, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-20T18:01:46Z
+- live url: https://github.com/openclaw/openclaw/pull/90626
+
+### #91473 feat(google): filter English "I will"/"I am" pre-tool narration from antigravity-cli
+
+- bucket: needs_proof
+- author: Kirchlive
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, triage: needs-real-behavior-proof, extensions: google, P2, rating: unranked krab, merge-risk: auth-provider, merge-risk: session-state, merge-risk: message-delivery, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T18:02:30Z
+- live url: https://github.com/openclaw/openclaw/pull/91473
+
+### #92128 fix(feishu): prefer native thread id for topic sessions
+
+- bucket: needs_proof
+- author: hanhuihanhui
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-20T18:03:59Z
+- live url: https://github.com/openclaw/openclaw/pull/92128
+
+### #95051 fix(telegram): deliver durable reasoning replies
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: no
+- assignees: vincentkoc
+- labels: channel: telegram, maintainer, size: S, mantis: telegram-visible-proof, P2, rating: silver shellfish, merge-risk: message-delivery, status: waiting on author
+- live updated: 2026-06-20T18:12:28Z
+- live url: https://github.com/openclaw/openclaw/pull/95051
+
+### #94785 fix(qqbot): persist group inbound delivery route for announce target resolution
+
+- bucket: needs_proof
+- author: lzyyzznl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, channel: qqbot, proof: supplied, P2, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-20T18:13:19Z
+- live url: https://github.com/openclaw/openclaw/pull/94785


### PR DESCRIPTION
Adds six plan-only inventory clusters for 30 additional open OpenClaw pull requests.

Validation:
- npm run validate