### PR TITLE
fix(router): require full ClawSweeper automerge head SHA

### DIFF
--- a/docs/auto-update-prs.md
+++ b/docs/auto-update-prs.md
@@ -127,6 +127,11 @@ action:
 <!-- clawsweeper-verdict:needs-human sha=<head-sha> -->
 ```
 
+The `sha` attribute is the reviewed pull request head and must be the full
+40-character Git SHA. Clownfish treats missing, shortened, malformed, or stale
+pass-marker SHAs as non-mergeable, and records the exact blocker instead of
+falling back to an unpinned merge.
+
 Accepted marker actions:
 
 - `fix-required`

--- a/scripts/comment-router-core.mjs
+++ b/scripts/comment-router-core.mjs
@@ -105,29 +105,25 @@ export function isMaintainerCommandAllowed({
 }
 
 export function buildAutomergeMergeArgs({ issueNumber, repo, expectedHeadSha }) {
-  const args = ["pr", "merge", String(issueNumber), "--repo", repo, "--squash"];
-  if (expectedHeadSha && expectedHeadSha !== "unknown") {
-    if (!isFullGitSha(expectedHeadSha)) throw new Error("expectedHeadSha must be a full 40-character Git SHA");
-    args.push("--match-head-commit", expectedHeadSha);
-  }
-  return args;
+  if (!isFullGitSha(expectedHeadSha)) throw new Error("expectedHeadSha must be a full 40-character Git SHA");
+  return ["pr", "merge", String(issueNumber), "--repo", repo, "--squash", "--match-head-commit", expectedHeadSha];
 }
 
 export function automergeReviewedHeadBlockReason({ expectedHeadSha, currentHeadSha }) {
-  const expected = String(expectedHeadSha ?? "").trim();
+  const expected = String(expectedHeadSha ?? "");
   if (!expected || expected === "unknown") {
     return "ClawSweeper pass marker must include the reviewed PR head SHA";
   }
   if (!isFullGitSha(expected)) {
     return "ClawSweeper pass marker must include a full 40-character reviewed PR head SHA";
   }
-  const current = String(currentHeadSha ?? "").trim();
+  const current = String(currentHeadSha ?? "");
   if (current && expected !== current) return "ClawSweeper pass marker targets a stale PR head SHA";
   return "";
 }
 
 export function isFullGitSha(value) {
-  return /^[0-9a-f]{40}$/i.test(String(value ?? "").trim());
+  return /^[0-9a-f]{40}$/i.test(String(value ?? ""));
 }
 
 export function parseCommand(body) {

--- a/scripts/comment-router-core.mjs
+++ b/scripts/comment-router-core.mjs
@@ -107,9 +107,27 @@ export function isMaintainerCommandAllowed({
 export function buildAutomergeMergeArgs({ issueNumber, repo, expectedHeadSha }) {
   const args = ["pr", "merge", String(issueNumber), "--repo", repo, "--squash"];
   if (expectedHeadSha && expectedHeadSha !== "unknown") {
+    if (!isFullGitSha(expectedHeadSha)) throw new Error("expectedHeadSha must be a full 40-character Git SHA");
     args.push("--match-head-commit", expectedHeadSha);
   }
   return args;
+}
+
+export function automergeReviewedHeadBlockReason({ expectedHeadSha, currentHeadSha }) {
+  const expected = String(expectedHeadSha ?? "").trim();
+  if (!expected || expected === "unknown") {
+    return "ClawSweeper pass marker must include the reviewed PR head SHA";
+  }
+  if (!isFullGitSha(expected)) {
+    return "ClawSweeper pass marker must include a full 40-character reviewed PR head SHA";
+  }
+  const current = String(currentHeadSha ?? "").trim();
+  if (current && expected !== current) return "ClawSweeper pass marker targets a stale PR head SHA";
+  return "";
+}
+
+export function isFullGitSha(value) {
+  return /^[0-9a-f]{40}$/i.test(String(value ?? "").trim());
 }
 
 export function parseCommand(body) {

--- a/scripts/comment-router.mjs
+++ b/scripts/comment-router.mjs
@@ -22,6 +22,7 @@ import {
   automergeGateBlockReason,
   automergeClusterId,
   automergeJobPath,
+  automergeReviewedHeadBlockReason,
   buildAutomergeMergeArgs,
   isMaintainerCommandAllowed,
   parseCommand,
@@ -423,17 +424,11 @@ function classifyAutomergePass(command, issue, pull) {
   if (String(issue.state ?? "").toLowerCase() !== "open") return { ...command, status: "skipped", reason: "PR is not open" };
   if (!pull) return { ...command, status: "skipped", reason: "ClawSweeper pass marker is not on a PR" };
   if (!hasLabel(command.target, AUTOMERGE_LABEL)) return { ...command, status: "skipped", reason: "PR is not opted into Clownfish automerge" };
-  if (!command.expected_head_sha || command.expected_head_sha === "unknown") {
-    return { ...command, status: "skipped", reason: "ClawSweeper pass marker must include the reviewed PR head SHA" };
-  }
-  if (
-    command.expected_head_sha &&
-    command.expected_head_sha !== "unknown" &&
-    command.target?.head_sha &&
-    command.expected_head_sha !== command.target.head_sha
-  ) {
-    return { ...command, status: "skipped", reason: "ClawSweeper pass marker targets a stale PR head SHA" };
-  }
+  const reviewedHeadBlock = automergeReviewedHeadBlockReason({
+    expectedHeadSha: command.expected_head_sha,
+    currentHeadSha: command.target?.head_sha,
+  });
+  if (reviewedHeadBlock) return { ...command, status: "skipped", reason: reviewedHeadBlock };
   return {
     ...command,
     status: "ready",
@@ -1032,17 +1027,11 @@ function validateAutomergeReadiness({ command, view, target }) {
   if (view.state && view.state !== "OPEN") return `pull request is ${String(view.state).toLowerCase()}`;
   if (view.isDraft) return "pull request is draft";
   if (String(view.baseRefName ?? "") !== "main") return "pull request base is not main";
-  if (!command.expected_head_sha || command.expected_head_sha === "unknown") {
-    return "ClawSweeper pass marker must include the reviewed PR head SHA";
-  }
-  if (
-    command.expected_head_sha &&
-    command.expected_head_sha !== "unknown" &&
-    view.headRefOid &&
-    command.expected_head_sha !== view.headRefOid
-  ) {
-    return "ClawSweeper pass marker targets a stale PR head SHA";
-  }
+  const reviewedHeadBlock = automergeReviewedHeadBlockReason({
+    expectedHeadSha: command.expected_head_sha,
+    currentHeadSha: view.headRefOid,
+  });
+  if (reviewedHeadBlock) return reviewedHeadBlock;
   if (view.mergeable !== "MERGEABLE") return `mergeable state is ${view.mergeable || "unknown"}`;
   if (!["CLEAN", "HAS_HOOKS"].includes(String(view.mergeStateStatus ?? ""))) {
     return `merge state status is ${view.mergeStateStatus || "unknown"}`;

--- a/test/comment-router-core.test.mjs
+++ b/test/comment-router-core.test.mjs
@@ -202,6 +202,10 @@ test("automerge pass contract requires a full exact reviewed head SHA", () => {
     "ClawSweeper pass marker must include a full 40-character reviewed PR head SHA",
   );
   assert.equal(
+    automergeReviewedHeadBlockReason({ expectedHeadSha: "g".repeat(40), currentHeadSha: HEAD_SHA }),
+    "ClawSweeper pass marker must include a full 40-character reviewed PR head SHA",
+  );
+  assert.equal(
     automergeReviewedHeadBlockReason({ expectedHeadSha: STALE_HEAD_SHA, currentHeadSha: HEAD_SHA }),
     "ClawSweeper pass marker targets a stale PR head SHA",
   );
@@ -475,10 +479,12 @@ test("automerge merge args pin the reviewed head SHA", () => {
     buildAutomergeMergeArgs({ issueNumber: 123, repo: "openclaw/openclaw", expectedHeadSha: HEAD_SHA }),
     ["pr", "merge", "123", "--repo", "openclaw/openclaw", "--squash", "--match-head-commit", HEAD_SHA],
   );
-  assert.throws(
-    () => buildAutomergeMergeArgs({ issueNumber: 123, repo: "openclaw/openclaw", expectedHeadSha: "abc123" }),
-    /full 40-character Git SHA/,
-  );
+  for (const expectedHeadSha of [undefined, "unknown", "abc123", "g".repeat(40)]) {
+    assert.throws(
+      () => buildAutomergeMergeArgs({ issueNumber: 123, repo: "openclaw/openclaw", expectedHeadSha }),
+      /full 40-character Git SHA/,
+    );
+  }
 });
 
 test("automerge gate block only reports closed merge policy gates", () => {

--- a/test/comment-router-core.test.mjs
+++ b/test/comment-router-core.test.mjs
@@ -11,6 +11,7 @@ import {
   automergeGateBlockReason,
   automergeJobBranch,
   automergeJobPath,
+  automergeReviewedHeadBlockReason,
   buildAutomergeMergeArgs,
   isMaintainerCommandAllowed,
   parseCommand,
@@ -21,6 +22,9 @@ import {
   selectCommentsById,
 } from "../scripts/comment-router-core.mjs";
 import { parseSimpleYaml, validateJob } from "../scripts/lib.mjs";
+
+const HEAD_SHA = "a".repeat(40);
+const STALE_HEAD_SHA = "b".repeat(40);
 
 test("parseCommand recognizes maintainer slash commands", () => {
   assert.deepEqual(parseCommand("/clownfish fix ci"), {
@@ -174,14 +178,34 @@ test("parseTrustedAutomation accepts trusted ClawSweeper pass verdicts for autom
   const parsed = parseTrustedAutomation(
     {
       user: { login: "clawsweeper[bot]" },
-      body: "ClawSweeper review passed.\n<!-- clawsweeper-verdict:pass sha=abc123 -->",
+      body: `ClawSweeper review passed.\n<!-- clawsweeper-verdict:pass sha=${HEAD_SHA} -->`,
     },
     { trustedAuthors },
   );
 
   assert.equal(parsed.intent, "clawsweeper_auto_merge");
-  assert.equal(parsed.expected_head_sha, "abc123");
+  assert.equal(parsed.expected_head_sha, HEAD_SHA);
   assert.match(parsed.repair_reason, /verdict: pass/);
+});
+
+test("automerge pass contract requires a full exact reviewed head SHA", () => {
+  assert.equal(
+    automergeReviewedHeadBlockReason({ expectedHeadSha: null, currentHeadSha: HEAD_SHA }),
+    "ClawSweeper pass marker must include the reviewed PR head SHA",
+  );
+  assert.equal(
+    automergeReviewedHeadBlockReason({ expectedHeadSha: "unknown", currentHeadSha: HEAD_SHA }),
+    "ClawSweeper pass marker must include the reviewed PR head SHA",
+  );
+  assert.equal(
+    automergeReviewedHeadBlockReason({ expectedHeadSha: "abc123", currentHeadSha: HEAD_SHA }),
+    "ClawSweeper pass marker must include a full 40-character reviewed PR head SHA",
+  );
+  assert.equal(
+    automergeReviewedHeadBlockReason({ expectedHeadSha: STALE_HEAD_SHA, currentHeadSha: HEAD_SHA }),
+    "ClawSweeper pass marker targets a stale PR head SHA",
+  );
+  assert.equal(automergeReviewedHeadBlockReason({ expectedHeadSha: HEAD_SHA, currentHeadSha: HEAD_SHA }), "");
 });
 
 test("parseTrustedAutomation treats trusted ClawSweeper needs-human as automerge repair input", () => {
@@ -189,13 +213,13 @@ test("parseTrustedAutomation treats trusted ClawSweeper needs-human as automerge
   const parsed = parseTrustedAutomation(
     {
       user: { login: "clawsweeper[bot]" },
-      body: "ClawSweeper needs maintainer judgment.\n<!-- clawsweeper-verdict:needs-human sha=abc123 -->",
+      body: `ClawSweeper needs maintainer judgment.\n<!-- clawsweeper-verdict:needs-human sha=${HEAD_SHA} -->`,
     },
     { trustedAuthors },
   );
 
   assert.equal(parsed.intent, "clawsweeper_auto_repair");
-  assert.equal(parsed.expected_head_sha, "abc123");
+  assert.equal(parsed.expected_head_sha, HEAD_SHA);
   assert.match(parsed.repair_reason, /needs-human/);
 });
 
@@ -204,13 +228,13 @@ test("parseTrustedAutomation preserves explicit human-review verdicts as pauses"
   const parsed = parseTrustedAutomation(
     {
       user: { login: "clawsweeper[bot]" },
-      body: "ClawSweeper needs explicit human review.\n<!-- clawsweeper-verdict:human-review sha=abc123 -->",
+      body: `ClawSweeper needs explicit human review.\n<!-- clawsweeper-verdict:human-review sha=${HEAD_SHA} -->`,
     },
     { trustedAuthors },
   );
 
   assert.equal(parsed.intent, "clawsweeper_needs_human");
-  assert.equal(parsed.expected_head_sha, "abc123");
+  assert.equal(parsed.expected_head_sha, HEAD_SHA);
 });
 
 test("parseTrustedAutomation falls back to actionable ClawSweeper review text", () => {
@@ -407,6 +431,28 @@ test("renderResponse reports automerge completion", () => {
   assert.doesNotMatch(body, /ProjectClownfish/i);
 });
 
+test("renderResponse explains blocked automerge pass decisions", () => {
+  const body = renderResponse(
+    {
+      comment_id: "790",
+      intent: "clawsweeper_auto_merge",
+      trusted_bot_author: "clawsweeper[bot]",
+      repair_reason: `structured ClawSweeper verdict: pass (sha=${HEAD_SHA})`,
+      target: { head_sha: HEAD_SHA },
+    },
+    {
+      merge: {
+        status: "blocked",
+        reason: "ClawSweeper pass marker targets a stale PR head SHA",
+      },
+    },
+  );
+
+  assert.match(body, /saw the passing review, but one reef gate still blocked the merge/);
+  assert.match(body, /Merge status: ClawSweeper pass marker targets a stale PR head SHA/);
+  assert.match(body, /left the PR open/);
+});
+
 test("repair intent set documents executable repair commands", () => {
   assert.deepEqual([...REPAIR_INTENTS].sort(), [
     "address_review",
@@ -426,8 +472,12 @@ test("autoclose intent set documents destructive maintainer commands", () => {
 
 test("automerge merge args pin the reviewed head SHA", () => {
   assert.deepEqual(
-    buildAutomergeMergeArgs({ issueNumber: 123, repo: "openclaw/openclaw", expectedHeadSha: "abc123" }),
-    ["pr", "merge", "123", "--repo", "openclaw/openclaw", "--squash", "--match-head-commit", "abc123"],
+    buildAutomergeMergeArgs({ issueNumber: 123, repo: "openclaw/openclaw", expectedHeadSha: HEAD_SHA }),
+    ["pr", "merge", "123", "--repo", "openclaw/openclaw", "--squash", "--match-head-commit", HEAD_SHA],
+  );
+  assert.throws(
+    () => buildAutomergeMergeArgs({ issueNumber: 123, repo: "openclaw/openclaw", expectedHeadSha: "abc123" }),
+    /full 40-character Git SHA/,
   );
 });
 


### PR DESCRIPTION
Fixes #134

## Summary
- require trusted ClawSweeper pass markers to name the exact full 40-character PR head SHA
- refuse to construct an automerge command unless that SHA is present and valid
- document the marker contract and cover missing, unknown, shortened, malformed, stale, and exact-head cases

Preserves the reviewed implementation from [brokemac79/codex/automerge-contract-harness](https://github.com/brokemac79/clownfish/tree/codex/automerge-contract-harness) with one additional fail-closed guard in the shared merge-argument builder.

## Validation
- `node --test test/comment-router-core.test.mjs`
- `npm test`
- `npm run validate`