### PR TITLE
chore: add fresh live PR inventory

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T133827-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T133827-001.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T133827-001
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#59705"
+  - "#86279"
+  - "#87923"
+  - "#91609"
+  - "#40392"
+cluster_refs:
+  - "#59705"
+  - "#86279"
+  - "#87923"
+  - "#91609"
+  - "#40392"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T13:38:27.623Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 1
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #59705 [codex] improve parallels windows smoke logging
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: scripts, maintainer, size: M, P3, rating: unranked krab, merge-risk: automation, status: needs proof
+- live updated: 2026-05-24T19:10:39Z
+- live url: https://github.com/openclaw/openclaw/pull/59705
+
+### #86279 fix: keep media generation success on delivery failure
+
+- bucket: ready_for_maintainer
+- author: tianxiaochannel-oss88
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, stale, size: XS, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T05:05:54Z
+- live url: https://github.com/openclaw/openclaw/pull/86279
+
+### #87923 fix(thinking): keep explicit session thinkingLevel when runtime downgrades (#87740)
+
+- bucket: ready_for_maintainer
+- author: hoobnn
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-15T05:14:37Z
+- live url: https://github.com/openclaw/openclaw/pull/87923
+
+### #91609 fix(docs): make check:docs work in native PowerShell on Windows
+
+- bucket: needs_proof
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-15T15:03:01Z
+- live url: https://github.com/openclaw/openclaw/pull/91609
+
+### #40392 config: use datetime suffix for config backup files instead of numeric rotation
+
+- bucket: needs_proof
+- author: davidxcli
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-16T04:24:54Z
+- live url: https://github.com/openclaw/openclaw/pull/40392

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T133827-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T133827-002.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T133827-002
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#41275"
+  - "#46895"
+  - "#48396"
+  - "#52236"
+  - "#55861"
+cluster_refs:
+  - "#41275"
+  - "#46895"
+  - "#48396"
+  - "#52236"
+  - "#55861"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T13:38:27.624Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 2
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #41275 fix(cron): allow timeoutSeconds: 0 for no-timeout mode
+
+- bucket: needs_proof
+- author: JonathanJing
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-16T08:05:17Z
+- live url: https://github.com/openclaw/openclaw/pull/41275
+
+### #46895 fix(slash): handle /model status locally[AI-assisted]#46894
+
+- bucket: needs_proof
+- author: xiaoHEI-312
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-16T08:12:11Z
+- live url: https://github.com/openclaw/openclaw/pull/46895
+
+### #48396 feat(ui): add message preview to session list
+
+- bucket: needs_proof
+- author: SiriuSM00N
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-16T11:03:51Z
+- live url: https://github.com/openclaw/openclaw/pull/48396
+
+### #52236 fix(mattermost): persist threadId in delivery context for all session types
+
+- bucket: draft
+- author: teconomix
+- author association: CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: channel: mattermost, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-16T15:22:21Z
+- live url: https://github.com/openclaw/openclaw/pull/52236
+
+### #55861 fix(ui): prevent collapsed sidebar overlap in control UI
+
+- bucket: needs_proof
+- author: betamod
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-16T18:06:22Z
+- live url: https://github.com/openclaw/openclaw/pull/55861

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T133827-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T133827-003.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T133827-003
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#58367"
+  - "#16544"
+  - "#47087"
+  - "#43938"
+  - "#84728"
+cluster_refs:
+  - "#58367"
+  - "#16544"
+  - "#47087"
+  - "#43938"
+  - "#84728"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T13:38:27.624Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 3
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #58367 Gateway: preserve approved scope baseline during pairing
+
+- bucket: maintainer_owned
+- author: jacobtomlinson
+- author association: MEMBER
+- draft: yes
+- assignees: none
+- labels: gateway, maintainer, size: M, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-17T20:01:39Z
+- live url: https://github.com/openclaw/openclaw/pull/58367
+
+### #16544 refactor(test): structural MockFn for harness exports
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: channel: imessage, channel: telegram, channel: whatsapp-web, maintainer, size: M, P3, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-18T00:38:53Z
+- live url: https://github.com/openclaw/openclaw/pull/16544
+
+### #47087 Attach provenance to spawned subagent tasks
+
+- bucket: draft
+- author: Christoffer91
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: yes
+- assignees: none
+- labels: agents, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-18T04:56:51Z
+- live url: https://github.com/openclaw/openclaw/pull/47087
+
+### #43938 fix(gateway): use account-scoped reload for channel account changes
+
+- bucket: needs_proof
+- author: coppynight
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: message-delivery, merge-risk: availability, status: needs proof
+- live updated: 2026-06-18T07:09:32Z
+- live url: https://github.com/openclaw/openclaw/pull/43938
+
+### #84728 Repair orphaned Codex custom tool outputs before resume
+
+- bucket: ready_for_maintainer
+- author: pfrederiksen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, extensions: codex, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: session-state, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-19T01:18:44Z
+- live url: https://github.com/openclaw/openclaw/pull/84728

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T133827-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T133827-004.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T133827-004
+mode: plan
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#88300"
+  - "#50250"
+  - "#74402"
+  - "#95059"
+  - "#93950"
+cluster_refs:
+  - "#88300"
+  - "#50250"
+  - "#74402"
+  - "#95059"
+  - "#93950"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T13:38:27.624Z; bucket=mixed; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 4
+
+This is a high-volume live inventory shard over open pull requests not already represented in Clownfish jobs or results.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #88300 fix(agents): strip leaked arg_value suffixes
+
+- bucket: maintainer_owned
+- author: vincentkoc
+- author association: MEMBER
+- draft: yes
+- assignees: vincentkoc
+- labels: agents, maintainer, size: M, P1, rating: unranked krab, merge-risk: availability, status: waiting on author
+- live updated: 2026-06-19T05:12:16Z
+- live url: https://github.com/openclaw/openclaw/pull/88300
+
+### #50250 fix(health): show gateway probe duration in text output
+
+- bucket: needs_proof
+- author: JonathanJing
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-19T08:40:32Z
+- live url: https://github.com/openclaw/openclaw/pull/50250
+
+### #74402 fix(agents): route async media completions through wake media
+
+- bucket: maintainer_owned
+- author: steipete
+- author association: MEMBER
+- draft: no
+- assignees: none
+- labels: agents, maintainer, size: XS, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-19T14:45:03Z
+- live url: https://github.com/openclaw/openclaw/pull/74402
+
+### #95059 fix(build): add explicit ESM format to nodeBuildConfig for type module package
+
+- bucket: needs_proof
+- author: mmyzwl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: supplied, P1, rating: unranked krab, status: needs proof, merge-risk: other
+- live updated: 2026-06-19T18:20:50Z
+- live url: https://github.com/openclaw/openclaw/pull/95059
+
+### #93950 [codex] fix setup health hint command surface
+
+- bucket: needs_proof
+- author: NianJiuZst
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, commands, size: XS, proof: supplied, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-19T20:42:28Z
+- live url: https://github.com/openclaw/openclaw/pull/93950


### PR DESCRIPTION
## Summary
- inventory 3,173 currently open OpenClaw PRs
- add four plan-only jobs covering 20 previously unrepresented, non-security PRs
- retain strict no-merge/no-fix/no-raise-PR limits for this first classification drip

## Validation
- `npm run validate` (6,340 jobs)
- `npm run validate:job` for each added inventory job