### PR TITLE
chore(queue): add remediation inventory batch

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T140336-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T140336-001.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T140336-001
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90280"
+  - "#95386"
+  - "#95522"
+  - "#95278"
+  - "#94215"
+cluster_refs:
+  - "#90280"
+  - "#95386"
+  - "#95522"
+  - "#95278"
+  - "#94215"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T14:03:36.528Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #90280 test: make zalo token resolver symlink test compatible with Windows
+
+- bucket: ready_for_maintainer
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: zalo, size: XS, proof: sufficient, P3, rating: gold shrimp, status: ready for maintainer look, triage: needs-pr-context
+- live updated: 2026-06-21T14:01:24Z
+- live url: https://github.com/openclaw/openclaw/pull/90280
+
+### #95386 fix #95351: [Feature]: Generic JSONL line-parsing hook for CliBackendPlugin (native tool-card support beyond claude-stream-json)
+
+- bucket: ready_for_maintainer
+- author: mikasa0818
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: L, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T14:01:16Z
+- live url: https://github.com/openclaw/openclaw/pull/95386
+
+### #95522 feat(telegram): unify progress fallback with assistant preview lane
+
+- bucket: ready_for_maintainer
+- author: snowzlmbot
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, scripts, agents, size: M, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T13:58:34Z
+- live url: https://github.com/openclaw/openclaw/pull/95522
+
+### #95278 Avoid copying process.env in ingress queue state DB opens
+
+- bucket: ready_for_maintainer
+- author: clawsweeper
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, clawsweeper, clawsweeper:automerge, proof: sufficient, P1, rating: platinum hermit, status: automerge armed
+- live updated: 2026-06-21T13:56:59Z
+- live url: https://github.com/openclaw/openclaw/pull/95278
+
+### #94215 fix(i18n): correct zh-CN theme/cron labels and translate Dreaming restart modal [AI-assisted]
+
+- bucket: ready_for_maintainer
+- author: eldar702
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, merge-risk: other
+- live updated: 2026-06-21T13:53:01Z
+- live url: https://github.com/openclaw/openclaw/pull/94215

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T140336-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T140336-002.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T140336-002
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94148"
+  - "#95376"
+  - "#93374"
+  - "#93351"
+  - "#93007"
+cluster_refs:
+  - "#94148"
+  - "#95376"
+  - "#93374"
+  - "#93351"
+  - "#93007"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T14:03:36.530Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 2
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94148 fix(doctor): prevent non-interactive --fix from auto-restarting gateway
+
+- bucket: ready_for_maintainer
+- author: zhangguiping-xydt
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T13:51:37Z
+- live url: https://github.com/openclaw/openclaw/pull/94148
+
+### #95376 fix(agent-tools): correct hallucinated document file extensions in tool path parameters (#93326)
+
+- bucket: ready_for_maintainer
+- author: mmyzwl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T13:48:49Z
+- live url: https://github.com/openclaw/openclaw/pull/95376
+
+### #93374 fix(agents): suggest recovery for unknown tool ids
+
+- bucket: ready_for_maintainer
+- author: mushuiyu886
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-21T13:47:36Z
+- live url: https://github.com/openclaw/openclaw/pull/93374
+
+### #93351 feat(cli): add --message-file to openclaw agent
+
+- bucket: ready_for_maintainer
+- author: ooiuuii
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, commands, size: S, clawsweeper:automerge, clawsweeper:human-review, proof: supplied, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: automerge armed, clownfish:automerge
+- live updated: 2026-06-21T13:47:27Z
+- live url: https://github.com/openclaw/openclaw/pull/93351
+
+### #93007 feat(gateway): forward web_search_options through OpenAI-compatible chat completions
+
+- bucket: ready_for_maintainer
+- author: Lellansin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, agents, size: XL, extensions: openai, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T13:46:28Z
+- live url: https://github.com/openclaw/openclaw/pull/93007

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T140336-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T140336-003.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T140336-003
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#95468"
+  - "#89962"
+  - "#90230"
+  - "#90217"
+  - "#89992"
+cluster_refs:
+  - "#95468"
+  - "#89962"
+  - "#90230"
+  - "#90217"
+  - "#89992"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T14:03:36.530Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 3
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #95468 fix(workboard): filter archived cards from CLI list output
+
+- bucket: ready_for_maintainer
+- author: maweibin
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: S, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look, plugin: workboard
+- live updated: 2026-06-21T13:46:02Z
+- live url: https://github.com/openclaw/openclaw/pull/95468
+
+### #89962 fix(discord): fall back to text when voice delivery fails
+
+- bucket: ready_for_maintainer
+- author: danhayman
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T13:45:03Z
+- live url: https://github.com/openclaw/openclaw/pull/89962
+
+### #90230 test: run permission hardening backup test on Windows
+
+- bucket: ready_for_maintainer
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T13:42:00Z
+- live url: https://github.com/openclaw/openclaw/pull/90230
+
+### #90217 test: make doctor state integrity symlink test robust on Windows
+
+- bucket: ready_for_maintainer
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T13:41:41Z
+- live url: https://github.com/openclaw/openclaw/pull/90217
+
+### #89992 feat(config): write local editor schema
+
+- bucket: ready_for_maintainer
+- author: danhayman
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, cli, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T13:38:24Z
+- live url: https://github.com/openclaw/openclaw/pull/89992

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T140336-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T140336-004.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T140336-004
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#83041"
+  - "#67432"
+  - "#95347"
+  - "#94134"
+  - "#94084"
+cluster_refs:
+  - "#83041"
+  - "#67432"
+  - "#95347"
+  - "#94134"
+  - "#94084"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-21T14:03:36.530Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 4
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #83041 Fix config patch restart-required notices
+
+- bucket: ready_for_maintainer
+- author: xuruiray
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, clownfish:automerge
+- live updated: 2026-06-21T13:34:05Z
+- live url: https://github.com/openclaw/openclaw/pull/83041
+
+### #67432 fix(ui): add aria-label to pinned message Unpin button
+
+- bucket: ready_for_maintainer
+- author: akinshaywai
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T13:34:04Z
+- live url: https://github.com/openclaw/openclaw/pull/67432
+
+### #95347 fix(memory): honor qmd search timeout and bound one-shot CLI cleanup
+
+- bucket: ready_for_maintainer
+- author: jason-allen-oneal
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: XL, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-21T13:32:34Z
+- live url: https://github.com/openclaw/openclaw/pull/95347
+
+### #94134 feat(ios): auto-connect nearby gateways during onboarding
+
+- bucket: ready_for_maintainer
+- author: zats
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: ios, size: L, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: auth-provider, status: ready for maintainer look, proof: video
+- live updated: 2026-06-21T13:20:46Z
+- live url: https://github.com/openclaw/openclaw/pull/94134
+
+### #94084 fix(cli): sync official plugins during update --all
+
+- bucket: ready_for_maintainer
+- author: ooiuuii
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, commands, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T13:18:19Z
+- live url: https://github.com/openclaw/openclaw/pull/94084


### PR DESCRIPTION
## Summary
- add four plan-only remediation inventory jobs for 20 live ready-for-maintainer PRs
- preserve merge, repair, and close decisions for reviewed worker artifacts

## Validation
- npm run validate:job -- jobs/openclaw/inbox/live-pr-inventory-20260621T140336-{001,002,003,004}.md
- git diff --check