### PR TITLE
chore(queue): add fresh PR remediation intake

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T1420-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T1420-001.md
@@ -1,0 +1,80 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T1420-001
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#93567"
+  - "#93504"
+  - "#90870"
+  - "#90153"
+  - "#90061"
+cluster_refs:
+  - "#93567"
+  - "#93504"
+  - "#90870"
+  - "#90153"
+  - "#90061"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Fresh independent PR remediation shard. A merge recommendation requires complete live merge preflight; a repair requires a complete executable fix artifact."
+notes: "Generated from the live ready-for-maintainer inventory on 2026-06-21T14:20Z. Excludes all refs with June 21 result artifacts. Plan-only: no GitHub mutation is permitted."
+---
+
+# PR Remediation Inventory 1
+
+## Goal
+
+Hydrate current GitHub state and identify an executable finalization path for each PR. Emit `merge_candidate` only with complete merge preflight. Emit `fix_needed` only with a complete bounded `fix_artifact`; otherwise retain the PR. Route security-sensitive work centrally. Do not mutate GitHub.
+
+## Inventory
+
+### #93567 fix(cron): normalize run-log jobId on write to match read-side validation
+
+- author: Alix-007
+- labels: size XS; proof supplied and sufficient; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/93567
+
+### #93504 fix(device-pairing): guard role normalization against non-string entries
+
+- author: ly-wang19
+- labels: size S; proof supplied and sufficient; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/93504
+
+### #90870 [AI] fix(memory-wiki): index wiki pages in query-dir subfolders
+
+- author: Agent-Aurelius
+- labels: memory-wiki; size S; proof supplied and sufficient; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/90870
+
+### #90153 fix(doctor): isolate channel doctor hook failures
+
+- author: vincentkoc
+- labels: cli; commands; maintainer; size M; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/90153
+
+### #90061 fix(agent-runtime): guard prompt cache tool names
+
+- author: vincentkoc
+- labels: agents; maintainer; size XS; P2; other merge risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/90061

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T1420-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T1420-002.md
@@ -1,0 +1,80 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T1420-002
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90033"
+  - "#89973"
+  - "#89720"
+  - "#89529"
+  - "#89132"
+cluster_refs:
+  - "#90033"
+  - "#89973"
+  - "#89720"
+  - "#89529"
+  - "#89132"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Fresh independent PR remediation shard. A merge recommendation requires complete live merge preflight; a repair requires a complete executable fix artifact."
+notes: "Generated from the live ready-for-maintainer inventory on 2026-06-21T14:20Z. Excludes all refs with June 21 result artifacts. Plan-only: no GitHub mutation is permitted."
+---
+
+# PR Remediation Inventory 2
+
+## Goal
+
+Hydrate current GitHub state and identify an executable finalization path for each PR. Emit `merge_candidate` only with complete merge preflight. Emit `fix_needed` only with a complete bounded `fix_artifact`; otherwise retain the PR. Route security-sensitive work centrally. Do not mutate GitHub.
+
+## Inventory
+
+### #90033 fix(llm): apply model.compat.sendSessionAffinityHeaders at openai transport
+
+- author: obuchowski
+- labels: agents; size S; proof supplied and sufficient; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/90033
+
+### #89973 fix(plugins): isolate doctor contract rows
+
+- author: vincentkoc
+- labels: maintainer; size S; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89973
+
+### #89720 fix(plugin-sdk): guard plain text tool name reads
+
+- author: vincentkoc
+- labels: maintainer; size S; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89720
+
+### #89529 fix(provider): harden unsupported schema keyword stripping
+
+- author: vincentkoc
+- labels: agents; maintainer; size M; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89529
+
+### #89132 fix(agent-core): guard tool lookup descriptors
+
+- author: vincentkoc
+- labels: maintainer; size S; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89132

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T1420-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T1420-003.md
@@ -1,0 +1,80 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T1420-003
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#92236"
+  - "#92114"
+  - "#90218"
+  - "#90182"
+  - "#90160"
+cluster_refs:
+  - "#92236"
+  - "#92114"
+  - "#90218"
+  - "#90182"
+  - "#90160"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Fresh independent PR remediation shard. A merge recommendation requires complete live merge preflight; a repair requires a complete executable fix artifact."
+notes: "Generated from the live ready-for-maintainer inventory on 2026-06-21T14:20Z. Excludes all refs with June 21 result artifacts. Plan-only: no GitHub mutation is permitted."
+---
+
+# PR Remediation Inventory 3
+
+## Goal
+
+Hydrate current GitHub state and identify an executable finalization path for each PR. Emit `merge_candidate` only with complete merge preflight. Emit `fix_needed` only with a complete bounded `fix_artifact`; otherwise retain the PR. Route security-sensitive work centrally. Do not mutate GitHub.
+
+## Inventory
+
+### #92236 fix(webchat): surface Codex commentary progress
+
+- author: 100yenadmin
+- labels: docs; telegram; web UI; size S; proof supplied and sufficient; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/92236
+
+### #92114 fix(memory): report indexed vector store in status
+
+- author: TurboTheTurtle
+- labels: memory-core; size S; proof supplied and sufficient; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/92114
+
+### #90218 Fix Mission Control docs markdown links
+
+- author: spacegeologist
+- labels: web UI; size M; proof supplied and sufficient; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/90218
+
+### #90182 fix(plugins): isolate definition metadata failures
+
+- author: vincentkoc
+- labels: maintainer; size S; proof sufficient; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/90182
+
+### #90160 fix(channels): guard pairing adapter metadata
+
+- author: vincentkoc
+- labels: maintainer; size S; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/90160

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T1420-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T1420-004.md
@@ -1,0 +1,80 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T1420-004
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#90150"
+  - "#90136"
+  - "#90099"
+  - "#90063"
+  - "#89967"
+cluster_refs:
+  - "#90150"
+  - "#90136"
+  - "#90099"
+  - "#90063"
+  - "#89967"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Fresh independent PR remediation shard. A merge recommendation requires complete live merge preflight; a repair requires a complete executable fix artifact."
+notes: "Generated from the live ready-for-maintainer inventory on 2026-06-21T14:20Z. Excludes all refs with June 21 result artifacts. Plan-only: no GitHub mutation is permitted."
+---
+
+# PR Remediation Inventory 4
+
+## Goal
+
+Hydrate current GitHub state and identify an executable finalization path for each PR. Emit `merge_candidate` only with complete merge preflight. Emit `fix_needed` only with a complete bounded `fix_artifact`; otherwise retain the PR. Route security-sensitive work centrally. Do not mutate GitHub.
+
+## Inventory
+
+### #90150 fix(doctor): guard tool allowlist manifest metadata
+
+- author: vincentkoc
+- labels: commands; maintainer; size S; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/90150
+
+### #90136 fix(plugins): guard manifest activation planning
+
+- author: vincentkoc
+- labels: maintainer; size M; proof sufficient; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/90136
+
+### #90099 fix(plugin-sdk): guard facade registry rows
+
+- author: vincentkoc
+- labels: maintainer; size M; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/90099
+
+### #90063 fix(channels): clarify message receipt delivery evidence
+
+- author: pdurlej
+- labels: docs; size S; proof supplied and sufficient; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/90063
+
+### #89967 fix #87199: macOS LaunchAgent external-home gateway run failure
+
+- author: zhangguiping-xydt
+- labels: gateway; size S; proof supplied and sufficient; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89967


### PR DESCRIPTION
Adds four plan-only shards for 20 live ready-for-maintainer PRs.

The cohort excludes every reference with a June 21 result artifact, so this is new work rather than a replay.