### PR TITLE
chore(queue): add second PR remediation intake

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T1430-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T1430-001.md
@@ -1,0 +1,80 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T1430-001
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89898"
+  - "#89880"
+  - "#89860"
+  - "#89747"
+  - "#89142"
+cluster_refs:
+  - "#89898"
+  - "#89880"
+  - "#89860"
+  - "#89747"
+  - "#89142"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Fresh independent PR remediation shard. A merge recommendation requires complete live merge preflight; a repair requires a complete executable fix artifact."
+notes: "Generated from the second live ready-for-maintainer page on 2026-06-21T14:30Z. Excludes all refs with June 21 result artifacts and the prior intake. Plan-only: no GitHub mutation is permitted."
+---
+
+# PR Remediation Inventory 1
+
+## Goal
+
+Hydrate current GitHub state and identify an executable finalization path for each PR. Emit `merge_candidate` only with complete merge preflight. Emit `fix_needed` only with a complete bounded `fix_artifact`; otherwise retain the PR. Route security-sensitive work centrally. Do not mutate GitHub.
+
+## Inventory
+
+### #89898 fix(plugins): guard plugin service registration metadata
+
+- author: vincentkoc
+- labels: maintainer; size S; P2; other merge risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89898
+
+### #89880 fix(plugins): guard model catalog registration metadata
+
+- author: vincentkoc
+- labels: maintainer; size S; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89880
+
+### #89860 fix(media): guard hosted resolver failure logging
+
+- author: vincentkoc
+- labels: maintainer; size S; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89860
+
+### #89747 fix(auto-reply): guard tools status inventory reads
+
+- author: vincentkoc
+- labels: maintainer; size M; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89747
+
+### #89142 fix(secrets): generate secretref reference docs from the credential matrix
+
+- author: 1052326311
+- labels: docs; scripts; size M; P2; automation risk; needs PR context
+- live url: https://github.com/openclaw/openclaw/pull/89142

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T1430-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T1430-002.md
@@ -1,0 +1,80 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T1430-002
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#95483"
+  - "#89917"
+  - "#89907"
+  - "#89897"
+  - "#89894"
+cluster_refs:
+  - "#95483"
+  - "#89917"
+  - "#89907"
+  - "#89897"
+  - "#89894"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Fresh independent PR remediation shard. A merge recommendation requires complete live merge preflight; a repair requires a complete executable fix artifact."
+notes: "Generated from the second live ready-for-maintainer page on 2026-06-21T14:30Z. Excludes all refs with June 21 result artifacts and the prior intake. Plan-only: no GitHub mutation is permitted."
+---
+
+# PR Remediation Inventory 2
+
+## Goal
+
+Hydrate current GitHub state and identify an executable finalization path for each PR. Emit `merge_candidate` only with complete merge preflight. Emit `fix_needed` only with a complete bounded `fix_artifact`; otherwise retain the PR. Route security-sensitive work centrally. Do not mutate GitHub.
+
+## Inventory
+
+### #95483 fix(whatsapp): preserve native quote replies
+
+- author: mcaxtr
+- labels: whatsapp-web; maintainer; size M; QA lab; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/95483
+
+### #89917 fix(agents): guard provider auth alias metadata
+
+- author: vincentkoc
+- labels: agents; maintainer; size S; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89917
+
+### #89907 fix(plugins): guard config contract metadata
+
+- author: vincentkoc
+- labels: maintainer; size S; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89907
+
+### #89897 fix(cli): replace hardcoded FLAG_TERMINATOR in getCommandPathInternal
+
+- author: whiteyzy
+- labels: cli; size XS; proof supplied and sufficient; P3; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89897
+
+### #89894 fix(docs): reorder AGENTS.md template to protect critical rules from truncation
+
+- author: dwc1997
+- labels: docs; size XS; proof supplied; P2; other merge risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89894

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T1430-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T1430-003.md
@@ -1,0 +1,80 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T1430-003
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89888"
+  - "#89886"
+  - "#89882"
+  - "#89865"
+  - "#89795"
+cluster_refs:
+  - "#89888"
+  - "#89886"
+  - "#89882"
+  - "#89865"
+  - "#89795"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Fresh independent PR remediation shard. A merge recommendation requires complete live merge preflight; a repair requires a complete executable fix artifact."
+notes: "Generated from the second live ready-for-maintainer page on 2026-06-21T14:30Z. Excludes all refs with June 21 result artifacts and the prior intake. Plan-only: no GitHub mutation is permitted."
+---
+
+# PR Remediation Inventory 3
+
+## Goal
+
+Hydrate current GitHub state and identify an executable finalization path for each PR. Emit `merge_candidate` only with complete merge preflight. Emit `fix_needed` only with a complete bounded `fix_artifact`; otherwise retain the PR. Route security-sensitive work centrally. Do not mutate GitHub.
+
+## Inventory
+
+### #89888 fix(plugins): guard active runtime registry metadata
+
+- author: vincentkoc
+- labels: maintainer; size S; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89888
+
+### #89886 fix(context-engine): forward abortSignal through delegation bridge to runtime compaction
+
+- author: openperf
+- labels: size XS; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89886
+
+### #89882 fix(plugins): rebuild missing installs on policy refresh
+
+- author: baskduf
+- labels: size XL; proof supplied and sufficient; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89882
+
+### #89865 fix(channels): guard startup maintenance metadata
+
+- author: vincentkoc
+- labels: maintainer; size S; proof sufficient; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89865
+
+### #89795 fix(plugins): guard host cleanup extension metadata
+
+- author: vincentkoc
+- labels: maintainer; size S; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89795

--- a/jobs/openclaw/inbox/live-pr-inventory-20260621T1430-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260621T1430-004.md
@@ -1,0 +1,80 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260621T1430-004
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#89778"
+  - "#89767"
+  - "#89619"
+  - "#89384"
+  - "#89320"
+cluster_refs:
+  - "#89778"
+  - "#89767"
+  - "#89619"
+  - "#89384"
+  - "#89320"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Fresh independent PR remediation shard. A merge recommendation requires complete live merge preflight; a repair requires a complete executable fix artifact."
+notes: "Generated from the second live ready-for-maintainer page on 2026-06-21T14:30Z. Excludes all refs with June 21 result artifacts and the prior intake. Plan-only: no GitHub mutation is permitted."
+---
+
+# PR Remediation Inventory 4
+
+## Goal
+
+Hydrate current GitHub state and identify an executable finalization path for each PR. Emit `merge_candidate` only with complete merge preflight. Emit `fix_needed` only with a complete bounded `fix_artifact`; otherwise retain the PR. Route security-sensitive work centrally. Do not mutate GitHub.
+
+## Inventory
+
+### #89778 fix(media): guard hosted media resolver metadata
+
+- author: vincentkoc
+- labels: maintainer; size S; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89778
+
+### #89767 fix(skills): route installs to requested agent workspace
+
+- author: AliAbuelkheir
+- labels: docs; web UI; gateway; size M; proof supplied and sufficient; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89767
+
+### #89619 fix(agents): wrap bundle MCP schema setup errors
+
+- author: vincentkoc
+- labels: agents; maintainer; size S; proof sufficient; P2; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89619
+
+### #89384 fix(plugins): isolate unreadable plugin tool descriptors
+
+- author: vincentkoc
+- labels: maintainer; size M; proof sufficient; P2; compatibility risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89384
+
+### #89320 docs: document ACP stateful target contracts
+
+- author: steipete
+- labels: web UI; gateway; maintainer; size XL; proof sufficient; P3; other merge risk; ready for maintainer look
+- live url: https://github.com/openclaw/openclaw/pull/89320


### PR DESCRIPTION
Adds four plan-only shards for 20 additional live ready-for-maintainer PRs.

The cohort excludes all June 21 result refs and the preceding intake, preventing replay work.