### PR TITLE
fix(automerge): scope adopted repair exceptions

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2445,6 +2445,7 @@ function mutableFixSourceRefs(fixArtifact) {
 
 function validateLiveAutonomousTargetPolicy({ job, fixArtifact }) {
   if (job.frontmatter.mode !== "autonomous") return null;
+  const adoptedAutomergeTarget = adoptedAutomergeRepairTarget(job);
 
   const sources =
     fixArtifact.repair_strategy === "repair_contributor_branch"
@@ -2458,7 +2459,9 @@ function validateLiveAutonomousTargetPolicy({ job, fixArtifact }) {
     const labels = (pull.labels ?? []).map((label) => String(label?.name ?? label)).filter(Boolean);
     const normalizedLabels = labels.map((label) => label.toLowerCase());
     const blockedSignals = [
-      ...(normalizedLabels.includes("clawsweeper:automerge") ? ["clawsweeper:automerge"] : []),
+      ...(normalizedLabels.includes("clawsweeper:automerge") && source.number !== adoptedAutomergeTarget
+        ? ["clawsweeper:automerge"]
+        : []),
       ...labels.filter((label) => /^merge-risk:/i.test(label)),
       ...(hasDeterministicSecuritySignal({ labels }) ? ["security-sensitive"] : []),
     ];
@@ -2472,6 +2475,12 @@ function validateLiveAutonomousTargetPolicy({ job, fixArtifact }) {
   }
 
   return null;
+}
+
+function adoptedAutomergeRepairTarget(job) {
+  if (job.frontmatter.source !== "pr_automerge") return 0;
+  const canonicalRefs = [...new Set((job.frontmatter.canonical ?? []).map(normalizeLocalRef).filter(Boolean))];
+  return canonicalRefs.length === 1 ? Number(canonicalRefs[0].slice(1)) : 0;
 }
 
 function validateAutonomousFixScope({ job, fixArtifact }) {

--- a/scripts/plan-cluster.mjs
+++ b/scripts/plan-cluster.mjs
@@ -493,6 +493,8 @@ function buildFixArtifact(plan, job) {
 
 function snapshotSourceJobPolicy(job) {
   return {
+    source: job.frontmatter.source ?? null,
+    canonical: [...(job.frontmatter.canonical ?? [])],
     allowed_actions: [...job.frontmatter.allowed_actions],
     blocked_actions: [...(job.frontmatter.blocked_actions ?? [])],
     allow_fix_pr: job.frontmatter.allow_fix_pr === true,

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -295,6 +295,8 @@ function fallbackPlan({ sourceJob, pullRequest, baseBranch }) {
 
 function sourceJobPermissions(job) {
   return {
+    source: job.frontmatter.source ?? null,
+    canonical: [...(job.frontmatter.canonical ?? [])],
     allowed_actions: [...job.frontmatter.allowed_actions],
     blocked_actions: [...(job.frontmatter.blocked_actions ?? [])],
     allow_fix_pr: job.frontmatter.allow_fix_pr === true,

--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -291,7 +291,13 @@ function reviewResult(resultPath) {
     }
     validateFixActionPermissions(sourceJobPolicy, fixActions, failures);
     validateFixArtifact(result.fix_artifact, failures);
-    validateExecutableFixTargetLabels({ fixActions, fixArtifact: result.fix_artifact, itemByRef, failures });
+    validateExecutableFixTargetLabels({
+      fixActions,
+      fixArtifact: result.fix_artifact,
+      itemByRef,
+      sourceJobPolicy,
+      failures,
+    });
   }
   const plannedMergeActions = mergeActions.filter((action) => action.status === "planned");
   if (plannedMergeActions.length > 0) {
@@ -682,11 +688,28 @@ function validateFixArtifact(fixArtifact, failures) {
   }
 }
 
-function validateExecutableFixTargetLabels({ fixActions, fixArtifact, itemByRef, failures }) {
+function validateExecutableFixTargetLabels({ fixActions, fixArtifact, itemByRef, sourceJobPolicy, failures }) {
   if (!EXECUTABLE_FIX_REPAIR_STRATEGIES.has(fixArtifact?.repair_strategy)) return;
 
   const plannedFixActions = fixActions.filter((action) => action.status === "planned");
   if (plannedFixActions.length === 0) return;
+  const adoptedAutomergeTarget = adoptedAutomergeRepairTarget(sourceJobPolicy);
+  const sourceRefs = [...new Set((fixArtifact.source_prs ?? []).map(normalizeRef).filter(Boolean))];
+  if (sourceJobPolicy?.source === "pr_automerge") {
+    if (!adoptedAutomergeTarget) {
+      failures.push("adopted automerge repair requires exactly one canonical PR");
+    } else if (sourceRefs.length !== 1 || sourceRefs[0] !== adoptedAutomergeTarget) {
+      failures.push(`adopted automerge repair source must be the canonical PR: ${adoptedAutomergeTarget}`);
+    } else if (!itemByRef.get(adoptedAutomergeTarget)) {
+      failures.push(`${adoptedAutomergeTarget} adopted automerge repair source was not hydrated in preflight`);
+    }
+    for (const action of plannedFixActions) {
+      const target = normalizeRef(action.target);
+      if (target && target !== adoptedAutomergeTarget) {
+        failures.push(`${target} adopted automerge repair action must target ${adoptedAutomergeTarget}`);
+      }
+    }
+  }
 
   const refs = new Set(
     [
@@ -700,15 +723,28 @@ function validateExecutableFixTargetLabels({ fixActions, fixArtifact, itemByRef,
 
   for (const ref of refs) {
     const item = itemByRef.get(ref);
-    const blockedLabel = findHighRiskMutationLabel(item?.labels);
+    const blockedLabel = findHighRiskMutationLabel(item?.labels, {
+      allowAutomergeRepair: ref === adoptedAutomergeTarget,
+    });
     if (blockedLabel) {
       failures.push(`${ref} executable repair target has blocked label: ${blockedLabel}`);
     }
   }
 }
 
-function findHighRiskMutationLabel(labels) {
-  return (labels ?? []).map(String).find((label) => /^merge-risk:/i.test(label) || label.toLowerCase() === "clawsweeper:automerge");
+function adoptedAutomergeRepairTarget(sourceJobPolicy) {
+  if (sourceJobPolicy?.source !== "pr_automerge") return "";
+  const canonicalRefs = [...new Set((sourceJobPolicy.canonical ?? []).map(normalizeRef).filter(Boolean))];
+  return canonicalRefs.length === 1 ? canonicalRefs[0] : "";
+}
+
+function findHighRiskMutationLabel(labels, { allowAutomergeRepair = false } = {}) {
+  return (labels ?? [])
+    .map(String)
+    .find(
+      (label) =>
+        /^merge-risk:/i.test(label) || (label.toLowerCase() === "clawsweeper:automerge" && !allowAutomergeRepair),
+    );
 }
 
 function isDisallowedPullRequestLifecycleValidationCommand(command) {
@@ -756,7 +792,10 @@ function readSourceJobPolicySnapshot(plan) {
     typeof permissions.allow_fix_pr !== "boolean" ||
     typeof permissions.allow_merge !== "boolean" ||
     !Array.isArray(permissions.maintainer_calibration) ||
-    !permissions.maintainer_calibration.every((entry) => typeof entry === "string")
+    !permissions.maintainer_calibration.every((entry) => typeof entry === "string") ||
+    (permissions.source !== undefined && permissions.source !== null && typeof permissions.source !== "string") ||
+    (permissions.canonical !== undefined &&
+      (!Array.isArray(permissions.canonical) || !permissions.canonical.every((entry) => typeof entry === "string")))
   ) {
     return null;
   }

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -170,7 +170,7 @@ process.exit(99);
 });
 
 test("execute-fix-artifact blocks live autonomous repair targets with risk labels before target mutation", () => {
-  for (const { label, expectedSignal, automerge, repairStrategy = "repair_contributor_branch" } of [
+  for (const { label, expectedSignal, repairStrategy = "repair_contributor_branch", adoptedCanonical = null } of [
     { label: "merge-risk: compatibility", expectedSignal: "merge-risk: compatibility", automerge: false },
     {
       label: "merge-risk: availability",
@@ -179,7 +179,12 @@ test("execute-fix-artifact blocks live autonomous repair targets with risk label
       repairStrategy: "replace_uneditable_branch",
     },
     { label: "security:sensitive", expectedSignal: "security-sensitive", automerge: false },
-    { label: "clawsweeper:automerge", expectedSignal: "clawsweeper:automerge", automerge: true },
+    { label: "clawsweeper:automerge", expectedSignal: "clawsweeper:automerge" },
+    {
+      label: "clawsweeper:automerge",
+      expectedSignal: "clawsweeper:automerge",
+      adoptedCanonical: "#2",
+    },
   ]) {
     const fixture = makeFixture();
     const clusterId = `live-target-policy-${label.replace(/[^a-z]+/gi, "-").replace(/^-|-$/g, "")}`;
@@ -189,10 +194,11 @@ test("execute-fix-artifact blocks live autonomous repair targets with risk label
 
     fs.writeFileSync(
       fixture.jobPath,
-      `${jobFile(clusterId).replace(
-        "security_sensitive: false",
-        `${automerge ? "source: pr_automerge\n" : ""}security_sensitive: false`,
-      )}`,
+      adoptedCanonical
+        ? jobFile(clusterId)
+            .replace("canonical: []", `canonical:\n  - "${adoptedCanonical}"`)
+            .replace("security_sensitive: false", "security_sensitive: false\nsource: pr_automerge")
+        : jobFile(clusterId),
     );
     const result = resultFile(clusterId);
     result.actions = [{ action: "fix_needed", status: "planned", target: "#1" }];
@@ -235,15 +241,18 @@ test("execute-fix-artifact blocks live autonomous repair targets with risk label
     assert.equal(report.no_target_mutations, true);
     assert.equal(report.actions[0].code, "live_target_policy_block");
     assert.match(report.reason, new RegExp(expectedSignal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
-    if (automerge) {
-      assert.deepEqual(report.actions.at(-1), {
-        action: "automerge_repair_outcome_comment",
-        target: "#1",
-        status: "skipped",
-        reason: "live target policy blocks all target mutations",
-      });
-    }
   }
+});
+
+test("execute-fix-artifact permits ClawSweeper automerge labels only for the adopted repair target", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "execute-fix-artifact.mjs"), "utf8");
+
+  assert.match(source, /function adoptedAutomergeRepairTarget\(job\)/);
+  assert.match(source, /job\.frontmatter\.source !== "pr_automerge"/);
+  assert.match(
+    source,
+    /normalizedLabels\.includes\("clawsweeper:automerge"\) && source\.number !== adoptedAutomergeTarget/,
+  );
 });
 
 test("execute-fix-artifact ignores security-routed lineage that is not a mutable repair source", () => {

--- a/test/plan-cluster.test.mjs
+++ b/test/plan-cluster.test.mjs
@@ -100,6 +100,8 @@ canonical:
   const plan = JSON.parse(fs.readFileSync(path.join(runDir, "cluster-plan.json"), "utf8"));
   const candidate = plan.items.find((item) => item.ref === "#2");
   assert.deepEqual(plan.source_job_permissions, {
+    source: null,
+    canonical: ["#1"],
     allowed_actions: ["comment"],
     blocked_actions: [],
     allow_fix_pr: false,

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -1074,6 +1074,86 @@ test("review-results rejects executable repair paths bound to risk-labeled prefl
   }
 });
 
+test("review-results permits ClawSweeper automerge labels for adopted repair jobs only", () => {
+  const dir = makeResultDir(
+    {
+      mode: "autonomous",
+      actions: [
+        {
+          target: "#91286",
+          action: "fix_needed",
+          status: "planned",
+          idempotency_key: "cluster-test:fix-needed:91286:adopted-automerge",
+          classification: "canonical",
+          target_kind: "pull_request",
+          target_updated_at: "2026-06-15T10:00:00Z",
+          evidence: ["#91286 is the bounded contributor repair target."],
+          reason: "Repair the contributor branch and preserve attribution.",
+        },
+      ],
+      fix_artifact: validFixArtifact({
+        repair_strategy: "repair_contributor_branch",
+        linked_refs: ["#91286"],
+        source_prs: ["https://github.com/openclaw/openclaw/pull/91286"],
+        credit_notes: ["Preserve the original contributor's credit on the repaired branch."],
+      }),
+    },
+    {
+      job: fixEnabledJob().replace("mode: autonomous", "mode: autonomous\nsource: pr_automerge"),
+      plan: {
+        source_job_permissions: {
+          source: "pr_automerge",
+          canonical: ["#91286"],
+          allowed_actions: ["comment", "label", "close", "fix", "raise_pr"],
+          blocked_actions: ["force_push"],
+          allow_fix_pr: true,
+          allow_merge: false,
+          maintainer_calibration: [],
+        },
+        items: [
+          {
+            ref: "#91286",
+            kind: "pull_request",
+            state: "open",
+            title: "fix(cron): repair timer behavior",
+            labels: ["clawsweeper:automerge"],
+            updated_at: "2026-06-15T10:00:00Z",
+            security_sensitive: false,
+          },
+        ],
+      },
+    },
+  );
+  fs.rmSync(path.join(dir, "job.md"));
+
+  const result = review(dir);
+
+  assert.equal(result.status, 0, result.stdout || result.stderr);
+  assert.match(result.stdout, /"status": "passed"/);
+
+  const artifactPath = path.join(dir, "result.json");
+  const mismatchedArtifact = JSON.parse(fs.readFileSync(artifactPath, "utf8"));
+  mismatchedArtifact.fix_artifact.source_prs = ["https://github.com/openclaw/openclaw/pull/91287"];
+  fs.writeFileSync(artifactPath, `${JSON.stringify(mismatchedArtifact, null, 2)}\n`);
+
+  const mismatch = review(dir);
+
+  assert.notEqual(mismatch.status, 0);
+  assert.match(mismatch.stdout, /adopted automerge repair source must be the canonical PR: #91286/);
+
+  mismatchedArtifact.fix_artifact.source_prs = ["https://github.com/openclaw/openclaw/pull/91286"];
+  fs.writeFileSync(artifactPath, `${JSON.stringify(mismatchedArtifact, null, 2)}\n`);
+  const planPath = path.join(dir, "cluster-plan.json");
+  const unhydratedPlan = JSON.parse(fs.readFileSync(planPath, "utf8"));
+  unhydratedPlan.items = [];
+  fs.writeFileSync(planPath, `${JSON.stringify(unhydratedPlan, null, 2)}\n`);
+
+  const unhydrated = review(dir);
+
+  assert.notEqual(unhydrated.status, 0);
+  assert.match(unhydrated.stdout, /#91286 adopted automerge repair source was not hydrated in preflight/);
+});
+
 test("review-results rejects close actions targeting risk-labeled preflight PRs", () => {
   for (const label of ["merge-risk: availability", "clawsweeper:automerge"]) {
     const dir = makeResultDir(


### PR DESCRIPTION
## Summary
- allow the ClawSweeper automerge marker only for the router-adopted canonical PR
- preserve the marker source and canonical target in archived job-policy snapshots
- reject redirected or unhydrated repair artifacts; merge, close, risk, and security gates remain unchanged

## Verification
- `npm test`
- `node --test test/execute-fix-artifact.test.mjs test/review-results.test.mjs test/plan-cluster.test.mjs`
- `npm run validate`