### PR TITLE
chore: queue guarded automerge repairs

### DIFF
--- a/jobs/openclaw/inbox/automerge-openclaw-openclaw-95084.md
+++ b/jobs/openclaw/inbox/automerge-openclaw-openclaw-95084.md
@@ -1,0 +1,46 @@
+---
+repo: openclaw/openclaw
+cluster_id: automerge-openclaw-openclaw-95084
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - fix
+  - raise_pr
+blocked_actions:
+  - close
+  - merge
+require_human_for:
+  - close
+  - merge
+canonical:
+  - #95084
+candidates:
+  - #95084
+cluster_refs:
+  - #95084
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: clownfish/automerge-openclaw-openclaw-95084
+source: pr_automerge
+---
+
+# Clownfish automerge repair candidate
+
+Maintainer opted #95084 into Clownfish automerge.
+
+Source PR: https://github.com/openclaw/openclaw/pull/95084
+Title: fix(googlechat): sanitize internal tool-trace lines from outbound text
+
+Clownfish should use this job only for the bounded ClawSweeper review/fix loop:
+
+- If ClawSweeper requests changes, returns `needs-human`, or finds failing checks/rebase work, and the PR branch is safe to update, emit a fix artifact with `repair_strategy: "repair_contributor_branch"` and `source_prs: ["https://github.com/openclaw/openclaw/pull/95084"]`.
+- If the PR branch cannot be safely updated, emit a narrow credited replacement only when the artifact can preserve the original contributor credit; otherwise return `needs_human`.
+- Do not merge, close, or bypass review gates from the worker. The comment router owns final merge only after a passing ClawSweeper verdict for the exact current head.
+- Keep repair scope limited to actionable ClawSweeper findings, failing relevant checks, and required review feedback on this PR.

--- a/jobs/openclaw/inbox/automerge-openclaw-openclaw-95278.md
+++ b/jobs/openclaw/inbox/automerge-openclaw-openclaw-95278.md
@@ -1,0 +1,46 @@
+---
+repo: openclaw/openclaw
+cluster_id: automerge-openclaw-openclaw-95278
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - fix
+  - raise_pr
+blocked_actions:
+  - close
+  - merge
+require_human_for:
+  - close
+  - merge
+canonical:
+  - #95278
+candidates:
+  - #95278
+cluster_refs:
+  - #95278
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: clownfish/automerge-openclaw-openclaw-95278
+source: pr_automerge
+---
+
+# Clownfish automerge repair candidate
+
+Maintainer opted #95278 into Clownfish automerge.
+
+Source PR: https://github.com/openclaw/openclaw/pull/95278
+Title: Avoid copying process.env in ingress queue state DB opens
+
+Clownfish should use this job only for the bounded ClawSweeper review/fix loop:
+
+- If ClawSweeper requests changes, returns `needs-human`, or finds failing checks/rebase work, and the PR branch is safe to update, emit a fix artifact with `repair_strategy: "repair_contributor_branch"` and `source_prs: ["https://github.com/openclaw/openclaw/pull/95278"]`.
+- If the PR branch cannot be safely updated, emit a narrow credited replacement only when the artifact can preserve the original contributor credit; otherwise return `needs_human`.
+- Do not merge, close, or bypass review gates from the worker. The comment router owns final merge only after a passing ClawSweeper verdict for the exact current head.
+- Keep repair scope limited to actionable ClawSweeper findings, failing relevant checks, and required review feedback on this PR.

--- a/jobs/openclaw/inbox/automerge-openclaw-openclaw-95572.md
+++ b/jobs/openclaw/inbox/automerge-openclaw-openclaw-95572.md
@@ -1,0 +1,46 @@
+---
+repo: openclaw/openclaw
+cluster_id: automerge-openclaw-openclaw-95572
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - fix
+  - raise_pr
+blocked_actions:
+  - close
+  - merge
+require_human_for:
+  - close
+  - merge
+canonical:
+  - #95572
+candidates:
+  - #95572
+cluster_refs:
+  - #95572
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_unmerged_fix_close: false
+allow_post_merge_close: false
+require_fix_before_close: true
+security_policy: central_security_only
+security_sensitive: false
+target_branch: clownfish/automerge-openclaw-openclaw-95572
+source: pr_automerge
+---
+
+# Clownfish automerge repair candidate
+
+Maintainer opted #95572 into Clownfish automerge.
+
+Source PR: https://github.com/openclaw/openclaw/pull/95572
+Title: fix(agents): reject bind specs with extra colon segments
+
+Clownfish should use this job only for the bounded ClawSweeper review/fix loop:
+
+- If ClawSweeper requests changes, returns `needs-human`, or finds failing checks/rebase work, and the PR branch is safe to update, emit a fix artifact with `repair_strategy: "repair_contributor_branch"` and `source_prs: ["https://github.com/openclaw/openclaw/pull/95572"]`.
+- If the PR branch cannot be safely updated, emit a narrow credited replacement only when the artifact can preserve the original contributor credit; otherwise return `needs_human`.
+- Do not merge, close, or bypass review gates from the worker. The comment router owns final merge only after a passing ClawSweeper verdict for the exact current head.
+- Keep repair scope limited to actionable ClawSweeper findings, failing relevant checks, and required review feedback on this PR.


### PR DESCRIPTION
Adds isolated autonomous repair jobs for #95084, #95278, and #95572.

Each job permits only comment, label, and bounded fix/replacement work. Close and merge are explicitly blocked.

Validation: `npm run validate`; offline planner smoke for all three jobs; focused job-policy tests (125 passing); Codex review clean.