### PR TITLE
fix: allow gateway health repair path

### DIFF
--- a/jobs/openclaw/inbox/automerge-openclaw-openclaw-94687-repair.md
+++ b/jobs/openclaw/inbox/automerge-openclaw-openclaw-94687-repair.md
@@ -19,6 +19,7 @@ allowed_fix_files:
   - src/cli/gateway-port-option.ts
   - src/commands/gateway-status.ts
   - src/commands/gateway-status/helpers.ts
+  - src/commands/health.ts
   - src/gateway/call.ts
   - src/gateway/connection-details.ts
   - src/cli/gateway-cli/register.option-collisions.test.ts


### PR DESCRIPTION
Fixes the bounded repair job for https://github.com/openclaw/openclaw/pull/94687 after the executor correctly rejected an undeclared source path during the review fix.\n\nThe only code change adds src/commands/health.ts to allowed_fix_files. Merge and close remain blocked.