### PR TITLE
fix(ci): smooth Clownfish worker bursts

### DIFF
--- a/.github/workflows/cluster-batch.yml
+++ b/.github/workflows/cluster-batch.yml
@@ -20,7 +20,7 @@ on:
       runner:
         description: "Runner label for cluster planning/review work"
         required: true
-        default: ubuntu-latest
+        default: blacksmith-4vcpu-ubuntu-2404
         type: string
       execution_runner:
         description: "Reserved for parity with cluster-worker dispatch"
@@ -35,7 +35,7 @@ on:
       max_parallel:
         description: "Maximum concurrent matrix workers"
         required: true
-        default: "50"
+        default: "8"
         type: string
       hydrate_comments:
         description: "Override CLOWNFISH_HYDRATE_COMMENTS for this run"
@@ -93,9 +93,9 @@ jobs:
           CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
           INPUT_JOBS_JSON: ${{ inputs.jobs_json || '[]' }}
           INPUT_MODE: ${{ inputs.mode || 'plan' }}
-          INPUT_RUNNER: ${{ inputs.runner || 'ubuntu-latest' }}
+          INPUT_RUNNER: ${{ inputs.runner || 'blacksmith-4vcpu-ubuntu-2404' }}
           INPUT_MODEL: ${{ inputs.model || vars.CLOWNFISH_MODEL || 'gpt-5.5' }}
-          INPUT_MAX_PARALLEL: ${{ inputs.max_parallel || '50' }}
+          INPUT_MAX_PARALLEL: ${{ inputs.max_parallel || '8' }}
           INPUT_HYDRATE_COMMENTS: ${{ inputs.hydrate_comments || '0' }}
           INPUT_MAX_LINKED_REFS: ${{ inputs.max_linked_refs || '0' }}
           INPUT_MAX_COMMENTS_PER_ITEM: ${{ inputs.max_comments_per_item || '0' }}
@@ -110,9 +110,11 @@ jobs:
           const fromDispatch = process.env.EVENT_NAME === "repository_dispatch";
           const jobs = fromDispatch ? payload.jobs : JSON.parse(process.env.INPUT_JOBS_JSON || "[]");
           const mode = String(fromDispatch ? payload.mode ?? "plan" : process.env.INPUT_MODE ?? "plan");
-          const runner = String(fromDispatch ? payload.runner ?? "ubuntu-latest" : process.env.INPUT_RUNNER);
+          const runner = String(
+            fromDispatch ? payload.runner ?? "blacksmith-4vcpu-ubuntu-2404" : process.env.INPUT_RUNNER,
+          );
           const model = String(fromDispatch ? payload.model ?? "gpt-5.5" : process.env.INPUT_MODEL);
-          const maxParallel = Number(fromDispatch ? payload.max_parallel ?? 50 : process.env.INPUT_MAX_PARALLEL);
+          const maxParallel = Number(fromDispatch ? payload.max_parallel ?? 8 : process.env.INPUT_MAX_PARALLEL);
           const hydration = payload.hydration ?? {};
           const hydrateComments = String(
             fromDispatch ? hydration.hydrate_comments ?? payload.hydrate_comments ?? "0" : process.env.INPUT_HYDRATE_COMMENTS ?? "0",
@@ -134,8 +136,8 @@ jobs:
           if (mode !== "plan") throw new Error("cluster-batch only supports plan mode");
           if (!Array.isArray(jobs) || jobs.length === 0) throw new Error("jobs must be a non-empty JSON array");
           if (jobs.length > 256) throw new Error("jobs must fit GitHub's 256-cell matrix limit");
-          if (!Number.isInteger(maxParallel) || maxParallel < 1 || maxParallel > 200) {
-            throw new Error("max_parallel must be an integer from 1 to 200");
+          if (!Number.isInteger(maxParallel) || maxParallel < 1 || maxParallel > 32) {
+            throw new Error("max_parallel must be an integer from 1 to 32");
           }
           for (const value of [hydrateComments, maxLinkedRefs, maxCommentsPerItem, maxReviewCommentsPerPr]) {
             if (!/^\d+$/.test(value)) throw new Error(`invalid numeric override: ${value}`);

--- a/.github/workflows/cluster-worker.yml
+++ b/.github/workflows/cluster-worker.yml
@@ -29,7 +29,7 @@ on:
       runner:
         description: "Runner label for cluster planning/review work"
         required: true
-        default: ubuntu-latest
+        default: blacksmith-4vcpu-ubuntu-2404
         type: string
       execution_runner:
         description: "Runner label for fix/apply execution work"
@@ -111,7 +111,7 @@ jobs:
           CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
           INPUT_JOB: ${{ github.event.inputs.job || '' }}
           INPUT_MODE: ${{ github.event.inputs.mode || 'plan' }}
-          INPUT_RUNNER: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+          INPUT_RUNNER: ${{ github.event.inputs.runner || 'blacksmith-4vcpu-ubuntu-2404' }}
           INPUT_EXECUTION_RUNNER: ${{ github.event.inputs.execution_runner || 'blacksmith-16vcpu-ubuntu-2404' }}
           INPUT_MODEL: ${{ github.event.inputs.model || vars.CLOWNFISH_MODEL || 'gpt-5.5' }}
           INPUT_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
@@ -136,7 +136,9 @@ jobs:
           const jobPath = String(fromDispatch ? payload.job ?? "" : process.env.INPUT_JOB ?? "");
           const mode = String(fromDispatch ? payload.mode ?? "plan" : process.env.INPUT_MODE ?? "plan");
           const runner = String(
-            fromDispatch ? payload.runner ?? "ubuntu-latest" : process.env.INPUT_RUNNER,
+            fromDispatch
+              ? payload.runner ?? "blacksmith-4vcpu-ubuntu-2404"
+              : process.env.INPUT_RUNNER,
           );
           const executionRunner = String(
             fromDispatch

--- a/.github/workflows/comment-router.yml
+++ b/.github/workflows/comment-router.yml
@@ -31,7 +31,7 @@ on:
       runner:
         description: "Runner label for repair planning/review work"
         required: true
-        default: ubuntu-latest
+        default: blacksmith-4vcpu-ubuntu-2404
         type: string
       execution_runner:
         description: "Runner label for fix/apply execution work"
@@ -88,7 +88,7 @@ jobs:
           lookback_minutes="${{ github.event_name == 'workflow_dispatch' && inputs.lookback_minutes || vars.CLOWNFISH_COMMENT_LOOKBACK_MINUTES || '180' }}"
           since="${{ github.event_name == 'workflow_dispatch' && inputs.since || '' }}"
           max_comments="${{ github.event_name == 'workflow_dispatch' && inputs.max_comments || vars.CLOWNFISH_COMMENT_MAX_COMMENTS || '100' }}"
-          runner="${{ github.event_name == 'workflow_dispatch' && inputs.runner || vars.CLOWNFISH_WORKER_RUNNER || 'ubuntu-latest' }}"
+          runner="${{ github.event_name == 'workflow_dispatch' && inputs.runner || vars.CLOWNFISH_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
           execution_runner="${{ github.event_name == 'workflow_dispatch' && inputs.execution_runner || vars.CLOWNFISH_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}"
 
           args=(

--- a/.github/workflows/finalize-open-prs.yml
+++ b/.github/workflows/finalize-open-prs.yml
@@ -16,7 +16,7 @@ on:
       runner:
         description: "Runner label for cluster planning/review work"
         required: true
-        default: ubuntu-latest
+        default: blacksmith-4vcpu-ubuntu-2404
         type: string
       execution_runner:
         description: "Runner label for fix/apply execution work"

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -16,7 +16,7 @@ on:
       runner:
         description: "Runner label for retried cluster workers"
         required: true
-        default: ubuntu-latest
+        default: blacksmith-4vcpu-ubuntu-2404
         type: string
       execution_runner:
         description: "Runner label for retried fix/apply execution work"

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Merge is deliberately harder than closeout. A merge action must include `merge_p
 
 Replacement fix work uses a recoverable target branch named `clownfish/<cluster-id>`. The executor resumes that branch if it already exists and pushes checkpoint commits after agent edits and review-fix edits, adding `Co-authored-by` trailers for non-bot source PR authors when a contributor PR is replaced. It then opens or updates the PR only after validation and Codex `/review` pass. If `/review` still blocks the merge after retries, the run writes a blocked fix report and leaves the checkpoint branch recoverable instead of losing the patch.
 
-Runs for the same job path and mode are queued instead of running concurrently. The workflow uses Node 24, `ubuntu-latest` for cluster planning/review, and `blacksmith-16vcpu-ubuntu-2404` for fix/apply execution. Fix execution prepares the target checkout with Corepack and the target `pnpm` package manager before validation; the execution job caches Codex, npm, Corepack, and the target pnpm store. Fix validation is pinned to OpenClaw's fast changed-lane posture by default: `pnpm check:changed` plus diff checks are the hard local gate, and target validation commands normalize to `pnpm check:changed` unless `CLOWNFISH_TARGET_VALIDATION_MODE=strict` or `CLOWNFISH_STRICT_TARGET_VALIDATION=1` is explicitly set. Unrelated flaky main CI, broad `pnpm check`, full tests, live, docker, and e2e lanes do not block narrow ProjectClownfish fixes by default.
+Runs for the same job path and mode are queued instead of running concurrently. The workflow uses Node 24, `blacksmith-4vcpu-ubuntu-2404` for cluster planning/review, and `blacksmith-16vcpu-ubuntu-2404` for fix/apply execution. Fix execution prepares the target checkout with Corepack and the target `pnpm` package manager before validation; the execution job caches Codex, npm, Corepack, and the target pnpm store. Fix validation is pinned to OpenClaw's fast changed-lane posture by default: `pnpm check:changed` plus diff checks are the hard local gate, and target validation commands normalize to `pnpm check:changed` unless `CLOWNFISH_TARGET_VALIDATION_MODE=strict` or `CLOWNFISH_STRICT_TARGET_VALIDATION=1` is explicitly set. Unrelated flaky main CI, broad `pnpm check`, full tests, live, docker, and e2e lanes do not block narrow ProjectClownfish fixes by default.
 
 Full worker prompts, Codex transcripts, and raw artifacts stay in GitHub Actions. The committed ledger keeps only the cluster summary, run URL, action counts, apply outcomes, closed targets, and needs-human entries.
 
@@ -334,12 +334,12 @@ npm run import-gitcrawl -- --from-gitcrawl --limit 80 --mode autonomous \
   --allow-post-merge-close
 
 # Dispatch reviewed jobs. Dispatch, requeue, and self-heal refuse to exceed
-# 50 live cluster-worker runs by default; tune with CLOWNFISH_MAX_LIVE_WORKERS
+# 32 live cluster-worker runs by default; tune with CLOWNFISH_MAX_LIVE_WORKERS
 # or --max-live-workers. With --wait-for-capacity, dispatch can drain a larger
 # file list in capacity-sized waves instead of refusing the whole batch.
-CLOWNFISH_MAX_LIVE_WORKERS=50 npm run dispatch -- jobs/openclaw/inbox/cluster-example.md \
+CLOWNFISH_MAX_LIVE_WORKERS=32 npm run dispatch -- jobs/openclaw/inbox/cluster-example.md \
   --mode autonomous \
-  --runner ubuntu-latest \
+  --runner blacksmith-4vcpu-ubuntu-2404 \
   --execution-runner blacksmith-16vcpu-ubuntu-2404
 
 # Select a plan-only wave by total referenced issue/PR count without dispatching.
@@ -369,14 +369,14 @@ npm run dispatch -- --jobs-file /tmp/clownfish-plan-wave-all.txt \
   --mode plan \
   --dispatch-event repository-batch \
   --allow-app-token-auth \
-  --max-live-workers 200 \
-  --batch-max-parallel 100 \
+  --max-live-workers 32 \
+  --batch-max-parallel 8 \
   --batch-matrix-limit 200 \
   --hydrate-comments 0 \
   --max-linked-refs 0 \
   --max-comments-per-item 0 \
   --max-review-comments-per-pr 0 \
-  --runner ubuntu-latest \
+  --runner blacksmith-4vcpu-ubuntu-2404 \
   --execution-runner blacksmith-16vcpu-ubuntu-2404
 
 # Full open-PR inventory sweep from the local gitcrawl snapshot. Generate
@@ -389,8 +389,9 @@ npm run import-gitcrawl-pr-inventory -- \
   --existing-dir jobs/openclaw/inbox \
   --mode plan
 
-# Dispatch that full plan lane wide with lean hydration. This is intentionally
-# separate from write/apply dispatches.
+# Dispatch that full plan lane with lean hydration. Repository-batch admission
+# rejects waves whose aggregate matrix width exceeds 32 workers, so this
+# high-volume example uses one worker per batch and stays inside the cap.
 node scripts/queue-status.mjs \
   --plan-ref-limit 4000 \
   --write-missing-plan /tmp/clownfish-plan-wave-all.txt \
@@ -399,14 +400,14 @@ npm run dispatch -- --jobs-file /tmp/clownfish-plan-wave-all.txt \
   --mode plan \
   --dispatch-event repository-batch \
   --allow-app-token-auth \
-  --max-live-workers 200 \
-  --batch-max-parallel 100 \
+  --max-live-workers 32 \
+  --batch-max-parallel 1 \
   --batch-matrix-limit 200 \
   --hydrate-comments 0 \
   --max-linked-refs 0 \
   --max-comments-per-item 0 \
   --max-review-comments-per-pr 0 \
-  --runner ubuntu-latest \
+  --runner blacksmith-4vcpu-ubuntu-2404 \
   --execution-runner blacksmith-16vcpu-ubuntu-2404
 
 # Write/apply dispatches are deliberately capped separately. The default
@@ -420,7 +421,7 @@ npm run dispatch -- --jobs-file /tmp/clownfish-close-retry.txt \
   --batch-size 1 \
   --batch-delay-ms 120000 \
   --dispatch-concurrency 1 \
-  --runner ubuntu-latest \
+  --runner blacksmith-4vcpu-ubuntu-2404 \
   --execution-runner blacksmith-16vcpu-ubuntu-2404
 
 # Find explicitly recoverable, checkpointed active-inbox fix failures that have
@@ -435,7 +436,7 @@ npm run requeue -- 24947178021
 # write gates when the job is execute/autonomous, waits for the run to start,
 # then closes the gates.
 npm run requeue -- 24947178021 --execute --open-execute-window \
-  --runner ubuntu-latest \
+  --runner blacksmith-4vcpu-ubuntu-2404 \
   --execution-runner blacksmith-16vcpu-ubuntu-2404
 
 # Execute a reviewed fix artifact locally. Requires both execution gates and a write token.
@@ -481,8 +482,8 @@ CLOWNFISH_ALLOW_EXECUTE=1 npm run tag-clownfish -- --live --apply
 # Retry failed jobs once. This briefly opens the execution gate, waits for the
 # dispatched workers to start, records the self-heal ledger, and closes the gate.
 npm run self-heal -- --execute --open-execute-window --max-jobs 5 \
-  --max-live-workers 50 \
-  --runner ubuntu-latest \
+  --max-live-workers 32 \
+  --runner blacksmith-4vcpu-ubuntu-2404 \
   --execution-runner blacksmith-16vcpu-ubuntu-2404
 ```
 
@@ -507,7 +508,7 @@ The workflow needs:
 - merge is separately gated by `CLOWNFISH_ALLOW_MERGE`; automerge additionally requires `CLOWNFISH_ALLOW_AUTOMERGE`; both default to `0`, and merge-ready PRs are labeled `clownfish:human-review` and `clownfish:merge-ready` for a maintainer to merge manually
 - optional `CLOWNFISH_CODEX_CLI_VERSION` variable to pin and refresh the cached Codex CLI
 - optional `CLOWNFISH_MODEL` override for dispatch scripts; default Codex model is `gpt-5.5`
-- optional `CLOWNFISH_MAX_LIVE_WORKERS` variable for dispatch/requeue/self-heal worker fan-out; default is `50`
+- optional `CLOWNFISH_MAX_LIVE_WORKERS` variable for dispatch/requeue/self-heal worker fan-out; default is `32`
 - optional `CLOWNFISH_MAX_ACTIVE_PRS_PER_AREA` variable for replacement PR backpressure; default is `50` open Clownfish PRs per touched area, `0` disables the area cap, and common changelog/release-note files are ignored for this check
 - ClawSweeper commit-finding repair PRs are labeled `clownfish:commit-finding`
 - optional `CLOWNFISH_CODEX_TIMEOUT_MS`, `CLOWNFISH_FIX_CODEX_TIMEOUT_MS`, and `CLOWNFISH_FIX_STEP_TIMEOUT_MS` variables; worker planning defaults to 30 minutes, while fix execution defaults to a 20 minute Codex budget inside a 40 minute executor step so timeout artifacts can be written

--- a/scripts/comment-router.mjs
+++ b/scripts/comment-router.mjs
@@ -63,7 +63,9 @@ const clownfishRepo = String(args["clownfish-repo"] ?? process.env.CLOWNFISH_REP
 const workflow = String(args.workflow ?? process.env.CLOWNFISH_COMMENT_WORKFLOW ?? "cluster-worker.yml");
 const clawsweeperRepo = String(args["clawsweeper-repo"] ?? process.env.CLOWNFISH_CLAWSWEEPER_REPO ?? "openclaw/clawsweeper");
 const clawsweeperWorkflow = String(args["clawsweeper-workflow"] ?? process.env.CLOWNFISH_CLAWSWEEPER_WORKFLOW ?? "sweep.yml");
-const runner = String(args.runner ?? process.env.CLOWNFISH_WORKER_RUNNER ?? "ubuntu-latest");
+const runner = String(
+  args.runner ?? process.env.CLOWNFISH_WORKER_RUNNER ?? "blacksmith-4vcpu-ubuntu-2404",
+);
 const executionRunner = String(
   args["execution-runner"] ?? args.execution_runner ?? process.env.CLOWNFISH_EXECUTION_RUNNER ?? "blacksmith-16vcpu-ubuntu-2404",
 );

--- a/scripts/dispatch-jobs.mjs
+++ b/scripts/dispatch-jobs.mjs
@@ -15,7 +15,7 @@ import {
 } from "./lib.mjs";
 
 const args = parseArgs(process.argv.slice(2));
-const defaultRunner = process.env.CLOWNFISH_WORKER_RUNNER ?? "ubuntu-latest";
+const defaultRunner = process.env.CLOWNFISH_WORKER_RUNNER ?? "blacksmith-4vcpu-ubuntu-2404";
 const defaultExecutionRunner = process.env.CLOWNFISH_EXECUTION_RUNNER ?? "blacksmith-16vcpu-ubuntu-2404";
 const mode = args.mode ?? "plan";
 const runner = args.runner ?? defaultRunner;
@@ -40,6 +40,7 @@ const batchWorkflow = String(
 const batchEventType = String(
   args["batch-event-type"] ?? args.batch_event_type ?? process.env.CLOWNFISH_BATCH_EVENT_TYPE ?? "projectclownfish_batch",
 );
+const BATCH_MAX_PARALLEL_CAP = 32;
 const workerEventType = String(
   args["worker-event-type"] ??
     args.worker_event_type ??
@@ -47,7 +48,7 @@ const workerEventType = String(
     "projectclownfish_worker",
 );
 const batchMaxParallel = positiveNumberArg(
-  args["batch-max-parallel"] ?? args.batch_max_parallel ?? process.env.CLOWNFISH_BATCH_MAX_PARALLEL ?? 50,
+  args["batch-max-parallel"] ?? args.batch_max_parallel ?? process.env.CLOWNFISH_BATCH_MAX_PARALLEL ?? 8,
   "batch-max-parallel",
 );
 const batchMatrixLimit = positiveNumberArg(
@@ -131,7 +132,7 @@ const headSha = currentHeadSha();
 
 if (files.length === 0) {
   console.error(
-    "usage: node scripts/dispatch-jobs.mjs <job.md> [...] [--jobs-file path] [--mode plan|execute|autonomous] [--runner label] [--execution-runner label] [--model model] [--gh-bin ghx] [--max-live-workers 50] [--wait-for-capacity] [--batch-size N] [--batch-delay-ms N] [--dispatch-limit N] [--dispatch-concurrency N] [--dispatch-event workflow|repository-worker|repository-batch] [--batch-max-parallel N] [--publish-backlog-threshold 25] [--publish-backlog-wait-ms 600000] [--publish-backlog-poll-ms 30000] [--hydrate-comments 0|1] [--max-linked-refs N] [--dry-run 0|1] [--allow-app-token-auth] [--skip-token-secret-check]",
+    "usage: node scripts/dispatch-jobs.mjs <job.md> [...] [--jobs-file path] [--mode plan|execute|autonomous] [--runner label] [--execution-runner label] [--model model] [--gh-bin ghx] [--max-live-workers 32] [--wait-for-capacity] [--batch-size N] [--batch-delay-ms N] [--dispatch-limit N] [--dispatch-concurrency N] [--dispatch-event workflow|repository-worker|repository-batch] [--batch-max-parallel N] [--publish-backlog-threshold 25] [--publish-backlog-wait-ms 600000] [--publish-backlog-poll-ms 30000] [--hydrate-comments 0|1] [--max-linked-refs N] [--dry-run 0|1] [--allow-app-token-auth] [--skip-token-secret-check]",
   );
   process.exit(2);
 }
@@ -166,6 +167,10 @@ if (repositoryBatchDispatch && dispatchBatchSize > 0) {
 }
 if (repositoryWorkerDispatch && ref && ref !== "main") {
   console.error("repository-worker dispatch only supports --ref main because repository_dispatch runs the default-branch workflow");
+  process.exit(2);
+}
+if (repositoryBatchDispatch && batchMaxParallel > BATCH_MAX_PARALLEL_CAP) {
+  console.error(`--batch-max-parallel cannot exceed ${BATCH_MAX_PARALLEL_CAP}`);
   process.exit(2);
 }
 if (repositoryBatchDispatch && batchMaxParallel > maxLiveWorkers) {
@@ -229,12 +234,17 @@ if (!failed) {
 
 if (!failed) {
   const requested = repositoryBatchDispatch
-    ? Math.ceil(jobsToDispatch.length / batchMatrixLimit)
+    ? Math.ceil(jobsToDispatch.length / batchMatrixLimit) * batchMaxParallel
     : throttledDispatch
       ? Math.min(jobsToDispatch.length, 1)
       : jobsToDispatch.length;
   const capacityOptions = { repo, workflow: dispatchWorkflow, requested, maxLiveWorkers, ghCommand };
   const capacity = throttledDispatch ? waitForLiveWorkerCapacity(capacityOptions) : assertLiveWorkerCapacity(capacityOptions);
+  if (repositoryBatchDispatch && capacity.active > 0) {
+    throw new Error(
+      `refusing repository-batch dispatch: ${capacity.active} active ${batchWorkflow} run(s) already occupy unknown matrix capacity; retry after they finish`,
+    );
+  }
   console.log(
     `live worker capacity: ${capacity.active}/${capacity.max_live_workers} active; dispatching ${jobsToDispatch.length} ${dispatchWorkflow} job(s)`,
   );

--- a/scripts/finalize-open-prs.mjs
+++ b/scripts/finalize-open-prs.mjs
@@ -37,7 +37,9 @@ const writeReport = Boolean(args["write-report"]);
 const execute = Boolean(args.execute);
 const dispatchRepairs = Boolean(args["dispatch-repairs"] || args.dispatch || execute);
 const workflow = String(args.workflow ?? process.env.CLOWNFISH_FINALIZER_WORKFLOW ?? "cluster-worker.yml");
-const runner = String(args.runner ?? process.env.CLOWNFISH_WORKER_RUNNER ?? "ubuntu-latest");
+const runner = String(
+  args.runner ?? process.env.CLOWNFISH_WORKER_RUNNER ?? "blacksmith-4vcpu-ubuntu-2404",
+);
 const executionRunner = String(
   args["execution-runner"] ?? args.execution_runner ?? process.env.CLOWNFISH_EXECUTION_RUNNER ?? "blacksmith-16vcpu-ubuntu-2404",
 );

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -10,7 +10,7 @@ const STRUCTURED_SECURITY_MARKER_PATTERN =
   /<!--\s*clawsweeper-(?:security|route|verdict)\s*:\s*(?:security|security-sensitive|sensitive|route-security|central-security)\b[^>]*-->/i;
 const PROMPT_ARTIFACT_MAX_CHARS = Number(process.env.CLOWNFISH_PROMPT_ARTIFACT_MAX_CHARS ?? 320_000);
 const PROMPT_STRING_MAX_CHARS = Number(process.env.CLOWNFISH_PROMPT_STRING_MAX_CHARS ?? 700);
-const DEFAULT_MAX_LIVE_WORKERS = 50;
+const DEFAULT_MAX_LIVE_WORKERS = 32;
 const DEFAULT_CAPACITY_POLL_MS = 30_000;
 const DEFAULT_CAPACITY_TIMEOUT_MS = 30 * 60 * 1000;
 const ACTIVE_WORKFLOW_STATUSES = ["queued", "in_progress", "waiting", "requested", "pending"];

--- a/scripts/requeue-job.mjs
+++ b/scripts/requeue-job.mjs
@@ -17,7 +17,7 @@ import { restoreGateValue } from "./gate-restore.mjs";
 
 const DEFAULT_REPO = currentProjectRepo();
 const DEFAULT_WORKFLOW = "cluster-worker.yml";
-const DEFAULT_RUNNER = process.env.CLOWNFISH_WORKER_RUNNER ?? "ubuntu-latest";
+const DEFAULT_RUNNER = process.env.CLOWNFISH_WORKER_RUNNER ?? "blacksmith-4vcpu-ubuntu-2404";
 const DEFAULT_EXECUTION_RUNNER = process.env.CLOWNFISH_EXECUTION_RUNNER ?? "blacksmith-16vcpu-ubuntu-2404";
 const DEFAULT_OBSERVE_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_GATE_CAPTURE_TIMEOUT_MS = 5 * 60 * 1000;

--- a/scripts/self-heal-failed-runs.mjs
+++ b/scripts/self-heal-failed-runs.mjs
@@ -17,7 +17,7 @@ import { isActiveInboxJob, selectRetryableFailedRuns } from "./self-heal-selecti
 
 const DEFAULT_REPO = currentProjectRepo();
 const DEFAULT_WORKFLOW = "cluster-worker.yml";
-const DEFAULT_RUNNER = process.env.CLOWNFISH_WORKER_RUNNER ?? "ubuntu-latest";
+const DEFAULT_RUNNER = process.env.CLOWNFISH_WORKER_RUNNER ?? "blacksmith-4vcpu-ubuntu-2404";
 const DEFAULT_EXECUTION_RUNNER = process.env.CLOWNFISH_EXECUTION_RUNNER ?? "blacksmith-16vcpu-ubuntu-2404";
 const QUEUED_STATUSES = new Set(["queued", "requested", "waiting", "pending"]);
 

--- a/test/app-token-auth.test.mjs
+++ b/test/app-token-auth.test.mjs
@@ -449,7 +449,7 @@ if (args[0] === "workflow" && args[1] === "run") {
     for (const expected of [
       "jobs_json=[\\"jobs/openclaw/inbox/cluster-example.md\\",\\"jobs/openclaw/outbox/finalized/gitcrawl-1109-intake-20260621.md\\"]",
       "mode=plan",
-      "runner=ubuntu-latest",
+      "runner=blacksmith-4vcpu-ubuntu-2404",
       "execution_runner=blacksmith-16vcpu-ubuntu-2404",
       "model=gpt-5.5",
       "max_parallel=2",
@@ -472,7 +472,7 @@ if (args[0] === "workflow" && args[1] === "run") {
     for (const expected of [
       "job=jobs/openclaw/inbox/cluster-example.md",
       "mode=autonomous",
-      "runner=ubuntu-latest",
+      "runner=blacksmith-4vcpu-ubuntu-2404",
       "execution_runner=blacksmith-16vcpu-ubuntu-2404",
       "model=gpt-5.5",
       "dry_run=true",
@@ -514,7 +514,7 @@ if (args[0] === "api" && args.includes("repos/openclaw/clownfish/dispatches")) {
     const expected = [
       ["event_type", payload.event_type, "projectclownfish_batch"],
       ["mode", client.mode, "plan"],
-      ["runner", client.runner, "ubuntu-latest"],
+      ["runner", client.runner, "blacksmith-4vcpu-ubuntu-2404"],
       ["execution_runner", client.execution_runner, "blacksmith-16vcpu-ubuntu-2404"],
       ["model", client.model, "gpt-5.5"],
       ["max_parallel", String(client.max_parallel), "2"],
@@ -535,7 +535,7 @@ if (args[0] === "api" && args.includes("repos/openclaw/clownfish/dispatches")) {
       ["event_type", payload.event_type, "projectclownfish_worker"],
       ["job", client.job, "jobs/openclaw/inbox/cluster-example.md"],
       ["mode", client.mode, "autonomous"],
-      ["runner", client.runner, "ubuntu-latest"],
+      ["runner", client.runner, "blacksmith-4vcpu-ubuntu-2404"],
       ["execution_runner", client.execution_runner, "blacksmith-16vcpu-ubuntu-2404"],
       ["model", client.model, "gpt-5.5"],
       ["dry_run", String(client.dry_run), "true"],


### PR DESCRIPTION
## Summary
- default planning/review workers to Blacksmith 4-vCPU runners
- lower cluster-batch matrix fan-out to 8 and cap repository-batch waves by aggregate worker width
- serialize normal CI defaults in the worker scripts and keep the batch CLI/workflow validation aligned

## Verification
- `npm test` (244 passed)
- `node --test test/app-token-auth.test.mjs` (11 passed)
- `node --check scripts/dispatch-jobs.mjs`
- Ruby YAML parse for changed workflows
- `git diff --check`
- local autoreview clean

Repository-batch admission now refuses overlapping batch runs whose matrix width cannot be inferred and refuses waves larger than the 32-worker cap, avoiding bursty registration spikes.