### PR TITLE
chore: add needs-proof closeout wave

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T065936-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T065936-001.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T065936-001
+mode: autonomous
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#63456"
+  - "#91609"
+  - "#40392"
+  - "#41275"
+  - "#43659"
+cluster_refs:
+  - "#63456"
+  - "#91609"
+  - "#40392"
+  - "#41275"
+  - "#43659"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T06:59:36.080Z; bucket=needs_proof; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 1
+
+This is a high-volume live inventory shard over open pull requests, including previously represented PRs being refreshed against live GitHub state.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #63456 Scope workspace guidance to coding contexts
+
+- bucket: needs_proof
+- author: ImLukeF
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, maintainer, size: XL, rating: unranked krab, status: needs proof
+- live updated: 2026-06-14T14:06:27Z
+- live url: https://github.com/openclaw/openclaw/pull/63456
+
+### #91609 fix(docs): make check:docs work in native PowerShell on Windows
+
+- bucket: needs_proof
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-15T15:03:01Z
+- live url: https://github.com/openclaw/openclaw/pull/91609
+
+### #40392 config: use datetime suffix for config backup files instead of numeric rotation
+
+- bucket: needs_proof
+- author: davidxcli
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-16T04:24:54Z
+- live url: https://github.com/openclaw/openclaw/pull/40392
+
+### #41275 fix(cron): allow timeoutSeconds: 0 for no-timeout mode
+
+- bucket: needs_proof
+- author: JonathanJing
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-16T08:05:17Z
+- live url: https://github.com/openclaw/openclaw/pull/41275
+
+### #43659 fix: copilot token cache ignores profile rotation on rate limit
+
+- bucket: needs_proof
+- author: faishalwahiduddin
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-16T08:07:34Z
+- live url: https://github.com/openclaw/openclaw/pull/43659

--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T065936-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T065936-002.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T065936-002
+mode: autonomous
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#46895"
+  - "#48396"
+  - "#49750"
+  - "#48278"
+  - "#50454"
+cluster_refs:
+  - "#46895"
+  - "#48396"
+  - "#49750"
+  - "#48278"
+  - "#50454"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T06:59:36.082Z; bucket=needs_proof; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 2
+
+This is a high-volume live inventory shard over open pull requests, including previously represented PRs being refreshed against live GitHub state.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #46895 fix(slash): handle /model status locally[AI-assisted]#46894
+
+- bucket: needs_proof
+- author: xiaoHEI-312
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-16T08:12:11Z
+- live url: https://github.com/openclaw/openclaw/pull/46895
+
+### #48396 feat(ui): add message preview to session list
+
+- bucket: needs_proof
+- author: SiriuSM00N
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-16T11:03:51Z
+- live url: https://github.com/openclaw/openclaw/pull/48396
+
+### #49750 fix(sessions): preserve slack thread routing for A2A sessions
+
+- bucket: needs_proof
+- author: qqchang2nd
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-16T11:05:43Z
+- live url: https://github.com/openclaw/openclaw/pull/49750
+
+### #48278 Config: scaffold compaction loop guard settings
+
+- bucket: needs_proof
+- author: xz0831
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-16T12:44:06Z
+- live url: https://github.com/openclaw/openclaw/pull/48278
+
+### #50454 fix: use explicit agent workspace when writing transcript headers
+
+- bucket: needs_proof
+- author: eggyrooch-blip
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-16T14:37:46Z
+- live url: https://github.com/openclaw/openclaw/pull/50454

--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T065936-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T065936-003.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T065936-003
+mode: autonomous
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#55861"
+  - "#55390"
+  - "#67420"
+  - "#77445"
+  - "#47589"
+cluster_refs:
+  - "#55861"
+  - "#55390"
+  - "#67420"
+  - "#77445"
+  - "#47589"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T06:59:36.082Z; bucket=needs_proof; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 3
+
+This is a high-volume live inventory shard over open pull requests, including previously represented PRs being refreshed against live GitHub state.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #55861 fix(ui): prevent collapsed sidebar overlap in control UI
+
+- bucket: needs_proof
+- author: betamod
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-16T18:06:22Z
+- live url: https://github.com/openclaw/openclaw/pull/55861
+
+### #55390 WIP feat(cli): sync local schema artifacts on startup
+
+- bucket: needs_proof
+- author: kvokka
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-16T20:25:47Z
+- live url: https://github.com/openclaw/openclaw/pull/55390
+
+### #67420 feat(memory): per-agent dreaming control
+
+- bucket: needs_proof
+- author: aaronwong1989
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: availability, status: needs proof
+- live updated: 2026-06-17T00:25:24Z
+- live url: https://github.com/openclaw/openclaw/pull/67420
+
+### #77445 fix(agents): persist delivered assistant text [AI]
+
+- bucket: needs_proof
+- author: sercada
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: M, proof: supplied, P2, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-17T02:43:52Z
+- live url: https://github.com/openclaw/openclaw/pull/77445
+
+### #47589 fix(reminder-guard): reduce false positives on memory-related statements
+
+- bucket: needs_proof
+- author: moltpill
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, mantis: telegram-visible-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-17T04:58:03Z
+- live url: https://github.com/openclaw/openclaw/pull/47589

--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T065936-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T065936-004.md
@@ -1,0 +1,109 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T065936-004
+mode: autonomous
+allowed_actions:
+  - "comment"
+  - "label"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "green_checks"
+  - "focused_bug_fix"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#51926"
+  - "#43953"
+  - "#43938"
+  - "#81360"
+  - "#50250"
+cluster_refs:
+  - "#51926"
+  - "#43953"
+  - "#43938"
+  - "#81360"
+  - "#50250"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T06:59:36.083Z; bucket=needs_proof; only safe close/comment/label actions are allowed."
+---
+
+# Live PR Inventory 4
+
+This is a high-volume live inventory shard over open pull requests, including previously represented PRs being refreshed against live GitHub state.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.
+
+## Inventory
+
+### #51926 Agents: default nodes describe to current node
+
+- bucket: needs_proof
+- author: Liuhaai
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-17T04:58:28Z
+- live url: https://github.com/openclaw/openclaw/pull/51926
+
+### #43953 feat(feishu): pass through form_value, input_value, option(s) from card actions
+
+- bucket: needs_proof
+- author: Edison94hu
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: feishu, size: S, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-17T23:18:29Z
+- live url: https://github.com/openclaw/openclaw/pull/43953
+
+### #43938 fix(gateway): use account-scoped reload for channel account changes
+
+- bucket: needs_proof
+- author: coppynight
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: message-delivery, merge-risk: availability, status: needs proof
+- live updated: 2026-06-18T07:09:32Z
+- live url: https://github.com/openclaw/openclaw/pull/43938
+
+### #81360 runtime: suppress lost-context subagent raw output
+
+- bucket: needs_proof
+- author: glfruit
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, P3, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-18T23:26:54Z
+- live url: https://github.com/openclaw/openclaw/pull/81360
+
+### #50250 fix(health): show gateway probe duration in text output
+
+- bucket: needs_proof
+- author: JonathanJing
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-19T08:40:32Z
+- live url: https://github.com/openclaw/openclaw/pull/50250


### PR DESCRIPTION
Adds four guarded autonomous triage jobs for 20 fresh open PRs marked needs-proof. The jobs may only comment or close under the conservative low-signal policy; merge, repair, labels, force-push, bypasses, and security handling remain blocked.