### PR TITLE
feat: import live low-signal PR sweeps

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T080152-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T080152-001.md
@@ -1,0 +1,111 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T080152-001
+mode: autonomous
+triage_policy: low_signal_prs
+allowed_actions:
+  - "comment"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+  - "label"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "focused_bug_fix"
+  - "green_checks"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#46895"
+  - "#55390"
+  - "#43938"
+  - "#67623"
+  - "#70056"
+cluster_refs:
+  - "#46895"
+  - "#55390"
+  - "#43938"
+  - "#67623"
+  - "#70056"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_low_signal_pr_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "No canonical is needed; this is an opt-in low-signal PR cleanup sweep generated from live GitHub inventory."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T08:01:52.686Z; bucket=low_signal_candidate; low-signal candidates were prefiltered for stale unassigned PRs. Maintainer comments and reviews are still rechecked by the worker and applicator before close."
+---
+
+# Low-Signal PR Sweep 1
+
+This is an opt-in low-signal cleanup shard over stale open pull requests from live GitHub inventory.
+
+## Goal
+
+Use `instructions/low-signal-prs.md`. Review only the listed open pull requests. Emit `close_low_signal` with `classification: "low_signal"` only when the PR is boringly clear under the low-signal policy and live GitHub state still has no maintainer signal. Otherwise emit `needs_human`, `keep_related`, or `keep_independent`. The deterministic applicator will re-fetch live state, reject non-PRs, reject maintainer-authored/reviewed/commented/assigned PRs, and close only planned `close_low_signal` actions.
+
+## Inventory
+
+### #46895 fix(slash): handle /model status locally[AI-assisted]#46894
+
+- bucket: low_signal_candidate
+- author: xiaoHEI-312
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-16T08:12:11Z
+- live url: https://github.com/openclaw/openclaw/pull/46895
+
+### #55390 WIP feat(cli): sync local schema artifacts on startup
+
+- bucket: low_signal_candidate
+- author: kvokka
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, size: M, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-16T20:25:47Z
+- live url: https://github.com/openclaw/openclaw/pull/55390
+
+### #43938 fix(gateway): use account-scoped reload for channel account changes
+
+- bucket: low_signal_candidate
+- author: coppynight
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: message-delivery, merge-risk: availability, status: needs proof
+- live updated: 2026-06-18T07:09:32Z
+- live url: https://github.com/openclaw/openclaw/pull/43938
+
+### #67623 fix: Change the scope of the variable SANDBOX_BACKEND_FACTORIES from
+
+- bucket: low_signal_candidate
+- author: earon-han
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, triage: blank-template, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-20T14:54:56Z
+- live url: https://github.com/openclaw/openclaw/pull/67623
+
+### #70056 fix(gateway): clean up store and set running=false on stop timeout
+
+- bucket: low_signal_candidate
+- author: garnetlyx
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, triage: refactor-only, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, merge-risk: availability, status: needs proof
+- live updated: 2026-06-20T17:17:25Z
+- live url: https://github.com/openclaw/openclaw/pull/70056

--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T080152-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T080152-002.md
@@ -1,0 +1,111 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T080152-002
+mode: autonomous
+triage_policy: low_signal_prs
+allowed_actions:
+  - "comment"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+  - "label"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "focused_bug_fix"
+  - "green_checks"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#85793"
+  - "#77550"
+  - "#85293"
+  - "#87739"
+  - "#87793"
+cluster_refs:
+  - "#85793"
+  - "#77550"
+  - "#85293"
+  - "#87739"
+  - "#87793"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_low_signal_pr_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "No canonical is needed; this is an opt-in low-signal PR cleanup sweep generated from live GitHub inventory."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T08:01:52.687Z; bucket=low_signal_candidate; low-signal candidates were prefiltered for stale unassigned PRs. Maintainer comments and reviews are still rechecked by the worker and applicator before close."
+---
+
+# Low-Signal PR Sweep 2
+
+This is an opt-in low-signal cleanup shard over stale open pull requests from live GitHub inventory.
+
+## Goal
+
+Use `instructions/low-signal-prs.md`. Review only the listed open pull requests. Emit `close_low_signal` with `classification: "low_signal"` only when the PR is boringly clear under the low-signal policy and live GitHub state still has no maintainer signal. Otherwise emit `needs_human`, `keep_related`, or `keep_independent`. The deterministic applicator will re-fetch live state, reject non-PRs, reject maintainer-authored/reviewed/commented/assigned PRs, and close only planned `close_low_signal` actions.
+
+## Inventory
+
+### #85793 docs(github): make post-install restart explicit
+
+- bucket: low_signal_candidate
+- author: nielskaspers
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-21T05:43:50Z
+- live url: https://github.com/openclaw/openclaw/pull/85793
+
+### #77550 fix(ui): format structured tool results instead of "[object Object]
+
+- bucket: low_signal_candidate
+- author: davidmartin3
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, triage: refactor-only, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof, triage: needs-pr-context
+- live updated: 2026-06-21T06:22:21Z
+- live url: https://github.com/openclaw/openclaw/pull/77550
+
+### #85293 fix(codex): prevent isolated app-server process leaks on timeout
+
+- bucket: low_signal_candidate
+- author: shivam-9090
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: codex, triage: refactor-only, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: availability, status: needs proof
+- live updated: 2026-06-21T06:25:04Z
+- live url: https://github.com/openclaw/openclaw/pull/85293
+
+### #87739 Telegram: keep long DM turns alive through progress previews
+
+- bucket: low_signal_candidate
+- author: dredozubov
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: telegram, size: XL, triage: mock-only-proof, mantis: telegram-visible-proof, P1, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-21T06:30:56Z
+- live url: https://github.com/openclaw/openclaw/pull/87739
+
+### #87793 fix(codex): clarify unsafe app-server completion stalls
+
+- bucket: low_signal_candidate
+- author: slatem
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: codex, triage: needs-real-behavior-proof, P2, rating: unranked krab, status: needs proof
+- live updated: 2026-06-21T06:31:54Z
+- live url: https://github.com/openclaw/openclaw/pull/87793

--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T080152-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T080152-003.md
@@ -1,0 +1,111 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T080152-003
+mode: autonomous
+triage_policy: low_signal_prs
+allowed_actions:
+  - "comment"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+  - "label"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "focused_bug_fix"
+  - "green_checks"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#87592"
+  - "#88738"
+  - "#88850"
+  - "#90227"
+  - "#54652"
+cluster_refs:
+  - "#87592"
+  - "#88738"
+  - "#88850"
+  - "#90227"
+  - "#54652"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_low_signal_pr_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "No canonical is needed; this is an opt-in low-signal PR cleanup sweep generated from live GitHub inventory."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T08:01:52.688Z; bucket=low_signal_candidate; low-signal candidates were prefiltered for stale unassigned PRs. Maintainer comments and reviews are still rechecked by the worker and applicator before close."
+---
+
+# Low-Signal PR Sweep 3
+
+This is an opt-in low-signal cleanup shard over stale open pull requests from live GitHub inventory.
+
+## Goal
+
+Use `instructions/low-signal-prs.md`. Review only the listed open pull requests. Emit `close_low_signal` with `classification: "low_signal"` only when the PR is boringly clear under the low-signal policy and live GitHub state still has no maintainer signal. Otherwise emit `needs_human`, `keep_related`, or `keep_independent`. The deterministic applicator will re-fetch live state, reject non-PRs, reject maintainer-authored/reviewed/commented/assigned PRs, and close only planned `close_low_signal` actions.
+
+## Inventory
+
+### #87592 feat(sidebar): add Session Reset button alongside New Session
+
+- bucket: low_signal_candidate
+- author: apoapostolov
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, triage: needs-real-behavior-proof, P3, rating: unranked krab, merge-risk: session-state, status: needs proof
+- live updated: 2026-06-21T07:18:14Z
+- live url: https://github.com/openclaw/openclaw/pull/87592
+
+### #88738 docs: document wacli message verification
+
+- bucket: low_signal_candidate
+- author: shbernal
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-21T08:20:29Z
+- live url: https://github.com/openclaw/openclaw/pull/88738
+
+### #88850 fix(msteams): thread proactive file sends
+
+- bucket: low_signal_candidate
+- author: charles-openclaw
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: msteams, size: S, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-21T08:21:17Z
+- live url: https://github.com/openclaw/openclaw/pull/88850
+
+### #90227 test: make zalo credentials tests compatible with Windows
+
+- bucket: low_signal_candidate
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: zalouser, size: S, triage: needs-real-behavior-proof, P3, rating: gold shrimp, status: needs proof
+- live updated: 2026-06-21T08:23:26Z
+- live url: https://github.com/openclaw/openclaw/pull/90227
+
+### #54652 test(auth): align device auth store scopes
+
+- bucket: low_signal_candidate
+- author: giulio-leone
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: stale, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-21T08:55:34Z
+- live url: https://github.com/openclaw/openclaw/pull/54652

--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T080152-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T080152-004.md
@@ -1,0 +1,111 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T080152-004
+mode: autonomous
+triage_policy: low_signal_prs
+allowed_actions:
+  - "comment"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+  - "label"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "focused_bug_fix"
+  - "green_checks"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#87545"
+  - "#88915"
+  - "#89088"
+  - "#89117"
+  - "#89447"
+cluster_refs:
+  - "#87545"
+  - "#88915"
+  - "#89088"
+  - "#89117"
+  - "#89447"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_low_signal_pr_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "No canonical is needed; this is an opt-in low-signal PR cleanup sweep generated from live GitHub inventory."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T08:01:52.688Z; bucket=low_signal_candidate; low-signal candidates were prefiltered for stale unassigned PRs. Maintainer comments and reviews are still rechecked by the worker and applicator before close."
+---
+
+# Low-Signal PR Sweep 4
+
+This is an opt-in low-signal cleanup shard over stale open pull requests from live GitHub inventory.
+
+## Goal
+
+Use `instructions/low-signal-prs.md`. Review only the listed open pull requests. Emit `close_low_signal` with `classification: "low_signal"` only when the PR is boringly clear under the low-signal policy and live GitHub state still has no maintainer signal. Otherwise emit `needs_human`, `keep_related`, or `keep_independent`. The deterministic applicator will re-fetch live state, reject non-PRs, reject maintainer-authored/reviewed/commented/assigned PRs, and close only planned `close_low_signal` actions.
+
+## Inventory
+
+### #87545 test(agents): cover quota prompt takeover regression
+
+- bucket: low_signal_candidate
+- author: Grynn
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-21T09:06:36Z
+- live url: https://github.com/openclaw/openclaw/pull/87545
+
+### #88915 fix(macos): skip redundant defaults suite
+
+- bucket: low_signal_candidate
+- author: charles-openclaw
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: macos, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-21T09:43:38Z
+- live url: https://github.com/openclaw/openclaw/pull/88915
+
+### #89088 test(gateway): cover rollover model override preservation
+
+- bucket: low_signal_candidate
+- author: charles-openclaw
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, triage: mock-only-proof, P3, rating: silver shellfish, status: needs proof
+- live updated: 2026-06-21T09:47:33Z
+- live url: https://github.com/openclaw/openclaw/pull/89088
+
+### #89117 Support Gemini Embedding 2 GA
+
+- bucket: low_signal_candidate
+- author: abel-zer0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, triage: needs-real-behavior-proof, extensions: google, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-21T09:48:48Z
+- live url: https://github.com/openclaw/openclaw/pull/89117
+
+### #89447 fix(status): show live channel state in fast status
+
+- bucket: low_signal_candidate
+- author: charles-openclaw
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, triage: blank-template, triage: needs-real-behavior-proof, P3, rating: unranked krab, merge-risk: availability, status: needs proof
+- live updated: 2026-06-21T09:54:34Z
+- live url: https://github.com/openclaw/openclaw/pull/89447

--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T080152-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T080152-005.md
@@ -1,0 +1,111 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T080152-005
+mode: autonomous
+triage_policy: low_signal_prs
+allowed_actions:
+  - "comment"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+  - "label"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "focused_bug_fix"
+  - "green_checks"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#61624"
+  - "#75918"
+  - "#85507"
+  - "#85727"
+  - "#89190"
+cluster_refs:
+  - "#61624"
+  - "#75918"
+  - "#85507"
+  - "#85727"
+  - "#89190"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_low_signal_pr_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "No canonical is needed; this is an opt-in low-signal PR cleanup sweep generated from live GitHub inventory."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T08:01:52.688Z; bucket=low_signal_candidate; low-signal candidates were prefiltered for stale unassigned PRs. Maintainer comments and reviews are still rechecked by the worker and applicator before close."
+---
+
+# Low-Signal PR Sweep 5
+
+This is an opt-in low-signal cleanup shard over stale open pull requests from live GitHub inventory.
+
+## Goal
+
+Use `instructions/low-signal-prs.md`. Review only the listed open pull requests. Emit `close_low_signal` with `classification: "low_signal"` only when the PR is boringly clear under the low-signal policy and live GitHub state still has no maintainer signal. Otherwise emit `needs_human`, `keep_related`, or `keep_independent`. The deterministic applicator will re-fetch live state, reject non-PRs, reject maintainer-authored/reviewed/commented/assigned PRs, and close only planned `close_low_signal` actions.
+
+## Inventory
+
+### #61624 feat(whatsapp): add dmRequireMention for DM trigger gating
+
+- bucket: low_signal_candidate
+- author: mubbie
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: whatsapp-web, size: S, triage: dirty-candidate, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-21T10:51:28Z
+- live url: https://github.com/openclaw/openclaw/pull/61624
+
+### #75918 feat(hooks): add persistent hook session mode
+
+- bucket: low_signal_candidate
+- author: ryanrhughes
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, commands, agents, size: L, extensions: codex, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: auth-provider, merge-risk: session-state, status: needs proof, feature: showcase, triage: needs-pr-context
+- live updated: 2026-06-21T10:52:00Z
+- live url: https://github.com/openclaw/openclaw/pull/75918
+
+### #85507 fix(slack): include assistant loading messages
+
+- bucket: low_signal_candidate
+- author: emergentash
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: slack, size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof, merge-risk: other, triage: needs-pr-context
+- live updated: 2026-06-21T10:53:59Z
+- live url: https://github.com/openclaw/openclaw/pull/85507
+
+### #85727 docs: add first run setup steps to CONTRIBUTING.md
+
+- bucket: low_signal_candidate
+- author: Arvuno
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: low-signal-docs, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-21T10:54:36Z
+- live url: https://github.com/openclaw/openclaw/pull/85727
+
+### #89190 feat(xai): add grok-composer-2.5-fast model
+
+- bucket: low_signal_candidate
+- author: lidge-jun
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, extensions: xai, P2, rating: silver shellfish, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-21T10:57:35Z
+- live url: https://github.com/openclaw/openclaw/pull/89190

--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T080152-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T080152-006.md
@@ -1,0 +1,111 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T080152-006
+mode: autonomous
+triage_policy: low_signal_prs
+allowed_actions:
+  - "comment"
+  - "close"
+blocked_actions:
+  - "force_push"
+  - "bypass_checks"
+  - "merge"
+  - "fix"
+  - "raise_pr"
+  - "label"
+require_human_for:
+  - "security_sensitive"
+  - "maintainer_signal"
+  - "active_author_followup"
+  - "focused_bug_fix"
+  - "green_checks"
+  - "technical_correctness_judgment"
+canonical: []
+candidates:
+  - "#90618"
+  - "#41067"
+  - "#60922"
+  - "#62722"
+  - "#64649"
+cluster_refs:
+  - "#90618"
+  - "#41067"
+  - "#60922"
+  - "#62722"
+  - "#64649"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_low_signal_pr_close: true
+allow_fix_pr: false
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "No canonical is needed; this is an opt-in low-signal PR cleanup sweep generated from live GitHub inventory."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T08:01:52.688Z; bucket=low_signal_candidate; low-signal candidates were prefiltered for stale unassigned PRs. Maintainer comments and reviews are still rechecked by the worker and applicator before close."
+---
+
+# Low-Signal PR Sweep 6
+
+This is an opt-in low-signal cleanup shard over stale open pull requests from live GitHub inventory.
+
+## Goal
+
+Use `instructions/low-signal-prs.md`. Review only the listed open pull requests. Emit `close_low_signal` with `classification: "low_signal"` only when the PR is boringly clear under the low-signal policy and live GitHub state still has no maintainer signal. Otherwise emit `needs_human`, `keep_related`, or `keep_independent`. The deterministic applicator will re-fetch live state, reject non-PRs, reject maintainer-authored/reviewed/commented/assigned PRs, and close only planned `close_low_signal` actions.
+
+## Inventory
+
+### #90618 fix: recover stuck Control UI chat runs
+
+- bucket: low_signal_candidate
+- author: clawsweeper
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: L, clawsweeper, P2, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-21T12:23:52Z
+- live url: https://github.com/openclaw/openclaw/pull/90618
+
+### #41067 Fix dashboard chat run recovery across reconnects
+
+- bucket: low_signal_candidate
+- author: Elysium-Seeker
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: macos, app: web-ui, gateway, size: L, triage: needs-real-behavior-proof, P1, rating: unranked krab, merge-risk: session-state, merge-risk: message-delivery, status: needs proof
+- live updated: 2026-06-21T12:50:01Z
+- live url: https://github.com/openclaw/openclaw/pull/41067
+
+### #60922 feat(agents): derive fallbacks from configured model catalog
+
+- bucket: low_signal_candidate
+- author: 08820048
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, agents, size: M, triage: dirty-candidate, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, merge-risk: auth-provider, status: needs proof
+- live updated: 2026-06-21T12:53:25Z
+- live url: https://github.com/openclaw/openclaw/pull/60922
+
+### #62722 fix(gateway): use already-aborted signal in stopChannel fallback
+
+- bucket: low_signal_candidate
+- author: pruthvishetty
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, triage: refactor-only, triage: needs-real-behavior-proof, P2, rating: unranked krab, merge-risk: compatibility, status: needs proof
+- live updated: 2026-06-21T12:55:36Z
+- live url: https://github.com/openclaw/openclaw/pull/62722
+
+### #64649 Test/run state machine clamp guard
+
+- bucket: low_signal_candidate
+- author: Rahulkumar070
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: needs-real-behavior-proof, P3, rating: unranked krab, status: needs proof
+- live updated: 2026-06-21T12:56:40Z
+- live url: https://github.com/openclaw/openclaw/pull/64649

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "import-gitcrawl-low-signal": "node scripts/import-gitcrawl-low-signal-prs.mjs",
     "import-gitcrawl-pr-inventory": "node scripts/import-gitcrawl-pr-inventory.mjs",
     "import-github-pr-inventory": "node scripts/import-github-pr-inventory.mjs",
+    "import-github-low-signal": "node scripts/import-github-pr-inventory.mjs --strategy low-signal",
     "import-ghcrawl": "node scripts/import-gitcrawl-clusters.mjs",
     "import-low-signal": "node scripts/import-gitcrawl-low-signal-prs.mjs",
     "worker": "node scripts/run-worker.mjs",

--- a/scripts/import-github-pr-inventory.mjs
+++ b/scripts/import-github-pr-inventory.mjs
@@ -8,6 +8,16 @@ import { hasSecuritySensitiveText } from "./security-sensitive.mjs";
 const args = parseArgs(process.argv.slice(2));
 const repo = String(args.repo ?? "openclaw/openclaw");
 const [owner, name] = repo.split("/");
+const DEFAULT_LOW_SIGNAL_BLOCK_LABELS = [
+  "proof:*",
+  "status:*ready for maintainer look",
+  "status:*waiting on author",
+  "rating:*platinum",
+  "rating:*gold",
+  "rating:*diamond",
+  "clawsweeper:needs-*",
+  "merge-risk:*security*",
+];
 const outDir = path.resolve(String(args.out ?? path.join(repoRoot(), "jobs", owner, "inbox")));
 const existingDir = path.resolve(String(args["existing-dir"] ?? args.existing_dir ?? outDir));
 const existingResultsDir = path.resolve(
@@ -25,22 +35,31 @@ const bucketFilter = String(args.bucket ?? defaultBucketFor({ mode, strategy }))
 const skipExisting = args["skip-existing"] !== "false";
 const includeSecurity = Boolean(args["include-security-candidates"]);
 const includeRefs = optionalRefsFile(args["include-refs-file"] ?? args.include_refs_file);
+const minScore = numberArg("min-score", 2);
+const maxFiles = numberArg("max-files", 120);
+const limitForHydration = limit === "all" ? 500 : Number(limit);
+const lowSignalHydrateLimit = numberArg("low-signal-hydrate-limit", Math.max(limitForHydration * 12, 300));
+const blockedLowSignalLabelPatterns = compileLabelPatterns(
+  argValues(process.argv.slice(2), ["block-label", "block_label"], args["block-label"] ?? args.block_label ?? DEFAULT_LOW_SIGNAL_BLOCK_LABELS),
+);
 const dryRun = Boolean(args["dry-run"] ?? args.dry_run);
 const jsonOutput = Boolean(args.json);
 const ghCommand = String(args["gh-bin"] ?? args.gh_bin ?? process.env.CLOWNFISH_GH_BIN ?? firstAvailableCommand(["ghx", "gh"]));
 
 if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) die("--repo must be owner/repo");
 if (!["plan", "autonomous"].includes(mode)) die("--mode must be plan or autonomous");
-if (!["triage", "remediation"].includes(strategy)) die("--strategy must be triage or remediation");
+if (!["triage", "remediation", "low-signal"].includes(strategy)) die("--strategy must be triage, remediation, or low-signal");
 if (strategy === "remediation" && mode !== "plan") die("--strategy remediation requires --mode plan");
 if (!["stale", "recent", "bucket"].includes(sort)) die("--sort must be stale, recent, or bucket");
 if (!["all", "terminal"].includes(existingResultsActionPolicy)) die("--existing-results-action-policy must be all or terminal");
 
-const existingRefs = skipExisting ? existingMentionedRefs([existingDir]) : new Set();
+const existingRefs = skipExisting ? existingRefsForStrategy() : new Set();
 if (skipExisting) mergeRefs(existingRefs, existingPublishedResultRefs(existingResultsDir, repo, existingResultsActionPolicy));
+const rawOpenPullRequests = fetchOpenPullRequests();
+if (strategy === "low-signal") hydrateLowSignalPullRequestFiles(rawOpenPullRequests);
 const candidates = dedupeCandidates(
-  fetchOpenPullRequests()
-  .map(classifyCandidate)
+  rawOpenPullRequests
+    .map(classifyCandidate)
   .filter((candidate) => !includeRefs || includeRefs.has(candidate.ref))
   .filter((candidate) => !skipExisting || !existingRefs.has(candidate.ref))
   .filter((candidate) => includeSecurity || candidate.bucket !== "security_route_candidate")
@@ -68,6 +87,11 @@ const payload = sanitizeJsonValue({
     batch_size: batchSize,
     sort,
     bucket: bucketFilter,
+    min_score: strategy === "low-signal" ? minScore : null,
+    max_files: strategy === "low-signal" ? maxFiles : null,
+    low_signal_hydrate_limit: strategy === "low-signal" ? lowSignalHydrateLimit : null,
+    low_signal_blocked_labels:
+      strategy === "low-signal" ? blockedLowSignalLabelPatterns.map((pattern) => pattern.source) : [],
     skip_existing: skipExisting,
     include_security_candidates: includeSecurity,
     include_refs_file: includeRefs
@@ -105,10 +129,15 @@ function fetchOpenPullRequests() {
           createdAt
           updatedAt
           isDraft
+          changedFiles
+          additions
+          deletions
           author { login }
           authorAssociation
           labels(first:30) { nodes { name } }
           assignees(first:10) { nodes { login } }
+          comments(first:1) { totalCount }
+          reviews(first:1) { totalCount }
         }
         pageInfo { hasNextPage endCursor }
       }
@@ -135,9 +164,10 @@ function classifyCandidate(raw) {
   const assignees = assigneeNames(raw.assignees);
   const title = asciiString(raw.title ?? "");
   const authorAssociation = asciiString(raw.authorAssociation ?? "");
+  const body = asciiString(raw.body ?? "");
+  const files = Array.isArray(raw.files) ? raw.files.map(asciiString).filter(Boolean) : [];
   const bucket = chooseBucket({ raw, title, labels, assignees, authorAssociation });
-
-  return {
+  const base = {
     number: Number(raw.number),
     ref: `#${raw.number}`,
     title,
@@ -149,8 +179,17 @@ function classifyCandidate(raw) {
     created_at: nullableAscii(raw.createdAt),
     updated_at: nullableAscii(raw.updatedAt),
     url: asciiString(raw.url ?? ""),
+    body_excerpt: excerpt(body),
+    files,
+    file_count: files.length,
+    comments: Number(raw.comments?.totalCount ?? 0),
+    reviews: Number(raw.reviews?.totalCount ?? 0),
+    changed_files: Number(raw.changedFiles ?? files.length),
+    additions: Number(raw.additions ?? 0),
+    deletions: Number(raw.deletions ?? 0),
     bucket,
   };
+  return strategy === "low-signal" ? classifyLowSignalCandidate(base, { raw, body }) : base;
 }
 
 function dedupeCandidates(candidates) {
@@ -164,7 +203,132 @@ function dedupeCandidates(candidates) {
   return [...byRef.values()];
 }
 
+function hydrateLowSignalPullRequestFiles(rawPullRequests) {
+  const selected = rawPullRequests
+    .filter((raw) => !hasLowSignalPrefilterBlocker(raw))
+    .sort((left, right) => String(left.updatedAt ?? "").localeCompare(String(right.updatedAt ?? "")))
+    .slice(0, lowSignalHydrateLimit);
+  if (selected.length === 0) return;
+
+  const filesByNumber = fetchLivePullRequestFiles(selected.map((raw) => Number(raw.number)));
+  for (const raw of selected) {
+    raw.files = filesByNumber.get(Number(raw.number)) ?? [];
+  }
+}
+
+function hasLowSignalPrefilterBlocker(raw) {
+  const labels = labelNames(raw.labels);
+  const assignees = assigneeNames(raw.assignees);
+  const title = asciiString(raw.title ?? "");
+  const body = asciiString(raw.body ?? "");
+  const authorAssociation = asciiString(raw.authorAssociation ?? "");
+  if (isMaintainerAssociated(authorAssociation)) return true;
+  if (Boolean(raw.isDraft)) return true;
+  if (assignees.length > 0) return true;
+  if (daysSince(raw.createdAt) < 14) return true;
+  if (hasExactSecuritySignal({ title, labels })) return true;
+  return labels.some((label) => {
+    const normalized = normalizeLabel(label);
+    return blockedLowSignalLabelPatterns.some((pattern) => pattern.test(normalized));
+  });
+}
+
+function fetchLivePullRequestFiles(numbers) {
+  const out = new Map();
+  const uniqueNumbers = [...new Set(numbers.filter(Number.isInteger))];
+  for (let index = 0; index < uniqueNumbers.length; index += 25) {
+    const batch = uniqueNumbers.slice(index, index + 25);
+    const payload = ghJsonWithRetry(["api", "graphql", "-f", `query=${renderPullRequestFilesQuery(batch)}`], {
+      operation: "hydrate low-signal PR files",
+    });
+    const fatalErrors = (payload.errors ?? []).filter(
+      (error) => !/^Could not resolve to a PullRequest with the number of \d+\.$/.test(String(error.message ?? "")),
+    );
+    if (fatalErrors.length > 0) {
+      throw new Error(`GitHub GraphQL failed while hydrating PR files: ${fatalErrors.map((error) => error.message).join("; ")}`);
+    }
+    for (const number of batch) {
+      const node = payload.data?.repository?.[`pr${number}`];
+      if (!node) continue;
+      const files = (node.files?.nodes ?? []).map((file) => asciiString(file.path ?? "")).filter(Boolean);
+      if (node.files?.pageInfo?.hasNextPage) files.push("__truncated__");
+      out.set(number, files);
+      const raw = fetchOpenPullRequests.cache?.find((item) => Number(item.number) === number);
+      if (raw) raw.body = node.body ?? "";
+    }
+  }
+  return out;
+}
+
+function renderPullRequestFilesQuery(numbers) {
+  return `query {
+  repository(owner: ${jsonString(owner)}, name: ${jsonString(name)}) {
+${numbers
+  .map(
+    (number) => `    pr${number}: pullRequest(number: ${number}) {
+      body
+      files(first: 100) {
+        nodes { path }
+        pageInfo { hasNextPage }
+      }
+    }`,
+  )
+  .join("\n")}
+  }
+}`;
+}
+
+function classifyLowSignalCandidate(base, { body }) {
+  const signals = [];
+  const blockers = [];
+  const files = base.files;
+  const labels = base.labels.map((label) => normalizeLabel(label));
+
+  if (base.bucket === "security_route_candidate" || hasSecuritySensitiveText(base.title, body, base.labels)) {
+    blockers.push("security-sensitive text or labels");
+  }
+  if (isMaintainerAssociated(base.author_association)) blockers.push(`author association is ${base.author_association}`);
+  if (base.is_draft) blockers.push("draft PR");
+  if (base.assignees.length > 0) blockers.push("assigned PR");
+  if (daysSince(base.created_at) < 14) blockers.push("new PR");
+  if (base.changed_files > maxFiles || files.length > maxFiles || files.includes("__truncated__")) {
+    blockers.push("too many or truncated changed files");
+  }
+  for (const label of base.labels) {
+    const normalized = normalizeLabel(label);
+    const blockedBy = blockedLowSignalLabelPatterns.find((pattern) => pattern.test(normalized));
+    if (blockedBy) blockers.push(`close-blocking label: ${label}`);
+  }
+
+  addSignal(signals, blankTemplateSignal(body), "blank_template");
+  addSignal(signals, labels.includes("triage: blank-template"), "blank_template");
+  addSignal(signals, docsOnlySignal(base.title, files), "docs_only");
+  addSignal(signals, testsOnlySignal(base.title, files), "test_only");
+  addSignal(signals, refactorOnlySignal(base.title, body, files), "refactor_or_cleanup");
+  addSignal(signals, labels.includes("triage: refactor-only"), "refactor_or_cleanup");
+  addSignal(signals, thirdPartyCoreSignal(base.title, body, files), "third_party_or_external_capability");
+  addSignal(signals, labels.includes("triage: external-plugin-candidate"), "third_party_or_external_capability");
+  addSignal(signals, riskyInfraSignal(base.title, files), "risky_infra");
+  addSignal(signals, dirtyBranchSignal(files), "dirty_branch");
+  addSignal(signals, labels.includes("triage: dirty-candidate"), "dirty_branch");
+
+  const hasConcreteFix = /\b(fixes|fixes?|root cause|repro|regression|bug|problem)\b/i.test(`${base.title}\n${body}`);
+  if (hasConcreteFix && signals.length === 1 && !signals.includes("blank_template")) {
+    blockers.push("possible focused fix needs human review");
+  }
+
+  const score = blockers.length > 0 ? 0 : signals.length;
+  return {
+    ...base,
+    bucket: score >= minScore ? "low_signal_candidate" : "low_signal_blocked",
+    score,
+    signals,
+    blockers,
+  };
+}
+
 function chooseBucket({ raw, title, labels, assignees, authorAssociation }) {
+  if (strategy === "low-signal") return "low_signal_candidate";
   if (hasExactSecuritySignal({ title, labels })) return "security_route_candidate";
   if (isMaintainerAssociated(authorAssociation) || assignees.length > 0) return "maintainer_owned";
   if (Boolean(raw.isDraft)) return "draft";
@@ -182,6 +346,7 @@ function writeJob(batch, index) {
   const now = new Date();
   const stamp = now.toISOString().replace(/[-:.]/g, "").slice(0, 15);
   const bucket = batch.every((item) => item.bucket === batch[0].bucket) ? batch[0].bucket : "mixed";
+  const lowSignal = strategy === "low-signal";
   const inventoryScope = skipExisting
     ? "open pull requests not already represented in Clownfish jobs or results"
     : "open pull requests, including previously represented PRs being refreshed against live GitHub state";
@@ -189,12 +354,23 @@ function writeJob(batch, index) {
   const filePath = path.join(outDir, `${clusterId}.md`);
   const refs = batch.map((candidate) => candidate.ref);
   const remediation = strategy === "remediation";
-  const allowedActions = remediation ? ["merge", "fix", "raise_pr"] : ["comment", "label", "close"];
+  const allowedActions = remediation ? ["merge", "fix", "raise_pr"] : lowSignal ? ["comment", "close"] : ["comment", "label", "close"];
   const blockedActions = remediation
     ? ["comment", "label", "close", "force_push", "bypass_checks"]
+    : lowSignal
+      ? ["force_push", "bypass_checks", "merge", "fix", "raise_pr", "label"]
     : ["force_push", "bypass_checks", "merge", "fix", "raise_pr"];
   const requireHumanFor = remediation
     ? ["security_sensitive", "unclear_canonical", "broad_code_delta", "active_author_followup"]
+    : lowSignal
+      ? [
+          "security_sensitive",
+          "maintainer_signal",
+          "active_author_followup",
+          "focused_bug_fix",
+          "green_checks",
+          "technical_correctness_judgment",
+        ]
     : [
         "security_sensitive",
         "maintainer_signal",
@@ -208,6 +384,7 @@ function writeJob(batch, index) {
     `repo: ${repo}`,
     `cluster_id: ${clusterId}`,
     `mode: ${mode}`,
+    ...(lowSignal ? ["triage_policy: low_signal_prs"] : []),
     "allowed_actions:",
     ...yamlList(allowedActions),
     "blocked_actions:",
@@ -221,7 +398,8 @@ function writeJob(batch, index) {
     ...yamlList(refs),
     "security_policy: central_security_only",
     "security_sensitive: false",
-    `allow_instant_close: ${remediation ? "false" : "true"}`,
+    `allow_instant_close: ${remediation || lowSignal ? "false" : "true"}`,
+    ...(lowSignal ? ["allow_low_signal_pr_close: true"] : []),
     `allow_fix_pr: ${remediation ? "true" : "false"}`,
     `allow_merge: ${remediation ? "true" : "false"}`,
     `allow_post_merge_close: false`,
@@ -229,25 +407,33 @@ function writeJob(batch, index) {
     `canonical_hint: ${quoteYaml(
       remediation
         ? "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+        : lowSignal
+          ? "No canonical is needed; this is an opt-in low-signal PR cleanup sweep generated from live GitHub inventory."
         : "This is a live PR inventory shard, not a dedupe cluster. Classify each PR independently and do not invent a shared canonical.",
     )}`,
     `notes: ${quoteYaml(
       remediation
         ? `Generated from live GitHub open PR inventory on ${now.toISOString()}; bucket=${bucket}; plan-only remediation assessment. No GitHub mutation is permitted from this job.`
+        : lowSignal
+          ? `Generated from live GitHub open PR inventory on ${now.toISOString()}; bucket=${bucket}; low-signal candidates were prefiltered for stale unassigned PRs. Maintainer comments and reviews are still rechecked by the worker and applicator before close.`
         : `Generated from live GitHub open PR inventory on ${now.toISOString()}; bucket=${bucket}; only safe close/comment/label actions are allowed.`,
     )}`,
     "---",
     "",
-    `# ${remediation ? "PR Remediation Inventory" : "Live PR Inventory"} ${index}`,
+    `# ${remediation ? "PR Remediation Inventory" : lowSignal ? "Low-Signal PR Sweep" : "Live PR Inventory"} ${index}`,
     "",
     remediation
       ? "This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests."
+      : lowSignal
+        ? "This is an opt-in low-signal cleanup shard over stale open pull requests from live GitHub inventory."
       : `This is a high-volume live inventory shard over ${inventoryScope}.`,
     "",
     "## Goal",
     "",
     remediation
       ? "Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only."
+      : lowSignal
+        ? "Use `instructions/low-signal-prs.md`. Review only the listed open pull requests. Emit `close_low_signal` with `classification: \"low_signal\"` only when the PR is boringly clear under the low-signal policy and live GitHub state still has no maintainer signal. Otherwise emit `needs_human`, `keep_related`, or `keep_independent`. The deterministic applicator will re-fetch live state, reject non-PRs, reject maintainer-authored/reviewed/commented/assigned PRs, and close only planned `close_low_signal` actions."
       : "Hydrate live GitHub state for each listed PR and emit one conservative action per PR. Prefer `keep_related`, `keep_independent`, `needs_human`, or `route_security`. Emit close-style actions only when fresh live evidence makes the PR boringly superseded, duplicate, abandoned, or low-signal under existing policies. Do not merge, fix, or raise PRs.",
     "",
     "## Inventory",
@@ -268,6 +454,7 @@ function writeJob(batch, index) {
 
 function defaultBucketFor({ mode, strategy }) {
   if (strategy === "remediation") return "ready_for_maintainer";
+  if (strategy === "low-signal") return "low_signal_candidate";
   return mode === "autonomous" ? "stale_unassigned" : "all";
 }
 
@@ -294,6 +481,23 @@ function existingMentionedRefs(roots) {
     if (!fs.existsSync(root) || visited.has(root)) continue;
     visited.add(root);
     for (const file of markdownJobFiles(root)) addStructuredJobRefs(refs, file);
+  }
+  return refs;
+}
+
+function existingRefsForStrategy() {
+  if (strategy === "low-signal") return existingLowSignalRefs();
+  return existingMentionedRefs([existingDir]);
+}
+
+function existingLowSignalRefs() {
+  const jobsDir = path.join(repoRoot(), "jobs");
+  const refs = new Set();
+  if (!fs.existsSync(jobsDir)) return refs;
+  for (const file of markdownJobFiles(jobsDir)) {
+    const text = fs.readFileSync(file, "utf8");
+    if (!text.includes("triage_policy: low_signal_prs")) continue;
+    for (const match of text.matchAll(/#(\d+)\b/g)) refs.add(`#${match[1]}`);
   }
   return refs;
 }
@@ -559,6 +763,107 @@ function sanitizeJsonValue(value) {
     return Object.fromEntries(Object.entries(value).map(([key, item]) => [asciiString(key), sanitizeJsonValue(item)]));
   }
   return value;
+}
+
+function excerpt(value, max = 240) {
+  const text = asciiString(value);
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function argValues(argv, names, fallback) {
+  const keys = new Set(names.map((name) => `--${name}`));
+  const values = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const item = argv[index];
+    const equalMatch = item.match(/^(--[^=]+)=(.*)$/);
+    if (equalMatch) {
+      if (keys.has(equalMatch[1])) values.push(equalMatch[2]);
+      continue;
+    }
+    if (!keys.has(item)) continue;
+    const next = argv[index + 1];
+    if (next && !next.startsWith("--")) {
+      values.push(next);
+      index += 1;
+    } else {
+      values.push("true");
+    }
+  }
+  return values.length > 0 ? values : fallback;
+}
+
+function compileLabelPatterns(values) {
+  return listArgValues(values).map((value) => {
+    const normalized = normalizeLabel(value);
+    if (normalized.includes("*")) return new RegExp(`^${normalized.split("*").map(escapeRegExp).join(".*")}$`);
+    return new RegExp(`^${escapeRegExp(normalized)}$`);
+  });
+}
+
+function listArgValues(value) {
+  const values = Array.isArray(value) ? value : [value];
+  return values
+    .flatMap((item) => String(item ?? "").split(/[\n,]/))
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function normalizeLabel(label) {
+  return String(label ?? "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function blankTemplateSignal(body) {
+  const text = String(body ?? "");
+  if (/Describe the problem and fix in 2.?5 bullets:\s*[\r\n]+\s*-\s*Problem:\s*[\r\n]+\s*-\s*Fix:/i.test(text)) {
+    return true;
+  }
+  const placeholders = ["Problem:", "Why it matters:", "Describe the problem and fix"];
+  return placeholders.filter((placeholder) => text.includes(placeholder)).length >= 2 && text.length < 700;
+}
+
+function docsOnlySignal(title, files) {
+  return /\bdocs?\b/i.test(title) && files.length > 0 && files.every((file) => isDocsPath(file));
+}
+
+function testsOnlySignal(title, files) {
+  return /\btest\b/i.test(title) && files.length > 0 && files.every((file) => isTestPath(file));
+}
+
+function refactorOnlySignal(title, body, files) {
+  return /\b(refactor|cleanup|format|chore)\b/i.test(title) && !/#\d+\b/.test(`${title}\n${body}`) && files.length > 0;
+}
+
+function thirdPartyCoreSignal(title, body, files) {
+  const text = `${title}\n${body}`.toLowerCase();
+  return (
+    /\b(new|add|feat).*(plugin|provider|channel|skill|tool|app)\b/.test(text) ||
+    files.some((file) => /^apps\/linux\//.test(file))
+  );
+}
+
+function riskyInfraSignal(title, files) {
+  return (
+    /\b(ci|infra|docker|build|release|workflow)\b/i.test(title) &&
+    files.some((file) => /^\.github\/|^Dockerfile|^scripts\/|^fly\.|^render\.|^docker-compose/.test(file))
+  );
+}
+
+function dirtyBranchSignal(files) {
+  if (files.length < 12) return false;
+  const topLevels = new Set(files.map((file) => file.split("/")[0]));
+  return topLevels.size >= 4 || (files.some((file) => file.includes(".generated")) && topLevels.size >= 2);
+}
+
+function isDocsPath(file) {
+  return /(^docs\/|^README|\.md$|\.mdx$|^skills\/|^\.github\/ISSUE_TEMPLATE)/.test(file);
+}
+
+function isTestPath(file) {
+  return /(\.test\.|\.spec\.|__tests__|^test\/|^test-fixtures\/)/.test(file);
+}
+
+function addSignal(signals, enabled, name) {
+  if (enabled && !signals.includes(name)) signals.push(name);
 }
 
 function asciiString(value) {


### PR DESCRIPTION
## Summary
- add a live GitHub low-signal strategy to the PR inventory importer
- use ClawSweeper triage labels plus hydrated changed files to build opt-in low-signal cleanup jobs
- add six autonomous close-only low-signal shards covering 30 OpenClaw PRs

## Validation
- npm run validate
- git diff --check
- npm test