### PR TITLE
chore: add ready remediation inventory jobs

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T082436-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T082436-001.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T082436-001
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#88103"
+  - "#88159"
+  - "#95412"
+  - "#87891"
+  - "#94219"
+cluster_refs:
+  - "#88103"
+  - "#88159"
+  - "#95412"
+  - "#87891"
+  - "#94219"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T08:24:36.438Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #88103 Update Teams CLI install command
+
+- bucket: ready_for_maintainer
+- author: heyitsaamir
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: msteams, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-06-21T06:37:38Z
+- live url: https://github.com/openclaw/openclaw/pull/88103
+
+### #88159 fix(cli): retry logs.tail after journal fallback in logs follow
+
+- bucket: ready_for_maintainer
+- author: anyech
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, size: M, proof: supplied, proof: sufficient, P2, rating: diamond lobster, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T06:38:27Z
+- live url: https://github.com/openclaw/openclaw/pull/88159
+
+### #95412 fix(discord): bound REST response body to prevent OOM flood
+
+- bucket: ready_for_maintainer
+- author: Alix-007
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: discord, size: S, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T06:49:36Z
+- live url: https://github.com/openclaw/openclaw/pull/95412
+
+### #87891 fix(telegram): expose spooled handler timeout config
+
+- bucket: ready_for_maintainer
+- author: khang-dogo
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: telegram, size: XS, triage: dirty-candidate, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look, triage: needs-pr-context
+- live updated: 2026-06-21T07:19:16Z
+- live url: https://github.com/openclaw/openclaw/pull/87891
+
+### #94219 fix(control-ui): restore provider usage quota pill in sidebar session switcher (fixes #93041)
+
+- bucket: ready_for_maintainer
+- author: Pick-cat
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: web-ui, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T07:22:49Z
+- live url: https://github.com/openclaw/openclaw/pull/94219

--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T082436-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T082436-002.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T082436-002
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#79702"
+  - "#85829"
+  - "#88400"
+  - "#88401"
+  - "#88681"
+cluster_refs:
+  - "#79702"
+  - "#85829"
+  - "#88400"
+  - "#88401"
+  - "#88681"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T08:24:36.440Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 2
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #79702 [AI-assisted] fix(openai): prefix instruction-aware embedding queries
+
+- bucket: ready_for_maintainer
+- author: kreucher
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: M, extensions: openai, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T08:15:56Z
+- live url: https://github.com/openclaw/openclaw/pull/79702
+
+### #85829 Avoid post-run auth success lane delay
+
+- bucket: ready_for_maintainer
+- author: TurboTheTurtle
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: auth-provider, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-21T08:17:13Z
+- live url: https://github.com/openclaw/openclaw/pull/85829
+
+### #88400 fix(config): accept overlays for bundled provider aliases
+
+- bucket: ready_for_maintainer
+- author: Pluviobyte
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, triage: blank-template, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T08:19:17Z
+- live url: https://github.com/openclaw/openclaw/pull/88400
+
+### #88401 fix(agents): safely record non-json transport errors
+
+- bucket: ready_for_maintainer
+- author: Pluviobyte
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T08:19:21Z
+- live url: https://github.com/openclaw/openclaw/pull/88401
+
+### #88681 Make runtime plugin startup stalls name in-flight plugins
+
+- bucket: ready_for_maintainer
+- author: alexzhu0
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T08:20:18Z
+- live url: https://github.com/openclaw/openclaw/pull/88681

--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T082436-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T082436-003.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T082436-003
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#88908"
+  - "#89817"
+  - "#89818"
+  - "#93087"
+  - "#93584"
+cluster_refs:
+  - "#88908"
+  - "#89817"
+  - "#89818"
+  - "#93087"
+  - "#93584"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T08:24:36.440Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 3
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #88908 fix(gateway): force exit on zombie shutdown + 503 healthz during shutdown
+
+- bucket: ready_for_maintainer
+- author: amittell
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, cli, size: L, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-21T08:21:45Z
+- live url: https://github.com/openclaw/openclaw/pull/88908
+
+### #89817 fix(commitments): preserve extraction batch on transient failure
+
+- bucket: ready_for_maintainer
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T08:22:56Z
+- live url: https://github.com/openclaw/openclaw/pull/89817
+
+### #89818 fix(providers): forward stop sequences in bundled Anthropic transports
+
+- bucket: ready_for_maintainer
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, extensions: amazon-bedrock, extensions: anthropic-vertex, P2, rating: diamond lobster, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T08:23:01Z
+- live url: https://github.com/openclaw/openclaw/pull/89818
+
+### #93087 Reject unsupported diagnostics OTel grpc config
+
+- bucket: ready_for_maintainer
+- author: kiranmagic7
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, gateway, extensions: diagnostics-otel, commands, size: M, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T08:24:56Z
+- live url: https://github.com/openclaw/openclaw/pull/93087
+
+### #93584 fix(agents): repair orphaned tool_use pairs on compaction prune path
+
+- bucket: ready_for_maintainer
+- author: dolphinsboy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: session-state, status: ready for maintainer look
+- live updated: 2026-06-21T08:25:36Z
+- live url: https://github.com/openclaw/openclaw/pull/93584

--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T082436-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T082436-004.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T082436-004
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#94072"
+  - "#95148"
+  - "#95240"
+  - "#53467"
+  - "#85710"
+cluster_refs:
+  - "#94072"
+  - "#95148"
+  - "#95240"
+  - "#53467"
+  - "#85710"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T08:24:36.440Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 4
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #94072 fix(agents): count message-tool source reply as user-facing reply for tool error warnings
+
+- bucket: ready_for_maintainer
+- author: chenyangjun-xy
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look, clownfish:automerge
+- live updated: 2026-06-21T08:25:56Z
+- live url: https://github.com/openclaw/openclaw/pull/94072
+
+### #95148 feat(android): add settings detail panels
+
+- bucket: ready_for_maintainer
+- author: Tosko4
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: android, size: M, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-21T08:28:00Z
+- live url: https://github.com/openclaw/openclaw/pull/95148
+
+### #95240 fix(matrix): bound non-raw JSON response body in transport
+
+- bucket: ready_for_maintainer
+- author: Alix-007
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: matrix, size: S, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T08:28:22Z
+- live url: https://github.com/openclaw/openclaw/pull/95240
+
+### #53467 feat(slack): add ignoreOtherMentions channel config
+
+- bucket: ready_for_maintainer
+- author: hanamizuki
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: slack, size: M, triage: dirty-candidate, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, merge-risk: message-delivery, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-21T08:55:12Z
+- live url: https://github.com/openclaw/openclaw/pull/53467
+
+### #85710 fix: use FLAG_TERMINATOR constant in getCommandPathInternal
+
+- bucket: ready_for_maintainer
+- author: d3Lap1ace
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: XS, proof: supplied, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-06-21T08:58:40Z
+- live url: https://github.com/openclaw/openclaw/pull/85710

--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T082436-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T082436-005.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T082436-005
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#81108"
+  - "#87601"
+  - "#85308"
+  - "#88150"
+  - "#88437"
+cluster_refs:
+  - "#81108"
+  - "#87601"
+  - "#85308"
+  - "#88150"
+  - "#88437"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T08:24:36.440Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 5
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #81108 fix(gateway): discover disk compaction checkpoints
+
+- bucket: ready_for_maintainer
+- author: luoyanglang
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XL, proof: supplied, proof: sufficient, P2, rating: platinum hermit, merge-risk: availability, status: ready for maintainer look
+- live updated: 2026-06-21T08:58:43Z
+- live url: https://github.com/openclaw/openclaw/pull/81108
+
+### #87601 fix(docs): render onboarding CLI info callout
+
+- bucket: ready_for_maintainer
+- author: Muggle-akko
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T08:59:05Z
+- live url: https://github.com/openclaw/openclaw/pull/87601
+
+### #85308 fix(subagents): preserve requester wake on visible delivery failure
+
+- bucket: ready_for_maintainer
+- author: DolencLuka
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: gold shrimp, merge-risk: compatibility, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T09:01:45Z
+- live url: https://github.com/openclaw/openclaw/pull/85308
+
+### #88150 fix(config): cap runtime session-store cache retention
+
+- bucket: ready_for_maintainer
+- author: yozakura-ava
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: supplied, proof: sufficient, P1, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-06-21T09:07:50Z
+- live url: https://github.com/openclaw/openclaw/pull/88150
+
+### #88437 docs: clarify blank Control UI recovery
+
+- bucket: ready_for_maintainer
+- author: Freedomziko
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T09:09:09Z
+- live url: https://github.com/openclaw/openclaw/pull/88437

--- a/jobs/openclaw/inbox/live-pr-inventory-20260622T082436-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260622T082436-006.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260622T082436-006
+mode: plan
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#88886"
+  - "#95508"
+  - "#18860"
+  - "#90223"
+  - "#88925"
+cluster_refs:
+  - "#88886"
+  - "#95508"
+  - "#18860"
+  - "#90223"
+  - "#88925"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-06-22T08:24:36.441Z; bucket=ready_for_maintainer; plan-only remediation assessment. No GitHub mutation is permitted from this job."
+---
+
+# PR Remediation Inventory 6
+
+This is a high-volume plan-only remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. Missing merge preflight alone is not a `needs_human` reason: it blocks only `merge_candidate`. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. Do not perform mutations: this job is plan-only.
+
+## Inventory
+
+### #88886 docs(agents): add recovery card handoff guidance
+
+- bucket: ready_for_maintainer
+- author: m4stanuj
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, stale, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T09:12:10Z
+- live url: https://github.com/openclaw/openclaw/pull/88886
+
+### #95508 fix #95489: [Bug]: claude-cli out-of-credits error bypasses model fallback chain error text delivered as final response
+
+- bucket: ready_for_maintainer
+- author: mikasa0818
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: sufficient, P1, rating: platinum hermit, merge-risk: auth-provider, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T09:25:49Z
+- live url: https://github.com/openclaw/openclaw/pull/95508
+
+### #18860 feat(agents): expose tools and their schemas via new after_tools_resolved hook [AI-assisted]
+
+- bucket: ready_for_maintainer
+- author: lan17
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, agents, size: M, proof: sufficient, P2, rating: gold shrimp, merge-risk: compatibility, status: ready for maintainer look, triage: needs-pr-context
+- live updated: 2026-06-21T09:34:43Z
+- live url: https://github.com/openclaw/openclaw/pull/18860
+
+### #90223 test: make qqbot symlinked media helper test robust on Windows
+
+- bucket: ready_for_maintainer
+- author: aniruddhaadak80
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, channel: qqbot, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-06-21T09:43:14Z
+- live url: https://github.com/openclaw/openclaw/pull/90223
+
+### #88925 Fix stuck-session recovery aborts for active reply runs
+
+- bucket: ready_for_maintainer
+- author: SnowSky1
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: M, proof: supplied, proof: sufficient, P1, rating: gold shrimp, merge-risk: session-state, merge-risk: message-delivery, status: ready for maintainer look
+- live updated: 2026-06-21T09:44:00Z
+- live url: https://github.com/openclaw/openclaw/pull/88925


### PR DESCRIPTION
## Summary
- add six plan-mode remediation inventory shards for 30 live ready-for-maintainer OpenClaw PRs
- keep the batch read-only/mutation-free so workers produce merge/fix recommendations before any execution lane

## Validation
- npm run validate
- git diff --check