### PR TITLE
fix: tolerate non-actionable preflight comments

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -337,16 +337,32 @@ function readOnlyBlockers({ sourceJob, pull, view, pullRequest }) {
   if (threads.hasNextPage) blockers.push("PR has more than 100 review threads");
   const unresolved = threads.nodes.filter((thread) => !thread.isResolved);
   if (unresolved.length > 0) blockers.push(`PR has ${unresolved.length} unresolved review thread(s)`);
-  if (issueComments.length > 0) blockers.push(`PR has ${issueComments.length} top-level issue comment(s); manual resolution evidence required`);
-  if (reviewComments.length > 0) blockers.push(`PR has ${reviewComments.length} inline review comment(s); manual resolution evidence required`);
+  const actionableIssueComments = issueComments.filter((comment) => isActionableCommentEvidence(comment, { pull }));
+  if (actionableIssueComments.length > 0) {
+    blockers.push(
+      `PR has ${actionableIssueComments.length} actionable top-level issue comment(s): ${evidenceExamples(actionableIssueComments).join(", ")}`,
+    );
+  }
+  const actionableReviewComments = reviewComments.filter((comment) => isActionableCommentEvidence(comment, { pull }));
+  if (actionableReviewComments.length > 0) {
+    blockers.push(
+      `PR has ${actionableReviewComments.length} actionable inline review comment(s): ${evidenceExamples(actionableReviewComments).join(", ")}`,
+    );
+  }
   const nonApprovalReviewBodies = (view.reviews ?? []).filter(
-    (review) => String(review.body ?? "").trim() && !isReviewBot(review),
+    (review) => String(review.body ?? "").trim() && !isReviewBot(review) && isActionableCommentEvidence(review, { pull }),
   );
   if (nonApprovalReviewBodies.length > 0) {
-    blockers.push(`PR has ${nonApprovalReviewBodies.length} human review body comment(s); manual resolution evidence required`);
+    blockers.push(
+      `PR has ${nonApprovalReviewBodies.length} actionable human review body comment(s): ${evidenceExamples(nonApprovalReviewBodies).join(", ")}`,
+    );
   }
-  const botReviewBodies = (view.reviews ?? []).filter((review) => isReviewBot(review) && String(review.body ?? "").trim());
-  if (botReviewBodies.length > 0) blockers.push(`PR has ${botReviewBodies.length} review-bot finding(s); manual resolution evidence required`);
+  const botReviewBodies = (view.reviews ?? []).filter(
+    (review) => isReviewBot(review) && String(review.body ?? "").trim() && isActionableCommentEvidence(review, { pull }),
+  );
+  if (botReviewBodies.length > 0) {
+    blockers.push(`PR has ${botReviewBodies.length} actionable review-bot finding(s): ${evidenceExamples(botReviewBodies).join(", ")}`);
+  }
   return blockers;
 }
 
@@ -574,6 +590,51 @@ function checkName(check) {
 
 function isReviewBot(review) {
   return REVIEW_BOT_PATTERN.test(`${review.author?.login ?? ""}\n${review.body ?? ""}`);
+}
+
+function isActionableCommentEvidence(comment, { pull }) {
+  const body = String(comment.body ?? "").trim();
+  if (!body) return false;
+  const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
+  const association = String(comment.author_association ?? comment.authorAssociation ?? "").toUpperCase();
+  const normalized = body.toLowerCase();
+
+  if (isBenignAutomationComment({ author, body: normalized })) return false;
+  if (isMaintainerCommandComment({ association, body: normalized })) return false;
+
+  if (isReviewBot({ author: { login: author }, body })) {
+    return /found issues|requested changes|changes requested|needs human|do not merge|duplicate|superseded|security/i.test(
+      body,
+    );
+  }
+
+  const pullAuthor = String(pull?.user?.login ?? "").toLowerCase();
+  if (author && pullAuthor && author === pullAuthor && isAuthorStatusComment(normalized)) return false;
+
+  return true;
+}
+
+function isBenignAutomationComment({ author, body }) {
+  if (!/\[bot\]$|bot$/.test(author)) return false;
+  return (
+    /clawsweeper pr egg|hatched:|hatch command|automatically marked as stale|clawsweeper-command-status|re-review requested|clownfish is on the reef|tagged `clownfish:automerge`/.test(
+      body,
+    ) || /^<!--\s*(?:clawsweeper|clownfish)-command/.test(body)
+  );
+}
+
+function isMaintainerCommandComment({ association, body }) {
+  return ["MEMBER", "OWNER", "COLLABORATOR"].includes(association) && /^\/(?:clownfish|clawsweeper)\b/.test(body);
+}
+
+function isAuthorStatusComment(body) {
+  return /\b(addressed|updated|added|fixed|ready for maintainer|marked `proof: sufficient`|please take a look|merge if)\b/.test(body);
+}
+
+function evidenceExamples(items) {
+  return items
+    .slice(0, 3)
+    .map((item) => item.html_url ?? item.url ?? item.author?.login ?? item.user?.login ?? "comment");
 }
 
 function isCleanCodexReview(review) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -67,7 +67,80 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
   assert.equal(reviewed.status, 0, reviewed.stderr || reviewed.stdout);
 });
 
-function makeFixture() {
+test("external merge preflight tolerates non-actionable automation comments", () => {
+  const fixture = makeFixture({
+    issueComments: [
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: "Codex review: needs maintainer review before merge. Summary only; no findings.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "vincentkoc" },
+        authorAssociation: "MEMBER",
+        body: "/clownfish automerge",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+      {
+        author: { login: "openclaw-clownfish[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: "Clownfish is on the reef for this PR. I tagged `clownfish:automerge`.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-3",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "passed");
+});
+
+test("external merge preflight blocks actionable comment findings", () => {
+  const fixture = makeFixture({
+    issueComments: [
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: "Codex review: found issues before merge. This changes the wrong source file.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
+function makeFixture({ issueComments = [], reviewComments = [], reviews = [] } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-external-preflight-"));
   const binDir = path.join(root, "bin");
   const runDir = path.join(root, "run");
@@ -120,7 +193,7 @@ if (args[0] === "repo" && args[1] === "clone") {
   process.exit(0);
 }
 if (args[0] === "pr" && args[1] === "view") {
-  console.log(JSON.stringify({ comments: [], headRefOid: head, isDraft: false, mergeStateStatus: "CLEAN", mergeable: "MERGEABLE", reviewDecision: "APPROVED", reviews: [], statusCheckRollup: [], updatedAt: "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" }));
+  console.log(JSON.stringify({ comments: ${JSON.stringify(issueComments)}, headRefOid: head, isDraft: false, mergeStateStatus: "CLEAN", mergeable: "MERGEABLE", reviewDecision: "APPROVED", reviews: ${JSON.stringify(reviews)}, statusCheckRollup: [], updatedAt: "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" }));
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {
@@ -128,7 +201,7 @@ if (args[0] === "api" && args[1] === "graphql") {
   process.exit(0);
 }
 if (args[0] === "api" && args[1].includes("/pulls/123/comments")) {
-  console.log("[]");
+  console.log(${JSON.stringify(JSON.stringify(reviewComments))});
   process.exit(0);
 }
 if (args[0] === "api" && args[1].endsWith("/pulls/123")) {


### PR DESCRIPTION
## Summary
- distinguish actionable review/comment evidence from automation boilerplate in external merge preflight
- allow maintainer automerge commands and non-finding ClawSweeper review notes to proceed to fresh validation/Codex review
- keep findings, duplicate/superseded/security text, human discussion, unresolved threads, and actionable review comments blocking

## Validation
- node --check scripts/preflight-external-pr-merge.mjs
- node --test test/preflight-external-pr-merge.test.mjs
- npm test
- npm run validate
- git diff --check