### PR TITLE
fix: tolerate ready automerge preflight evidence

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -314,8 +314,8 @@ function readOnlyBlockers({ sourceJob, pull, view, pullRequest }) {
     pull.title,
     pull.body,
     ...(pull.labels ?? []).map((label) => label.name),
-    ...issueComments.map((comment) => comment.body),
-    ...(view.reviews ?? []).map((review) => review.body),
+    ...issueComments.filter((comment) => !isNonBlockingCommentEvidence(comment, { pull })).map((comment) => comment.body),
+    ...(view.reviews ?? []).filter((review) => !isNonBlockingCommentEvidence(review, { pull })).map((review) => review.body),
     ...reviewComments.map((comment) => comment.body),
   ];
 
@@ -593,14 +593,10 @@ function isReviewBot(review) {
 }
 
 function isActionableCommentEvidence(comment, { pull }) {
-  const body = String(comment.body ?? "").trim();
-  if (!body) return false;
-  const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
-  const association = String(comment.author_association ?? comment.authorAssociation ?? "").toUpperCase();
-  const normalized = body.toLowerCase();
+  if (isNonBlockingCommentEvidence(comment, { pull })) return false;
 
-  if (isBenignAutomationComment({ author, body: normalized })) return false;
-  if (isMaintainerCommandComment({ association, body: normalized })) return false;
+  const body = String(comment.body ?? "").trim();
+  const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
 
   if (isReviewBot({ author: { login: author }, body })) {
     return /found issues|requested changes|changes requested|needs human|do not merge|duplicate|superseded|security/i.test(
@@ -608,14 +604,27 @@ function isActionableCommentEvidence(comment, { pull }) {
     );
   }
 
-  const pullAuthor = String(pull?.user?.login ?? "").toLowerCase();
-  if (author && pullAuthor && author === pullAuthor && isAuthorStatusComment(normalized)) return false;
-
   return true;
 }
 
-function isBenignAutomationComment({ author, body }) {
+function isNonBlockingCommentEvidence(comment, { pull }) {
+  const body = String(comment.body ?? "").trim();
+  if (!body) return true;
+  const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
+  const association = String(comment.author_association ?? comment.authorAssociation ?? "").toUpperCase();
+  const normalized = body.toLowerCase();
+
+  if (isBenignAutomationComment({ author, body: normalized, pull })) return true;
+  if (isMaintainerCommandComment({ association, body: normalized })) return true;
+
+  const pullAuthor = String(pull?.user?.login ?? "").toLowerCase();
+  if (author && pullAuthor && author === pullAuthor && isAuthorStatusComment(normalized)) return true;
+  return false;
+}
+
+function isBenignAutomationComment({ author, body, pull }) {
   if (!/\[bot\]$|bot$/.test(author)) return false;
+  if (isClawSweeperReadyReviewComment({ author, body, pull })) return true;
   return (
     /clawsweeper pr egg|hatched:|hatch command|automatically marked as stale|clawsweeper-command-status|re-review requested|clownfish is on the reef|tagged `clownfish:automerge`/.test(
       body,
@@ -624,7 +633,24 @@ function isBenignAutomationComment({ author, body }) {
 }
 
 function isMaintainerCommandComment({ association, body }) {
-  return ["MEMBER", "OWNER", "COLLABORATOR"].includes(association) && /^\/(?:clownfish|clawsweeper)\b/.test(body);
+  return (
+    ["MEMBER", "OWNER", "COLLABORATOR"].includes(association) &&
+    (/^\/(?:clownfish|clawsweeper)\b/.test(body) || /^<!--\s*(?:clownfish|clawsweeper)-command:/.test(body))
+  );
+}
+
+function isClawSweeperReadyReviewComment({ author, body, pull }) {
+  if (author !== "clawsweeper[bot]") return false;
+  if (!hasClownfishAutomergeLabel(pull)) return false;
+  if (!/^codex review:\s*needs maintainer review before merge\./.test(body)) return false;
+  if (!/(review metrics:\*\*\s*none identified|review metrics:\s*none identified|result:\s*ready for maintainer review|no repair job is needed)/.test(body)) {
+    return false;
+  }
+  return !/found issues before merge|requested changes|changes requested|do not merge/.test(body);
+}
+
+function hasClownfishAutomergeLabel(pull) {
+  return (pull?.labels ?? []).some((label) => String(label?.name ?? "").toLowerCase() === "clownfish:automerge");
 }
 
 function isAuthorStatusComment(body) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -69,17 +69,38 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
 
 test("external merge preflight tolerates non-actionable automation comments", () => {
   const fixture = makeFixture({
+    pullLabels: [{ name: "clownfish:automerge" }],
     issueComments: [
       {
         author: { login: "clawsweeper[bot]" },
         authorAssociation: "CONTRIBUTOR",
-        body: "Codex review: needs maintainer review before merge. Summary only; no findings.",
+        body: [
+          "Codex review: needs maintainer review before merge.",
+          "",
+          "**Review metrics:** none identified.",
+          "",
+          "Result: ready for maintainer review.",
+          "",
+          "**Next step before merge**",
+          "- [P2] No repair job is needed; the remaining action is the maintainer or automerge path for this exact head after normal checks and mergeability gates.",
+          "",
+          "**Security**",
+          "Cleared: Security review cleared: the diff does not touch credentials, auth, dependencies, workflows, package resolution, or code execution surfaces.",
+          "",
+          "<!-- clawsweeper-verdict:needs-human item=123 sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa confidence=high -->",
+          "<!-- clawsweeper-review item=123 -->",
+        ].join("\n"),
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
       },
       {
         author: { login: "vincentkoc" },
         authorAssociation: "MEMBER",
-        body: "/clownfish automerge",
+        body: [
+          "<!-- clownfish-command:4748167943:2026-06-19T03:09:29Z:automerge:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->",
+          "Clownfish is on the reef for this PR.",
+          "",
+          "I tagged `clownfish:automerge` and sent ClawSweeper over this exact head. If the sweep finds rough coral, failing checks, or `needs-human`, I will take another bounded repair lap.",
+        ].join("\n"),
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
       },
       {
@@ -140,7 +161,7 @@ test("external merge preflight blocks actionable comment findings", () => {
   assert.match(report.reason, /actionable top-level issue comment/);
 });
 
-function makeFixture({ issueComments = [], reviewComments = [], reviews = [] } = {}) {
+function makeFixture({ issueComments = [], reviewComments = [], reviews = [], pullLabels = [] } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-external-preflight-"));
   const binDir = path.join(root, "bin");
   const runDir = path.join(root, "run");
@@ -205,7 +226,7 @@ if (args[0] === "api" && args[1].includes("/pulls/123/comments")) {
   process.exit(0);
 }
 if (args[0] === "api" && args[1].endsWith("/pulls/123")) {
-  console.log(JSON.stringify({ state: "open", draft: false, title: "fix: fixture", body: "", html_url: "https://github.com/openclaw/openclaw/pull/123", updated_at: "2026-06-19T00:00:00Z", labels: [], head: { sha: head, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: base, ref: "main" } }));
+  console.log(JSON.stringify({ state: "open", draft: false, title: "fix: fixture", body: "", html_url: "https://github.com/openclaw/openclaw/pull/123", updated_at: "2026-06-19T00:00:00Z", labels: ${JSON.stringify(pullLabels)}, head: { sha: head, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: base, ref: "main" } }));
   process.exit(0);
 }
 process.stderr.write("unexpected gh command: " + args.join(" "));


### PR DESCRIPTION
## Summary
- ignore non-blocking ClawSweeper ready-review evidence when a PR is explicitly labeled `clownfish:automerge`
- treat maintainer command marker comments as command acknowledgements instead of actionable blockers
- keep actual findings, requested changes, do-not-merge text, and unresolved evidence blocking external merge preflight

## Validation
- node --check scripts/preflight-external-pr-merge.mjs
- node --test test/preflight-external-pr-merge.test.mjs
- npm test
- npm run validate
- git diff --check