### PR TITLE
fix: recognize preflight automation app logins

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -623,7 +623,7 @@ function isNonBlockingCommentEvidence(comment, { pull }) {
 }
 
 function isBenignAutomationComment({ author, body, pull }) {
-  if (!/\[bot\]$|bot$/.test(author)) return false;
+  if (!isAutomationAuthor(author)) return false;
   if (isClawSweeperReadyReviewComment({ author, body, pull })) return true;
   return (
     /clawsweeper pr egg|hatched:|hatch command|automatically marked as stale|clawsweeper-command-status|re-review requested|clownfish is on the reef|tagged `clownfish:automerge`/.test(
@@ -640,7 +640,7 @@ function isMaintainerCommandComment({ association, body }) {
 }
 
 function isClawSweeperReadyReviewComment({ author, body, pull }) {
-  if (author !== "clawsweeper[bot]") return false;
+  if (!["clawsweeper", "clawsweeper[bot]"].includes(author)) return false;
   if (!hasClownfishAutomergeLabel(pull)) return false;
   if (!/^codex review:\s*needs maintainer review before merge\./.test(body)) return false;
   if (!/(review metrics:\*\*\s*none identified|review metrics:\s*none identified|result:\s*ready for maintainer review|no repair job is needed)/.test(body)) {
@@ -651,6 +651,10 @@ function isClawSweeperReadyReviewComment({ author, body, pull }) {
 
 function hasClownfishAutomergeLabel(pull) {
   return (pull?.labels ?? []).some((label) => String(label?.name ?? "").toLowerCase() === "clownfish:automerge");
+}
+
+function isAutomationAuthor(author) {
+  return /\[bot\]$|bot$/.test(author) || ["clawsweeper", "openclaw-clownfish"].includes(author);
 }
 
 function isAuthorStatusComment(body) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -72,7 +72,7 @@ test("external merge preflight tolerates non-actionable automation comments", ()
     pullLabels: [{ name: "clownfish:automerge" }],
     issueComments: [
       {
-        author: { login: "clawsweeper[bot]" },
+        author: { login: "clawsweeper" },
         authorAssociation: "CONTRIBUTOR",
         body: [
           "Codex review: needs maintainer review before merge.",


### PR DESCRIPTION
## Summary
- recognize trusted automation app logins such as `clawsweeper` when GitHub omits the `[bot]` suffix
- keep the ready-review preflight exception scoped to ClawSweeper automerge evidence

## Validation
- node --check scripts/preflight-external-pr-merge.mjs
- node --test test/preflight-external-pr-merge.test.mjs
- npm test
- npm run validate
- git diff --check