### PR TITLE
fix: evaluate latest external preflight checks

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -332,7 +332,7 @@ function readOnlyBlockers({ sourceJob, pull, view, pullRequest }) {
   if (["CHANGES_REQUESTED", "REVIEW_REQUIRED"].includes(String(view.reviewDecision ?? ""))) {
     blockers.push(`PR review decision is ${view.reviewDecision}`);
   }
-  const failingChecks = (view.statusCheckRollup ?? []).filter(isFailingCheck).map(checkName);
+  const failingChecks = latestStatusChecks(view.statusCheckRollup ?? []).filter(isFailingCheck).map(checkName);
   if (failingChecks.length > 0) blockers.push(`PR has non-passing checks: ${failingChecks.slice(0, 4).join(", ")}`);
   if (threads.hasNextPage) blockers.push("PR has more than 100 review threads");
   const unresolved = threads.nodes.filter((thread) => !thread.isResolved);
@@ -582,6 +582,23 @@ function isFailingCheck(check) {
   const status = String(check.status ?? check.state ?? "").toUpperCase();
   const conclusion = String(check.conclusion ?? "").toUpperCase();
   return (status && !["COMPLETED", "SUCCESS"].includes(status)) || (conclusion && !PASSING_CHECK_CONCLUSIONS.has(conclusion));
+}
+
+function latestStatusChecks(checks) {
+  const latest = new Map();
+  for (const check of checks) {
+    const key = `${String(check.workflowName ?? "")}\0${checkName(check)}`;
+    const prior = latest.get(key);
+    if (!prior || checkTimestamp(check) >= checkTimestamp(prior)) {
+      latest.set(key, check);
+    }
+  }
+  return [...latest.values()];
+}
+
+function checkTimestamp(check) {
+  const value = Date.parse(String(check.completedAt ?? check.completed_at ?? check.startedAt ?? check.started_at ?? ""));
+  return Number.isFinite(value) ? value : 0;
 }
 
 function checkName(check) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -70,6 +70,24 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
 test("external merge preflight tolerates non-actionable automation comments", () => {
   const fixture = makeFixture({
     pullLabels: [{ name: "clownfish:automerge" }],
+    statusCheckRollup: [
+      {
+        name: "Real behavior proof",
+        workflowName: "Real behavior proof",
+        status: "COMPLETED",
+        conclusion: "CANCELLED",
+        startedAt: "2026-06-18T16:38:09Z",
+        completedAt: "2026-06-18T16:38:12Z",
+      },
+      {
+        name: "Real behavior proof",
+        workflowName: "Real behavior proof",
+        status: "COMPLETED",
+        conclusion: "SUCCESS",
+        startedAt: "2026-06-19T03:15:11Z",
+        completedAt: "2026-06-19T03:15:25Z",
+      },
+    ],
     issueComments: [
       {
         author: { login: "clawsweeper" },
@@ -161,7 +179,7 @@ test("external merge preflight blocks actionable comment findings", () => {
   assert.match(report.reason, /actionable top-level issue comment/);
 });
 
-function makeFixture({ issueComments = [], reviewComments = [], reviews = [], pullLabels = [] } = {}) {
+function makeFixture({ issueComments = [], reviewComments = [], reviews = [], pullLabels = [], statusCheckRollup = [] } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-external-preflight-"));
   const binDir = path.join(root, "bin");
   const runDir = path.join(root, "run");
@@ -214,7 +232,7 @@ if (args[0] === "repo" && args[1] === "clone") {
   process.exit(0);
 }
 if (args[0] === "pr" && args[1] === "view") {
-  console.log(JSON.stringify({ comments: ${JSON.stringify(issueComments)}, headRefOid: head, isDraft: false, mergeStateStatus: "CLEAN", mergeable: "MERGEABLE", reviewDecision: "APPROVED", reviews: ${JSON.stringify(reviews)}, statusCheckRollup: [], updatedAt: "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" }));
+  console.log(JSON.stringify({ comments: ${JSON.stringify(issueComments)}, headRefOid: head, isDraft: false, mergeStateStatus: "CLEAN", mergeable: "MERGEABLE", reviewDecision: "APPROVED", reviews: ${JSON.stringify(reviews)}, statusCheckRollup: ${JSON.stringify(statusCheckRollup)}, updatedAt: "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" }));
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {


### PR DESCRIPTION
## Summary
- evaluate only the latest status check per workflow/name during external merge preflight
- avoid blocking on stale cancelled check attempts when a newer equivalent check passed

## Validation
- node --check scripts/preflight-external-pr-merge.mjs
- node --test test/preflight-external-pr-merge.test.mjs
- npm test
- npm run validate
- git diff --check