### PR TITLE
fix: align unstable merge preflight checks

### DIFF
--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -784,14 +784,14 @@ function validateMergeablePullRequest({ pullRequest, view }) {
   if (pullRequest.draft || view.isDraft) return "pull request is draft";
   if (String(view.baseRefName ?? pullRequest.base?.ref ?? "") !== "main") return "pull request base is not main";
   if (view.mergeable !== "MERGEABLE") return `mergeable state is ${view.mergeable || "unknown"}`;
-  if (!CLEAN_MERGE_STATES.has(String(view.mergeStateStatus ?? ""))) {
-    return `merge state status is ${view.mergeStateStatus || "unknown"}`;
-  }
   if (["CHANGES_REQUESTED", "REVIEW_REQUIRED"].includes(String(view.reviewDecision ?? ""))) {
     return `review decision is ${view.reviewDecision}`;
   }
   const checkBlock = validateStatusChecks(view.statusCheckRollup ?? []);
   if (checkBlock) return checkBlock;
+  if (!isAcceptableMergeState(view)) {
+    return `merge state status is ${view.mergeStateStatus || "unknown"}`;
+  }
   return "";
 }
 
@@ -818,7 +818,7 @@ function validatePullRequestCurrentBase({ repo, pullRequest }) {
 function validateStatusChecks(checks) {
   if (!Array.isArray(checks) || checks.length === 0) return "no PR checks found";
   const blockers = [];
-  for (const check of checks) {
+  for (const check of latestStatusChecks(checks)) {
     const name = check.name ?? check.context ?? "unknown check";
     const status = String(check.status ?? check.state ?? "").toUpperCase();
     const conclusion = String(check.conclusion ?? "").toUpperCase();
@@ -832,6 +832,29 @@ function validateStatusChecks(checks) {
   }
   if (blockers.length > 0) return `checks are not clean: ${blockers.slice(0, 5).join(", ")}`;
   return "";
+}
+
+function isAcceptableMergeState(view) {
+  const state = String(view.mergeStateStatus ?? "");
+  if (CLEAN_MERGE_STATES.has(state)) return true;
+  return state === "UNSTABLE" && view.mergeable === "MERGEABLE" && !validateStatusChecks(view.statusCheckRollup ?? []);
+}
+
+function latestStatusChecks(checks) {
+  const latest = new Map();
+  for (const check of checks) {
+    const key = `${String(check.workflowName ?? "")}\0${check.name ?? check.context ?? "unknown check"}`;
+    const prior = latest.get(key);
+    if (!prior || checkTimestamp(check) >= checkTimestamp(prior)) {
+      latest.set(key, check);
+    }
+  }
+  return [...latest.values()];
+}
+
+function checkTimestamp(check) {
+  const value = Date.parse(String(check.completedAt ?? check.completed_at ?? check.startedAt ?? check.started_at ?? ""));
+  return Number.isFinite(value) ? value : 0;
 }
 
 function isApplicatorAction(action) {

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -326,14 +326,14 @@ function readOnlyBlockers({ sourceJob, pull, view, pullRequest }) {
   if (!/^[0-9a-f]{40}$/i.test(String(pull.head?.sha ?? ""))) blockers.push("PR head SHA is unavailable");
   if (!/^[0-9a-f]{40}$/i.test(String(pull.base?.sha ?? ""))) blockers.push("PR base SHA is unavailable");
   if (view.mergeable !== "MERGEABLE") blockers.push(`PR mergeability is ${view.mergeable ?? "unknown"}`);
-  if (!CLEAN_MERGE_STATES.has(String(view.mergeStateStatus ?? ""))) {
-    blockers.push(`PR merge state is ${view.mergeStateStatus ?? "unknown"}`);
-  }
   if (["CHANGES_REQUESTED", "REVIEW_REQUIRED"].includes(String(view.reviewDecision ?? ""))) {
     blockers.push(`PR review decision is ${view.reviewDecision}`);
   }
   const failingChecks = latestStatusChecks(view.statusCheckRollup ?? []).filter(isFailingCheck).map(checkName);
   if (failingChecks.length > 0) blockers.push(`PR has non-passing checks: ${failingChecks.slice(0, 4).join(", ")}`);
+  if (!isAcceptableMergeState(view)) {
+    blockers.push(`PR merge state is ${view.mergeStateStatus ?? "unknown"}`);
+  }
   if (threads.hasNextPage) blockers.push("PR has more than 100 review threads");
   const unresolved = threads.nodes.filter((thread) => !thread.isResolved);
   if (unresolved.length > 0) blockers.push(`PR has ${unresolved.length} unresolved review thread(s)`);
@@ -582,6 +582,12 @@ function isFailingCheck(check) {
   const status = String(check.status ?? check.state ?? "").toUpperCase();
   const conclusion = String(check.conclusion ?? "").toUpperCase();
   return (status && !["COMPLETED", "SUCCESS"].includes(status)) || (conclusion && !PASSING_CHECK_CONCLUSIONS.has(conclusion));
+}
+
+function isAcceptableMergeState(view) {
+  const state = String(view.mergeStateStatus ?? "");
+  if (CLEAN_MERGE_STATES.has(state)) return true;
+  return state === "UNSTABLE" && view.mergeable === "MERGEABLE" && latestStatusChecks(view.statusCheckRollup ?? []).every((check) => !isFailingCheck(check));
 }
 
 function latestStatusChecks(checks) {

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -378,6 +378,40 @@ test("apply-result pins a clean merge to the reviewed PR head", () => {
   assert.deepEqual(mergeArgs.slice(-3), ["--squash", "--match-head-commit", EXPECTED_HEAD_SHA]);
 });
 
+test("apply-result allows unstable merge state when latest checks are clean", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    mergeStateStatus: "UNSTABLE",
+    statusCheckRollup: [
+      { name: "Real behavior proof", workflowName: "Real behavior proof", status: "COMPLETED", conclusion: "CANCELLED", completedAt: "2026-06-18T16:38:12Z" },
+      { name: "Real behavior proof", workflowName: "Real behavior proof", status: "COMPLETED", conclusion: "SUCCESS", completedAt: "2026-06-19T03:15:25Z" },
+    ],
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "executed");
+});
+
 function apply(jobPath, resultPath, reportPath, binDir, { dryRun = true, callLogPath, allowMerge = false, mergeStatePath } = {}) {
   const args = ["scripts/apply-result.mjs", jobPath, resultPath];
   if (dryRun) args.push("--dry-run");
@@ -505,7 +539,10 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
   fs.chmodSync(ghPath, 0o755);
 }
 
-function writeReadyMergeGhStub(binDir, { headSha }) {
+function writeReadyMergeGhStub(
+  binDir,
+  { headSha, mergeStateStatus = "CLEAN", statusCheckRollup = [{ name: "CI", status: "COMPLETED", conclusion: "SUCCESS" }] },
+) {
   const ghPath = path.join(binDir, "gh");
   fs.writeFileSync(
     ghPath,
@@ -550,9 +587,9 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
     baseRefName: "main",
     isDraft: false,
     mergeable: "MERGEABLE",
-    mergeStateStatus: "CLEAN",
+    mergeStateStatus: ${JSON.stringify(mergeStateStatus)},
     reviewDecision: "APPROVED",
-    statusCheckRollup: [{ name: "CI", status: "COMPLETED", conclusion: "SUCCESS" }]
+    statusCheckRollup: ${JSON.stringify(statusCheckRollup)}
   });
 } else if (args[0] === "pr" && args[1] === "merge" && args[2] === "60063") {
   fs.writeFileSync(process.env.MERGE_STATE, "merged");

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -69,6 +69,7 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
 
 test("external merge preflight tolerates non-actionable automation comments", () => {
   const fixture = makeFixture({
+    mergeStateStatus: "UNSTABLE",
     pullLabels: [{ name: "clownfish:automerge" }],
     statusCheckRollup: [
       {
@@ -179,7 +180,14 @@ test("external merge preflight blocks actionable comment findings", () => {
   assert.match(report.reason, /actionable top-level issue comment/);
 });
 
-function makeFixture({ issueComments = [], reviewComments = [], reviews = [], pullLabels = [], statusCheckRollup = [] } = {}) {
+function makeFixture({
+  issueComments = [],
+  reviewComments = [],
+  reviews = [],
+  pullLabels = [],
+  statusCheckRollup = [],
+  mergeStateStatus = "CLEAN",
+} = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-external-preflight-"));
   const binDir = path.join(root, "bin");
   const runDir = path.join(root, "run");
@@ -232,7 +240,7 @@ if (args[0] === "repo" && args[1] === "clone") {
   process.exit(0);
 }
 if (args[0] === "pr" && args[1] === "view") {
-  console.log(JSON.stringify({ comments: ${JSON.stringify(issueComments)}, headRefOid: head, isDraft: false, mergeStateStatus: "CLEAN", mergeable: "MERGEABLE", reviewDecision: "APPROVED", reviews: ${JSON.stringify(reviews)}, statusCheckRollup: ${JSON.stringify(statusCheckRollup)}, updatedAt: "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" }));
+  console.log(JSON.stringify({ comments: ${JSON.stringify(issueComments)}, headRefOid: head, isDraft: false, mergeStateStatus: ${JSON.stringify(mergeStateStatus)}, mergeable: "MERGEABLE", reviewDecision: "APPROVED", reviews: ${JSON.stringify(reviews)}, statusCheckRollup: ${JSON.stringify(statusCheckRollup)}, updatedAt: "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" }));
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {


### PR DESCRIPTION
## Summary
- let external merge preflight proceed through `UNSTABLE` merge state only when the PR is mergeable and latest checks are clean
- make the guarded applicator use the same latest-check policy so preflight and apply agree
- keep stale base/head, failing latest checks, unresolved comments, and review/security blockers intact

## Validation
- node --check scripts/preflight-external-pr-merge.mjs
- node --check scripts/apply-result.mjs
- node --test test/preflight-external-pr-merge.test.mjs test/apply-result.test.mjs
- npm test
- npm run validate
- git diff --check