### PR TITLE
fix: deepen external preflight merge base

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -382,7 +382,21 @@ function checkoutExactPullHead({ repo, pullRequest, expectedHeadSha }) {
   if (actualHeadSha !== expectedHeadSha) {
     throw new Error(`PR head changed during checkout: expected ${expectedHeadSha}, got ${actualHeadSha}`);
   }
-  run("git", ["merge-base", `origin/${baseBranch}`, "HEAD"], { cwd: targetDir });
+  ensureMergeBase({ cwd: targetDir, baseBranch, pullRequest, ref });
+}
+
+function ensureMergeBase({ cwd, baseBranch, pullRequest, ref }) {
+  for (const depth of [50, 200, 1000]) {
+    const probe = spawnSync("git", ["merge-base", `origin/${baseBranch}`, "HEAD"], {
+      cwd,
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+    });
+    if (probe.status === 0 && String(probe.stdout ?? "").trim()) return;
+    run("git", ["fetch", "--no-tags", "--deepen", String(depth), "origin", `${baseBranch}:refs/remotes/origin/${baseBranch}`], { cwd });
+    run("git", ["fetch", "--no-tags", "--deepen", String(depth), "origin", `pull/${pullRequest}/head:${ref}`], { cwd });
+  }
+  run("git", ["merge-base", `origin/${baseBranch}`, "HEAD"], { cwd });
 }
 
 function prepareTargetToolchain(cwd) {
@@ -766,11 +780,11 @@ function normalizeState(value) {
 }
 
 function redact(value) {
-  return value
-    .replaceAll(process.env.GH_TOKEN ?? "", "[redacted]")
-    .replaceAll(process.env.GITHUB_TOKEN ?? "", "[redacted]")
-    .replaceAll(process.env.CLOWNFISH_READ_GH_TOKEN ?? "", "[redacted]")
-    .slice(0, 1200);
+  let redacted = value;
+  for (const secret of [process.env.GH_TOKEN, process.env.GITHUB_TOKEN, process.env.CLOWNFISH_READ_GH_TOKEN]) {
+    if (secret) redacted = redacted.replaceAll(secret, "[redacted]");
+  }
+  return redacted.slice(0, 1200);
 }
 
 function writeJson(filePath, value) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -13,6 +13,9 @@ test("external merge preflight is exact-head, read-only, and refuses unresolved 
   assert.match(script, /source job does not explicitly contain/);
   assert.match(script, /pull\/\$\{pullRequest\}\/head:\$\{ref\}/);
   assert.match(script, /PR head changed during checkout/);
+  assert.match(script, /function ensureMergeBase/);
+  assert.match(script, /--deepen/);
+  assert.match(script, /if \(secret\) redacted = redacted\.replaceAll/);
   assert.match(script, /base advanced before validation/);
   assert.match(script, /unresolved review thread/);
   assert.match(script, /top-level issue comment/);
@@ -266,6 +269,7 @@ const args = process.argv.slice(2);
 const head = ${JSON.stringify(headSha)};
 const base = ${JSON.stringify(baseSha)};
 if (args[0] === "rev-parse") console.log(args[1] === "origin/main" ? base : head);
+if (args[0] === "merge-base") console.log(base);
 process.exit(0);
 `,
   );


### PR DESCRIPTION
## Summary
- deepen shallow target fetches when external merge preflight cannot prove a merge base
- keep exact-head validation while avoiding false blocks from depth-1 target checkouts
- fix redaction so empty secret env vars do not garble preflight failure messages

## Validation
- node --check scripts/preflight-external-pr-merge.mjs
- node --test test/preflight-external-pr-merge.test.mjs
- npm test
- npm run validate
- git diff --check