### PR TITLE
fix: tolerate clean external merge base drift

### DIFF
--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -521,7 +521,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       live_updated_at: live.updated_at,
     };
   }
-  const currentBaseBlock = validatePullRequestCurrentBase({ repo: result.repo, pullRequest });
+  const currentBaseBlock = validatePullRequestCurrentBase({ repo: result.repo, pullRequest, view });
   if (currentBaseBlock) {
     return {
       ...base,
@@ -795,7 +795,7 @@ function validateMergeablePullRequest({ pullRequest, view }) {
   return "";
 }
 
-function validatePullRequestCurrentBase({ repo, pullRequest }) {
+function validatePullRequestCurrentBase({ repo, pullRequest, view }) {
   const pullRequestBaseSha = String(pullRequest?.base?.sha ?? "");
   const currentMainSha = fetchBranchHeadSha(repo, "main");
   if (!pullRequestBaseSha || !currentMainSha) {
@@ -806,6 +806,9 @@ function validatePullRequestCurrentBase({ repo, pullRequest }) {
     };
   }
   if (pullRequestBaseSha !== currentMainSha) {
+    if (view?.mergeable === "MERGEABLE" && isAcceptableMergeState(view) && !validateStatusChecks(view.statusCheckRollup ?? [])) {
+      return null;
+    }
     return {
       reason: "pull request base is stale relative to current main; rebase and rerun validation",
       pull_request_base_sha: pullRequestBaseSha,

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -83,7 +83,8 @@ try {
 
   checkoutExactPullHead({ repo: sourceJob.frontmatter.repo, pullRequest, expectedHeadSha: pull.head.sha });
   const currentMainSha = run("git", ["rev-parse", `origin/${baseBranch}`], { cwd: targetDir }).trim();
-  if (currentMainSha !== pull.base.sha) {
+  const baseDriftAllowed = currentMainSha !== pull.base.sha && canTolerateBaseDrift(view);
+  if (currentMainSha !== pull.base.sha && !baseDriftAllowed) {
     writeBlockedArtifacts({
       reason: `base advanced before validation: reviewed base ${pull.base.sha}, current ${currentMainSha}`,
       currentMainSha,
@@ -119,6 +120,7 @@ try {
     validationCommands,
     codexReview,
     currentMainSha,
+    baseDriftAllowed,
   });
   report = {
     ...report,
@@ -126,6 +128,7 @@ try {
     reviewed_head_sha: pull.head.sha,
     reviewed_base_sha: pull.base.sha,
     current_main_sha: currentMainSha,
+    base_drift_allowed: baseDriftAllowed,
     validation_commands: validationCommands,
     codex_review: {
       status: codexReview.status,
@@ -502,10 +505,12 @@ function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sour
   return JSON.parse(fs.readFileSync(outputPath, "utf8"));
 }
 
-function buildMergeResult({ sourceJob, virtualJob, pull, view, pullRequest, validationCommands, codexReview, currentMainSha }) {
+function buildMergeResult({ sourceJob, virtualJob, pull, view, pullRequest, validationCommands, codexReview, currentMainSha, baseDriftAllowed }) {
   const evidence = [
     `Exact PR head ${pull.head.sha} checked out from refs/pull/${pullRequest}/head.`,
-    `PR base ${pull.base.sha} matched current origin/main ${currentMainSha} before validation.`,
+    baseDriftAllowed
+      ? `PR base ${pull.base.sha} drifted from origin/main ${currentMainSha}; exact head remained mergeable with clean latest checks and validation ran against origin/main.`
+      : `PR base ${pull.base.sha} matched current origin/main ${currentMainSha} before validation.`,
     `GitHub merge state ${view.mergeStateStatus} and review decision ${view.reviewDecision ?? "none"} were clean.`,
   ];
   return {
@@ -602,6 +607,10 @@ function isAcceptableMergeState(view) {
   const state = String(view.mergeStateStatus ?? "");
   if (CLEAN_MERGE_STATES.has(state)) return true;
   return state === "UNSTABLE" && view.mergeable === "MERGEABLE" && latestStatusChecks(view.statusCheckRollup ?? []).every((check) => !isFailingCheck(check));
+}
+
+function canTolerateBaseDrift(view) {
+  return view?.mergeable === "MERGEABLE" && isAcceptableMergeState(view) && latestStatusChecks(view.statusCheckRollup ?? []).every((check) => !isFailingCheck(check));
 }
 
 function latestStatusChecks(checks) {

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -297,7 +297,7 @@ test("apply-result records primary GitHub rate limits as retryable blocks", () =
   assert.match(report.actions[0].reason, /GitHub rate limit/);
 });
 
-test("apply-result blocks a merge when the PR base is behind current main", () => {
+test("apply-result tolerates stale PR base when exact head remains mergeable with clean checks", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");
   fs.mkdirSync(binDir, { recursive: true });
@@ -314,9 +314,27 @@ test("apply-result blocks a merge when the PR base is behind current main", () =
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
   assert.equal(report.actions[0].status, "blocked");
-  assert.match(report.actions[0].reason, /base is stale relative to current main/);
-  assert.equal(report.actions[0].pull_request_base_sha, "stale-base");
-  assert.equal(report.actions[0].current_main_sha, "current-main");
+  assert.match(report.actions[0].reason, /CLOWNFISH_ALLOW_MERGE=1/);
+});
+
+test("apply-result blocks a stale PR base when latest checks are not clean", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeStaleMergeGhStub(binDir, { statusCheckRollup: [{ name: "CI", status: "IN_PROGRESS", conclusion: "" }] });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /checks are not clean/);
 });
 
 test("apply-result blocks a merge when the PR head changed after worker review", () => {
@@ -486,7 +504,7 @@ process.exit(1);
   fs.chmodSync(ghPath, 0o755);
 }
 
-function writeStaleMergeGhStub(binDir) {
+function writeStaleMergeGhStub(binDir, { statusCheckRollup = [{ name: "CI", status: "COMPLETED", conclusion: "SUCCESS" }] } = {}) {
   const ghPath = path.join(binDir, "gh");
   fs.writeFileSync(
     ghPath,
@@ -528,7 +546,7 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
     mergeable: "MERGEABLE",
     mergeStateStatus: "CLEAN",
     reviewDecision: "APPROVED",
-    statusCheckRollup: [{ name: "CI", status: "COMPLETED", conclusion: "SUCCESS" }]
+    statusCheckRollup: ${JSON.stringify(statusCheckRollup)}
   });
 } else {
   process.stderr.write("unexpected gh call: " + args.join(" ") + "\\n");

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -70,6 +70,30 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
   assert.equal(reviewed.status, 0, reviewed.stderr || reviewed.stdout);
 });
 
+test("external merge preflight tolerates base drift when exact head remains clean", () => {
+  const fixture = makeFixture({ currentMainSha: "c".repeat(40) });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const result = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "result.json"), "utf8"));
+  assert.equal(result.actions.length, 1);
+  assert.match(result.actions[0].evidence.join("\n"), /drifted from origin\/main/);
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.base_drift_allowed, true);
+});
+
 test("external merge preflight tolerates non-actionable automation comments", () => {
   const fixture = makeFixture({
     mergeStateStatus: "UNSTABLE",
@@ -190,6 +214,7 @@ function makeFixture({
   pullLabels = [],
   statusCheckRollup = [],
   mergeStateStatus = "CLEAN",
+  currentMainSha = null,
 } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-external-preflight-"));
   const binDir = path.join(root, "bin");
@@ -268,7 +293,8 @@ process.exit(1);
 const args = process.argv.slice(2);
 const head = ${JSON.stringify(headSha)};
 const base = ${JSON.stringify(baseSha)};
-if (args[0] === "rev-parse") console.log(args[1] === "origin/main" ? base : head);
+const currentMain = ${JSON.stringify(currentMainSha)} || base;
+if (args[0] === "rev-parse") console.log(args[1] === "origin/main" ? currentMain : head);
 if (args[0] === "merge-base") console.log(base);
 process.exit(0);
 `,


### PR DESCRIPTION
## Summary
- allow external merge preflight to tolerate base drift when the exact PR head remains mergeable and latest checks are clean
- keep validation and Codex review pinned to the checked-out exact PR head against current origin/main
- apply the same clean-base-drift policy in the guarded applicator while preserving --match-head-commit

## Validation
- node --check scripts/preflight-external-pr-merge.mjs
- node --check scripts/apply-result.mjs
- node --test test/preflight-external-pr-merge.test.mjs test/apply-result.test.mjs
- npm test
- npm run validate
- git diff --check