### PR TITLE
fix: route external merge apply runner

### DIFF
--- a/.github/workflows/external-merge-preflight.yml
+++ b/.github/workflows/external-merge-preflight.yml
@@ -14,7 +14,7 @@ on:
         required: true
         type: string
       runner:
-        description: "Runner for deterministic target validation and review"
+        description: "Runner for deterministic target validation, review, and guarded apply"
         required: true
         default: blacksmith-16vcpu-ubuntu-2404
         type: string
@@ -108,7 +108,7 @@ jobs:
     name: Apply reviewed merge
     needs: preflight
     if: ${{ needs.preflight.result == 'success' && needs.preflight.outputs.preflight_passed == 'true' && inputs.apply && vars.CLOWNFISH_ALLOW_EXECUTE == '1' && vars.CLOWNFISH_ALLOW_MERGE == '1' }}
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -36,6 +36,7 @@ test("external merge workflow validates before guarded apply", () => {
   assert.match(workflow, /preflight_passed: \$\{\{ steps\.outcome\.outputs\.preflight_passed \}\}/);
   assert.match(workflow, /needs\.preflight\.outputs\.preflight_passed == 'true'/);
   assert.match(workflow, /inputs\.apply && vars\.CLOWNFISH_ALLOW_EXECUTE == '1' && vars\.CLOWNFISH_ALLOW_MERGE == '1'/);
+  assert.match(workflow, /runs-on: \$\{\{ inputs\.runner \}\}/);
   assert.match(workflow, /npm run apply-result/);
   assert.match(workflow, /permission-pull-requests: write/);
 });


### PR DESCRIPTION
## Summary
- route the external merge apply job through the workflow runner input
- keep Blacksmith as the default while allowing ubuntu-latest during Blacksmith outages
- cover the workflow contract in the external preflight test

## Validation
- node --test test/preflight-external-pr-merge.test.mjs
- npm test
- npm run validate
- git diff --check