### PR TITLE
fix: slim external merge artifacts

### DIFF
--- a/.github/workflows/external-merge-preflight.yml
+++ b/.github/workflows/external-merge-preflight.yml
@@ -101,7 +101,11 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: external-merge-preflight-${{ github.run_id }}
-          path: .projectclownfish/external-merge-preflight
+          path: |
+            .projectclownfish/external-merge-preflight/preflight-job.md
+            .projectclownfish/external-merge-preflight/result.json
+            .projectclownfish/external-merge-preflight/cluster-plan.json
+            .projectclownfish/external-merge-preflight/preflight-report.json
           if-no-files-found: warn
 
   apply:
@@ -146,5 +150,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: external-merge-apply-${{ github.run_id }}
-          path: .projectclownfish/external-merge-preflight
+          path: |
+            .projectclownfish/external-merge-preflight/preflight-job.md
+            .projectclownfish/external-merge-preflight/result.json
+            .projectclownfish/external-merge-preflight/cluster-plan.json
+            .projectclownfish/external-merge-preflight/preflight-report.json
+            .projectclownfish/external-merge-preflight/apply-report.json
           if-no-files-found: warn

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -37,6 +37,7 @@ test("external merge workflow validates before guarded apply", () => {
   assert.match(workflow, /needs\.preflight\.outputs\.preflight_passed == 'true'/);
   assert.match(workflow, /inputs\.apply && vars\.CLOWNFISH_ALLOW_EXECUTE == '1' && vars\.CLOWNFISH_ALLOW_MERGE == '1'/);
   assert.match(workflow, /runs-on: \$\{\{ inputs\.runner \}\}/);
+  assert.match(workflow, /external-merge-preflight\/preflight-report\.json/);
   assert.match(workflow, /npm run apply-result/);
   assert.match(workflow, /permission-pull-requests: write/);
 });


### PR DESCRIPTION
## Summary
- upload only external merge preflight/apply JSON reports instead of the full target checkout
- keep apply downloads compatible with the guarded applicator
- cover the workflow artifact contract in tests

## Validation
- node --test test/preflight-external-pr-merge.test.mjs
- npm test
- npm run validate
- git diff --check