### PR TITLE
fix: use actions-safe external review sandbox

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -437,6 +437,8 @@ function runValidation({ targetDir, baseBranch }) {
 function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sourceJob }) {
   const schemaPath = path.join(runDir, "codex-review.schema.json");
   const outputPath = path.join(runDir, "codex-review.json");
+  const defaultCodexReviewSandbox = process.env.GITHUB_ACTIONS === "true" ? "danger-full-access" : "read-only";
+  const codexReviewSandbox = process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_CODEX_SANDBOX ?? defaultCodexReviewSandbox;
   writeJson(schemaPath, {
     $schema: "https://json-schema.org/draft/2020-12/schema",
     type: "object",
@@ -484,7 +486,7 @@ function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sour
       "--model",
       String(process.env.CLOWNFISH_MODEL ?? "gpt-5.5"),
       "--sandbox",
-      "read-only",
+      codexReviewSandbox,
       "--output-schema",
       schemaPath,
       "--output-last-message",

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -20,8 +20,14 @@ test("external merge preflight is exact-head, read-only, and refuses unresolved 
   assert.match(script, /unresolved review thread/);
   assert.match(script, /top-level issue comment/);
   assert.match(script, /inline review comment/);
-  assert.match(script, /--sandbox",\s*"read-only"/);
+  assert.match(
+    script,
+    /const defaultCodexReviewSandbox = process\.env\.GITHUB_ACTIONS === "true" \? "danger-full-access" : "read-only";/,
+  );
+  assert.match(script, /CLOWNFISH_EXTERNAL_PREFLIGHT_CODEX_SANDBOX \?\? defaultCodexReviewSandbox/);
+  assert.match(script, /--sandbox",\s*codexReviewSandbox/);
   assert.match(script, /delete env\[key\]/);
+  assert.match(script, /if \(process\.env\.GITHUB_ACTIONS === "true"\) \{\s*delete env\.OPENAI_API_KEY;\s*delete env\.CODEX_API_KEY;/s);
   assert.match(script, /function validationEnv\(\)[\s\S]*?"CLOWNFISH_READ_GH_TOKEN"/);
   assert.doesNotMatch(script, /pr", "merge"/);
   assert.doesNotMatch(script, /resolveReviewThread/);


### PR DESCRIPTION
## Summary
- use an Actions-safe Codex review sandbox for external merge preflight
- keep local external preflight reviews read-only by default
- preserve token stripping before Codex runs on GitHub Actions

## Why
External merge preflight run 27944689985 blocked #94072 because Codex /review failed before reads with bwrap loopback permissions on ubuntu-latest. This matches the existing Actions-safe run-worker pattern.

## Tests
- node --test test/preflight-external-pr-merge.test.mjs
- node --check scripts/preflight-external-pr-merge.mjs
- git diff --check
- npm test
- npm run validate