### PR TITLE
fix: poll external mergeability preflight

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -61,15 +61,7 @@ let report = {
 
 try {
   pull = ghJson(["api", `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}`]);
-  view = ghJson([
-    "pr",
-    "view",
-    String(pullRequest),
-    "--repo",
-    sourceJob.frontmatter.repo,
-    "--json",
-    "comments,headRefOid,isDraft,mergeStateStatus,mergeable,reviewDecision,reviews,statusCheckRollup,updatedAt,url",
-  ]);
+  view = fetchSettledPullRequestView({ repo: sourceJob.frontmatter.repo, pullRequest });
 
   const virtualJob = writePreflightJob({ sourceJob, pull, pullRequest, runDir });
   preflightJobPath = virtualJob.path;
@@ -306,6 +298,32 @@ function sourceJobPermissions(job) {
     allow_merge: job.frontmatter.allow_merge === true,
     maintainer_calibration: [...(job.frontmatter.maintainer_calibration ?? [])],
   };
+}
+
+function fetchSettledPullRequestView({ repo, pullRequest }) {
+  const attempts = positiveInteger(process.env.CLOWNFISH_MERGEABLE_POLL_ATTEMPTS, 6);
+  const delayMs = nonNegativeInteger(process.env.CLOWNFISH_MERGEABLE_POLL_DELAY_MS, 5000);
+  let latest = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    latest = ghJson([
+      "pr",
+      "view",
+      String(pullRequest),
+      "--repo",
+      repo,
+      "--json",
+      "comments,headRefOid,isDraft,mergeStateStatus,mergeable,reviewDecision,reviews,statusCheckRollup,updatedAt,url",
+    ]);
+    if (!hasUnknownMergeability(latest)) return latest;
+    if (attempt < attempts && delayMs > 0) {
+      run("sleep", [String(delayMs / 1000)]);
+    }
+  }
+  return latest;
+}
+
+function hasUnknownMergeability(view) {
+  return ["", "UNKNOWN"].includes(String(view?.mergeable ?? "").toUpperCase()) || ["", "UNKNOWN"].includes(String(view?.mergeStateStatus ?? "").toUpperCase());
 }
 
 function readOnlyBlockers({ sourceJob, pull, view, pullRequest }) {
@@ -722,6 +740,16 @@ function isCleanCodexReview(review) {
     review.findings.length === 0 &&
     review.findings_addressed === true
   );
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function nonNegativeInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
 function ghJson(commandArgs) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -102,6 +102,35 @@ test("external merge preflight tolerates base drift when exact head remains clea
   assert.equal(report.base_drift_allowed, true);
 });
 
+test("external merge preflight polls transient unknown mergeability", () => {
+  const fixture = makeFixture({
+    mergeViews: [
+      { mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" },
+      { mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+        CLOWNFISH_MERGEABLE_POLL_DELAY_MS: "0",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const result = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "result.json"), "utf8"));
+  assert.equal(result.actions.length, 1);
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "passed");
+});
+
 test("external merge preflight tolerates non-actionable automation comments", () => {
   const fixture = makeFixture({
     mergeStateStatus: "UNSTABLE",
@@ -222,6 +251,7 @@ function makeFixture({
   pullLabels = [],
   statusCheckRollup = [],
   mergeStateStatus = "CLEAN",
+  mergeViews = null,
   currentMainSha = null,
 } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-external-preflight-"));
@@ -269,6 +299,7 @@ const path = require("node:path");
 const args = process.argv.slice(2);
 const head = ${JSON.stringify(headSha)};
 const base = ${JSON.stringify(baseSha)};
+const mergeViews = ${JSON.stringify(mergeViews)};
 if (args[0] === "repo" && args[1] === "clone") {
   const target = args[3];
   fs.mkdirSync(path.join(target, ".git"), { recursive: true });
@@ -276,7 +307,11 @@ if (args[0] === "repo" && args[1] === "clone") {
   process.exit(0);
 }
 if (args[0] === "pr" && args[1] === "view") {
-  console.log(JSON.stringify({ comments: ${JSON.stringify(issueComments)}, headRefOid: head, isDraft: false, mergeStateStatus: ${JSON.stringify(mergeStateStatus)}, mergeable: "MERGEABLE", reviewDecision: "APPROVED", reviews: ${JSON.stringify(reviews)}, statusCheckRollup: ${JSON.stringify(statusCheckRollup)}, updatedAt: "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" }));
+  const counterPath = ${JSON.stringify(path.join(root, "pr-view-count"))};
+  const count = fs.existsSync(counterPath) ? Number(fs.readFileSync(counterPath, "utf8")) : 0;
+  fs.writeFileSync(counterPath, String(count + 1));
+  const mergeView = Array.isArray(mergeViews) ? mergeViews[Math.min(count, mergeViews.length - 1)] : {};
+  console.log(JSON.stringify({ comments: ${JSON.stringify(issueComments)}, headRefOid: head, isDraft: false, mergeStateStatus: mergeView.mergeStateStatus ?? ${JSON.stringify(mergeStateStatus)}, mergeable: mergeView.mergeable ?? "MERGEABLE", reviewDecision: "APPROVED", reviews: ${JSON.stringify(reviews)}, statusCheckRollup: ${JSON.stringify(statusCheckRollup)}, updatedAt: "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" }));
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {


### PR DESCRIPTION
## Summary
- poll transient UNKNOWN mergeability from `gh pr view` before blocking external merge preflight
- keep UNKNOWN as a real blocker after bounded retries
- add a fixture that returns UNKNOWN then MERGEABLE

## Why
After #200 fixed the Actions sandbox issue, run 27945279151 still skipped apply because GitHub returned `mergeable=UNKNOWN` and `mergeStateStatus=UNKNOWN` inside Actions. Live re-fetch outside the workflow showed #94072 was MERGEABLE/UNSTABLE with clean checks, so this should be treated as a transient computed-field delay.

## Tests
- node --test test/preflight-external-pr-merge.test.mjs
- node --check scripts/preflight-external-pr-merge.mjs
- git diff --check
- npm test
- npm run validate