### PR TITLE
fix: pass applicator token to gh

### DIFF
--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -1084,6 +1084,7 @@ function ghWithRetry(ghArgs, attempts = 6) {
 
 function githubCliEnv() {
   const env = { ...process.env, NO_COLOR: "1", CLICOLOR: "0" };
+  if (!env.GH_TOKEN && env.CLOWNFISH_GH_TOKEN) env.GH_TOKEN = env.CLOWNFISH_GH_TOKEN;
   delete env.FORCE_COLOR;
   return env;
 }

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -9,6 +9,12 @@ const repoRoot = path.resolve(import.meta.dirname, "..");
 const EXPECTED_HEAD_SHA = "a".repeat(40);
 const CHANGED_HEAD_SHA = "b".repeat(40);
 
+test("apply-result maps the applicator token into gh CLI auth", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "apply-result.mjs"), "utf8");
+
+  assert.match(source, /if \(!env\.GH_TOKEN && env\.CLOWNFISH_GH_TOKEN\) env\.GH_TOKEN = env\.CLOWNFISH_GH_TOKEN;/);
+});
+
 test("apply-result allows explicit current-main fixed-by close without candidate_fix", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");


### PR DESCRIPTION
## Summary
- map CLOWNFISH_GH_TOKEN into GH_TOKEN for apply-result gh subprocesses
- keep no-color gh output behavior unchanged
- add a regression check for the token mapping

## Why
Run 27945644915 proved external preflight passed for openclaw/openclaw#94072, but the apply job failed immediately because gh in GitHub Actions requires GH_TOKEN. The workflow only exposed the App token as CLOWNFISH_GH_TOKEN.

## Tests
- node --test test/apply-result.test.mjs
- node --check scripts/apply-result.mjs
- git diff --check
- npm test
- npm run validate