### PR TITLE
fix: allow adopted automerge repair risk labels

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2458,11 +2458,12 @@ function validateLiveAutonomousTargetPolicy({ job, fixArtifact }) {
     const pull = fetchPullRequest(source.number);
     const labels = (pull.labels ?? []).map((label) => String(label?.name ?? label)).filter(Boolean);
     const normalizedLabels = labels.map((label) => label.toLowerCase());
+    const isAdoptedAutomergeTarget = source.number === adoptedAutomergeTarget;
     const blockedSignals = [
-      ...(normalizedLabels.includes("clawsweeper:automerge") && source.number !== adoptedAutomergeTarget
+      ...(normalizedLabels.includes("clawsweeper:automerge") && !isAdoptedAutomergeTarget
         ? ["clawsweeper:automerge"]
         : []),
-      ...labels.filter((label) => /^merge-risk:/i.test(label)),
+      ...labels.filter((label) => /^merge-risk:/i.test(label) && (!isAdoptedAutomergeTarget || hasDeterministicSecuritySignal({ labels: [label] }))),
       ...(hasDeterministicSecuritySignal({ labels }) ? ["security-sensitive"] : []),
     ];
     if (blockedSignals.length === 0) continue;

--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -743,7 +743,8 @@ function findHighRiskMutationLabel(labels, { allowAutomergeRepair = false } = {}
     .map(String)
     .find(
       (label) =>
-        /^merge-risk:/i.test(label) || (label.toLowerCase() === "clawsweeper:automerge" && !allowAutomergeRepair),
+        (allowAutomergeRepair ? /^merge-risk:.*security/i.test(label) : /^merge-risk:/i.test(label)) ||
+        (label.toLowerCase() === "clawsweeper:automerge" && !allowAutomergeRepair),
     );
 }
 

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -251,8 +251,65 @@ test("execute-fix-artifact permits ClawSweeper automerge labels only for the ado
   assert.match(source, /job\.frontmatter\.source !== "pr_automerge"/);
   assert.match(
     source,
-    /normalizedLabels\.includes\("clawsweeper:automerge"\) && source\.number !== adoptedAutomergeTarget/,
+    /normalizedLabels\.includes\("clawsweeper:automerge"\) && !isAdoptedAutomergeTarget/,
   );
+});
+
+test("execute-fix-artifact permits non-security merge-risk labels for the adopted automerge repair target", () => {
+  const fixture = makeFixture();
+  const clusterId = "live-target-policy-adopted-risk";
+  const resultPath = path.join(fixture.runDir, "result.json");
+  const reportPath = path.join(fixture.runDir, "fix-execution-report.json");
+  const ghLog = path.join(fixture.root, "gh.log");
+
+  fs.writeFileSync(
+    fixture.jobPath,
+    jobFile(clusterId)
+      .replace("canonical: []", 'canonical:\n  - "#1"')
+      .replace("security_sensitive: false", "security_sensitive: false\nsource: pr_automerge"),
+  );
+  const result = resultFile(clusterId);
+  result.actions = [{ action: "fix_needed", status: "planned", target: "#1" }];
+  result.fix_artifact.repair_strategy = "repair_contributor_branch";
+  result.fix_artifact.source_prs = ["https://github.com/openclaw/openclaw/pull/1"];
+  fs.writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`);
+  writeLiveTargetPolicyGhStub({ binDir: fixture.binDir, ghLog, labels: ["merge-risk: compatibility", "clawsweeper:automerge"] });
+
+  const child = spawnSync(
+    process.execPath,
+    [
+      "scripts/execute-fix-artifact.mjs",
+      fixture.jobPath,
+      resultPath,
+      "--target-dir",
+      fixture.targetDir,
+      "--work-dir",
+      fixture.workDir,
+      "--report",
+      reportPath,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+        CLOWNFISH_ALLOW_EXECUTE: "1",
+        CLOWNFISH_ALLOW_FIX_PR: "1",
+      },
+    },
+  );
+
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  assert.deepEqual(fs.readFileSync(ghLog, "utf8").trim().split("\n"), [
+    "api repos/openclaw/openclaw/pulls/1",
+    "api repos/openclaw/openclaw/issues/1/comments?per_page=100 --paginate --jq .[].body",
+  ]);
+
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.notEqual(report.code, "live_target_policy_block");
+  assert.notEqual(report.actions[0]?.code, "live_target_policy_block");
 });
 
 test("execute-fix-artifact ignores security-routed lineage that is not a mutable repair source", () => {

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -1074,7 +1074,7 @@ test("review-results rejects executable repair paths bound to risk-labeled prefl
   }
 });
 
-test("review-results permits ClawSweeper automerge labels for adopted repair jobs only", () => {
+test("review-results permits non-security automerge risk labels for adopted repair jobs only", () => {
   const dir = makeResultDir(
     {
       mode: "autonomous",
@@ -1116,7 +1116,7 @@ test("review-results permits ClawSweeper automerge labels for adopted repair job
             kind: "pull_request",
             state: "open",
             title: "fix(cron): repair timer behavior",
-            labels: ["clawsweeper:automerge"],
+            labels: ["clawsweeper:automerge", "merge-risk: availability"],
             updated_at: "2026-06-15T10:00:00Z",
             security_sensitive: false,
           },
@@ -1152,6 +1152,64 @@ test("review-results permits ClawSweeper automerge labels for adopted repair job
 
   assert.notEqual(unhydrated.status, 0);
   assert.match(unhydrated.stdout, /#91286 adopted automerge repair source was not hydrated in preflight/);
+});
+
+test("review-results still blocks security merge-risk labels for adopted repair jobs", () => {
+  const dir = makeResultDir(
+    {
+      mode: "autonomous",
+      actions: [
+        {
+          target: "#91286",
+          action: "fix_needed",
+          status: "planned",
+          idempotency_key: "cluster-test:fix-needed:91286:adopted-automerge-security",
+          classification: "canonical",
+          target_kind: "pull_request",
+          target_updated_at: "2026-06-15T10:00:00Z",
+          evidence: ["#91286 is the bounded contributor repair target."],
+          reason: "Repair the contributor branch and preserve attribution.",
+        },
+      ],
+      fix_artifact: validFixArtifact({
+        repair_strategy: "repair_contributor_branch",
+        linked_refs: ["#91286"],
+        source_prs: ["https://github.com/openclaw/openclaw/pull/91286"],
+        credit_notes: ["Preserve the original contributor's credit on the repaired branch."],
+      }),
+    },
+    {
+      job: fixEnabledJob().replace("mode: autonomous", "mode: autonomous\nsource: pr_automerge"),
+      plan: {
+        source_job_permissions: {
+          source: "pr_automerge",
+          canonical: ["#91286"],
+          allowed_actions: ["comment", "label", "close", "fix", "raise_pr"],
+          blocked_actions: ["force_push"],
+          allow_fix_pr: true,
+          allow_merge: false,
+          maintainer_calibration: [],
+        },
+        items: [
+          {
+            ref: "#91286",
+            kind: "pull_request",
+            state: "open",
+            title: "fix(cron): repair timer behavior",
+            labels: ["merge-risk: security-boundary"],
+            updated_at: "2026-06-15T10:00:00Z",
+            security_sensitive: false,
+          },
+        ],
+      },
+    },
+  );
+  fs.rmSync(path.join(dir, "job.md"));
+
+  const result = review(dir);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /#91286 executable repair target has blocked label: merge-risk: security-boundary/);
 });
 
 test("review-results rejects close actions targeting risk-labeled preflight PRs", () => {


### PR DESCRIPTION
## Summary
- allow maintainer-opted `source: pr_automerge` repair jobs to repair their adopted PR despite non-security `merge-risk:*` labels
- keep security merge-risk labels and unrelated automerge/risk-labeled PRs blocked

## Tests
- `node --test test/review-results.test.mjs --test-name-pattern=automerge|risk labels|security merge-risk`
- `node --test test/execute-fix-artifact.test.mjs --test-name-pattern=live autonomous repair targets|adopted automerge repair target|ClawSweeper automerge labels`
- `npm test`
- `npm run validate`
- `git diff --check`