### PR TITLE
fix: trust adopted automerge source scope

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2506,14 +2506,21 @@ function validateAutonomousFixScope({ job, fixArtifact }) {
   const crossesCore = likelyFiles.some((file) => /^src\//.test(String(file)));
   const crossSurfaceCount = [crossesDocs, crossesConfig, crossesTests, crossesCore].filter(Boolean).length;
   const tooManyFiles = likelyFiles.length > maxAutonomousFixFiles;
+  const tooManySurfacesBeforeScope = affectedSurfaces.length > maxAutonomousFixSurfaces;
+  const mixedFeatureScopeBeforeScope = likelyFiles.length > 4 && crossSurfaceCount >= 3;
+
+  if (!featureSignal || (!tooManyFiles && !tooManySurfacesBeforeScope && !mixedFeatureScopeBeforeScope)) return null;
+
   const allowedFixFiles = declaredAllowedFixFiles(job);
-  const artifactWithinDeclaredScope =
-    allowedFixFiles.length > 0 &&
+  const adoptedAutomergeFiles = adoptedAutomergeRepairSourceFiles({ job, fixArtifact });
+  const allowedScopeFiles = uniqueStrings([...allowedFixFiles, ...adoptedAutomergeFiles]);
+  const artifactWithinAllowedScope =
+    allowedScopeFiles.length > 0 &&
     likelyFiles.length > 0 &&
-    likelyFiles.every((file) => allowedFixFiles.includes(String(file)));
+    likelyFiles.every((file) => allowedScopeFiles.includes(String(file)));
   const tooManySurfaces =
-    affectedSurfaces.length > maxAutonomousFixSurfaces && !artifactWithinDeclaredScope;
-  const mixedFeatureScope = likelyFiles.length > 4 && crossSurfaceCount >= 3;
+    tooManySurfacesBeforeScope && !artifactWithinAllowedScope;
+  const mixedFeatureScope = mixedFeatureScopeBeforeScope && !artifactWithinAllowedScope;
 
   if (!featureSignal || (!tooManyFiles && !tooManySurfaces && !mixedFeatureScope)) return null;
 
@@ -2526,7 +2533,8 @@ function validateAutonomousFixScope({ job, fixArtifact }) {
       `affected_surfaces=${affectedSurfaces.length}/${maxAutonomousFixSurfaces}`,
       `cross_surface_count=${crossSurfaceCount}`,
       `mixed_feature_scope=${mixedFeatureScope}`,
-      `artifact_within_declared_scope=${artifactWithinDeclaredScope}`,
+      `artifact_within_allowed_scope=${artifactWithinAllowedScope}`,
+      `adopted_automerge_scope_files=${adoptedAutomergeFiles.length}`,
       `sample_files=${likelyFiles.slice(0, 8).join(", ")}`,
     ],
   };
@@ -2534,6 +2542,21 @@ function validateAutonomousFixScope({ job, fixArtifact }) {
 
 function declaredAllowedFixFiles(job) {
   return [...new Set((job.frontmatter.allowed_fix_files ?? []).map((file) => String(file).trim()).filter(Boolean))];
+}
+
+function adoptedAutomergeRepairSourceFiles({ job, fixArtifact }) {
+  const adoptedTarget = adoptedAutomergeRepairTarget(job);
+  if (!adoptedTarget || fixArtifact.repair_strategy !== "repair_contributor_branch") return [];
+
+  let source;
+  try {
+    source = firstSourcePullRequest(fixArtifact);
+  } catch {
+    return [];
+  }
+  if (source.number !== adoptedTarget) return [];
+
+  return fetchPullRequestFilePaths({ targetDir: repoRoot(), number: adoptedTarget });
 }
 
 function validateRebaseOnlyRepair({ job, fixArtifact }) {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -42,16 +42,28 @@ test("execute-fix-artifact enforces job action permissions for replacement side 
   assert.match(source, /function appendAutomergeRepairOutcomeComment\([\s\S]*?if \(!jobAllowsAction\("comment"\)\)/);
 });
 
-test("execute-fix-artifact permits surface-heavy artifacts only within a declared file allowlist", () => {
+test("execute-fix-artifact permits surface-heavy artifacts within an explicit or adopted PR file scope", () => {
   const source = fs.readFileSync(path.join(repoRoot, "scripts", "execute-fix-artifact.mjs"), "utf8");
 
   assert.match(
     source,
-    /const artifactWithinDeclaredScope =[\s\S]*?likelyFiles\.every\(\(file\) => allowedFixFiles\.includes\(String\(file\)\)\);/,
+    /const adoptedAutomergeFiles = adoptedAutomergeRepairSourceFiles\(\{ job, fixArtifact \}\);/,
   );
   assert.match(
     source,
-    /const tooManySurfaces =\s*\n\s*affectedSurfaces\.length > maxAutonomousFixSurfaces && !artifactWithinDeclaredScope;/,
+    /const allowedScopeFiles = uniqueStrings\(\[\.\.\.allowedFixFiles, \.\.\.adoptedAutomergeFiles\]\);/,
+  );
+  assert.match(
+    source,
+    /const artifactWithinAllowedScope =[\s\S]*?likelyFiles\.every\(\(file\) => allowedScopeFiles\.includes\(String\(file\)\)\);/,
+  );
+  assert.match(
+    source,
+    /const tooManySurfaces =\s*\n\s*tooManySurfacesBeforeScope && !artifactWithinAllowedScope;/,
+  );
+  assert.match(
+    source,
+    /function adoptedAutomergeRepairSourceFiles\(\{ job, fixArtifact \}\)[\s\S]*?fixArtifact\.repair_strategy !== "repair_contributor_branch"[\s\S]*?source\.number !== adoptedTarget[\s\S]*?fetchPullRequestFilePaths\(\{ targetDir: repoRoot\(\), number: adoptedTarget \}\)/,
   );
 });
 
@@ -522,7 +534,8 @@ test("execute-fix-artifact defers a broad scope block only for explicit rebase-o
 test("execute-fix-artifact permits narrow config-and-test repairs", () => {
   const source = fs.readFileSync(path.join(repoRoot, "scripts", "execute-fix-artifact.mjs"), "utf8");
 
-  assert.match(source, /const mixedFeatureScope = likelyFiles\.length > 4 && crossSurfaceCount >= 3;/);
+  assert.match(source, /const mixedFeatureScopeBeforeScope = likelyFiles\.length > 4 && crossSurfaceCount >= 3;/);
+  assert.match(source, /const mixedFeatureScope = mixedFeatureScopeBeforeScope && !artifactWithinAllowedScope;/);
   assert.match(source, /!tooManyFiles && !tooManySurfaces && !mixedFeatureScope/);
 });
 


### PR DESCRIPTION
## Summary
- allow adopted `source: pr_automerge` repairs to use the live source PR file list as the autonomous scope
- keep broad-scope blocking for unrelated or non-adopted repairs
- cover the executor scope guard in tests

## Verification
- `node --test test/execute-fix-artifact.test.mjs --test-name-pattern='surface-heavy|narrow config|risk labels|adopted automerge|live autonomous repair targets'`\n- `npm test`\n- `npm run validate`\n- `git diff --check`