### PR TITLE
test: update security boundary quarantine expectation

### DIFF
--- a/test/import-close-canaries-from-results.test.mjs
+++ b/test/import-close-canaries-from-results.test.mjs
@@ -275,7 +275,7 @@ test("import-close-canaries quarantines security-shaped candidates before genera
   );
   assert.deepEqual(
     payload.dropped.map((candidate) => [candidate.target, candidate.reason]),
-    [["#91286", "security signal in target"]],
+    [["#91286", "target has human-hold label merge-risk: security-boundary"]],
   );
   assert.equal(fs.existsSync(path.join(fixture.inbox, "pr-close-canary-91286-test.md")), false);
   assert.equal(fs.existsSync(path.join(fixture.inbox, "pr-close-canary-92164-test.md")), true);


### PR DESCRIPTION
## Summary

- What changed: update the canary-import assertion for the current human-hold label.
- Why: `merge-risk: security-boundary` is intentionally reported as the more specific protection reason.

## Verification

- Targeted import tests: 7/7 passing.
- Full validation: 6,487 jobs validated.

AI-assisted: yes.
