### PR TITLE
fix: retry resumed validation repairs

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2046,10 +2046,7 @@ function isRetryableValidationFixError(error) {
   }
   const baseline = error.changed_gate_baseline;
   if (baseline?.status !== "failed") return true;
-  return (
-    baseline.report?.eligible === true &&
-    !sameDiagnosticSet(baseline.diagnostics.items, currentDiagnostics.items)
-  );
+  return baseline.report?.eligible === true;
 }
 
 function runCodexValidationFix({ fixArtifact, targetDir, mode, validationError, attempt }) {

--- a/scripts/import-close-canaries-from-results.mjs
+++ b/scripts/import-close-canaries-from-results.mjs
@@ -239,11 +239,11 @@ function dropReasonFor(item, target, canonical) {
   if (!target) return "target not found";
   if (!canonical) return "canonical not found";
   if (target.state !== "OPEN") return `target is ${target.state}`;
+  const securityReason = securityDropReason(item, target, canonical);
+  if (securityReason) return securityReason;
   const protectionReason = targetProtectionDropReason(target);
   if (protectionReason) return protectionReason;
   if (!canCloseAgainstCanonical(item, canonical)) return canonicalDropReason(item, canonical);
-  const securityReason = securityDropReason(item, target, canonical);
-  if (securityReason) return securityReason;
   return "";
 }
 

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -1205,7 +1205,7 @@ test("execute-fix-artifact rejects changed-gate failures with new diagnostics", 
   assert.equal(fs.existsSync(run.targetedTestMarker), false);
 });
 
-test("execute-fix-artifact rejects unchanged baseline diagnostics that touch changed files", () => {
+test("execute-fix-artifact tries validation repair for unchanged baseline diagnostics that touch changed files", () => {
   const output = "src/app.test.js(2,1): error TS2322: Type 'string' is not assignable to type 'number'.";
   const run = runBaselineChangedGateFixture({
     clusterId: "changed-file-diagnostic-cluster",
@@ -1216,6 +1216,7 @@ test("execute-fix-artifact rejects unchanged baseline diagnostics that touch cha
   assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
   assert.equal(run.report.status, "blocked");
   assert.equal(run.report.changed_gate_baseline.eligible, true);
+  assert.match(fs.readFileSync(run.validationPrompt, "utf8"), /src\/app\.test\.js\(2,1\): error TS2322/);
   assert.equal(fs.existsSync(run.targetedTestMarker), false);
 });
 
@@ -1307,6 +1308,7 @@ function runBaselineChangedGateFixture({
   const targetedTestMarker = path.join(fixture.root, "targeted-test-command");
   const changedGateMarker = path.join(fixture.root, "check-changed-calls");
   const initialPrompt = path.join(fixture.root, "initial-codex-prompt");
+  const validationPrompt = path.join(fixture.root, "validation-fix-prompt");
 
   fs.writeFileSync(fixture.jobPath, jobFile(clusterId));
   const result = resultFile(clusterId);
@@ -1332,6 +1334,8 @@ if (args.includes("--output-schema")) {
 }
 if (!fs.existsSync(${JSON.stringify(initialPrompt)})) {
   fs.writeFileSync(${JSON.stringify(initialPrompt)}, fs.readFileSync(0, "utf8"));
+} else {
+  fs.writeFileSync(${JSON.stringify(validationPrompt)}, fs.readFileSync(0, "utf8"));
 }
 fs.writeFileSync(path.join(cd, ${JSON.stringify(editedFile)}), "export const fixture = true;\\n");
 if (${JSON.stringify(dependencyManifestChange)}) {
@@ -1414,6 +1418,7 @@ process.exit(0);
     targetedTestMarker,
     changedGateMarker,
     initialPrompt,
+    validationPrompt,
   };
 }
 


### PR DESCRIPTION
## Summary
- let resumed fix branches run validation repair when eligible changed-gate diagnostics match the captured baseline
- keep close-canary security quarantine precedence deterministic before generic human-hold labels
- add regression coverage proving unchanged baseline diagnostics on touched files are handed to the validation repair prompt

## Evidence
- `node --check scripts/execute-fix-artifact.mjs`
- `node --check scripts/import-close-canaries-from-results.mjs`
- `node --test --test-name-pattern 'changed-gate failures with new diagnostics|unchanged baseline diagnostics that touch changed files|repairs an ordinary validation exit failure' test/execute-fix-artifact.test.mjs`
- `node --test --test-name-pattern 'quarantines security-shaped candidates before generation|skips maintainer targets and human-hold targets|quarantines security-shaped canonical refs' test/import-close-canaries-from-results.test.mjs`
- `node --test test/execute-fix-artifact.test.mjs`
- `npm test`
- `npm run validate`
- `git diff --check`
