### PR TITLE
fix(automation): restore daily PR intake

### DIFF
--- a/.github/workflows/checks-success-preflight-intake.yml
+++ b/.github/workflows/checks-success-preflight-intake.yml
@@ -50,7 +50,7 @@ env:
 
 jobs:
   intake:
-    if: ${{ github.event_name != 'schedule' || vars.CLOWNFISH_CHECKS_SUCCESS_PREFLIGHT_ENABLED != '0' }}
+    if: ${{ github.event_name != 'schedule' || vars.CLOWNFISH_CHECKS_SUCCESS_PREFLIGHT_ENABLED == '' || vars.CLOWNFISH_CHECKS_SUCCESS_PREFLIGHT_ENABLED != '0' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -94,6 +94,7 @@ jobs:
             --mode autonomous \
             --strategy remediation \
             --checks-success \
+            --sort recent \
             --limit "$LIMIT" \
             --batch-size "$BATCH_SIZE" \
             --json > "$IMPORT_JSON"

--- a/scripts/import-github-pr-inventory.mjs
+++ b/scripts/import-github-pr-inventory.mjs
@@ -229,7 +229,7 @@ function fetchOpenPullRequestsFromSearch() {
     fields,
   ];
   if (checksSuccessPreflight) {
-    ghArgs.push("--checks", "success");
+    ghArgs.push("--base", "main", "--checks", "success");
   } else if (strategy === "remediation") {
     ghArgs.push("--label", "status: 👀 ready for maintainer look", "--label", "proof: sufficient");
   }
@@ -453,7 +453,9 @@ function prListMergeBlocker(raw) {
   if (raw.isDraft) return true;
   if (checksSuccessPreflight) {
     const authorAssociation = asciiString(raw.authorAssociation ?? "");
+    const unexpectedAssignee = assigneeNames(raw.assignees).some((login) => login.toLowerCase() !== "vincentkoc");
     if (isMaintainerAssociated(authorAssociation) || hasMaintainerLabel(labels)) return true;
+    if (unexpectedAssignee) return true;
     if (hasStatusBlockedLabel(labels)) return true;
     if (hasChecksSuccessScopeBlocker(raw.title, labels)) return true;
   }
@@ -885,6 +887,7 @@ function existingMentionedRefs(roots) {
 }
 
 function existingRefsForStrategy() {
+  if (checksSuccessPreflight) return new Set();
   if (strategy === "low-signal") return existingLowSignalRefs();
   return existingMentionedRefs([existingDir]);
 }
@@ -1054,7 +1057,10 @@ function hasRemediationNoiseTitle(title) {
 
 function hasChecksSuccessScopeBlocker(title, labels) {
   if (hasRemediationNoiseTitle(title) || /^feat(?:\(.+?\))?:/i.test(String(title ?? "").trim())) return true;
-  return labels.some((label) => /^(?:app:\s*web-ui|docs|size:\s*XL|feature:)/i.test(String(label ?? "").trim()));
+  if (!labels.some((label) => /^rating:\s*(?:platinum|diamond)\b/i.test(String(label ?? "").trim()))) return true;
+  return labels.some((label) =>
+    /^(?:app:\s*web-ui|docs|size:\s*XL|feature:|P(?:[3-9]|[1-9]\d+)\b)/i.test(String(label ?? "").trim()),
+  );
 }
 
 function isMaintainerAssociated(value) {

--- a/scripts/import-github-pr-inventory.mjs
+++ b/scripts/import-github-pr-inventory.mjs
@@ -34,7 +34,7 @@ const existingResultsActionPolicy = String(
   args["existing-results-action-policy"] ?? args.existing_results_action_policy ?? "terminal",
 );
 const defaultInventorySource = checksSuccessPreflight
-  ? "pr-list"
+  ? "search"
   : strategy === "remediation" && mode === "autonomous"
     ? "pr-list"
     : "graphql";
@@ -235,7 +235,8 @@ function fetchOpenPullRequestsFromSearch() {
   }
   const pulls = ghJsonWithRetry(ghArgs, { operation: "search open pull request inventory" });
   if (!Array.isArray(pulls)) throw new Error("GitHub PR search returned a non-array payload");
-  return pulls.map(normalizeSearchPullRequest);
+  const normalized = pulls.map(normalizeSearchPullRequest);
+  return checksSuccessPreflight ? normalized.filter((pull) => !prListMergeBlocker(pull)) : normalized;
 }
 
 function fetchOpenPullRequestsFromPrList() {
@@ -452,10 +453,9 @@ function prListMergeBlocker(raw) {
   if (raw.isDraft) return true;
   if (checksSuccessPreflight) {
     const authorAssociation = asciiString(raw.authorAssociation ?? "");
-    const assignees = assigneeNames(raw.assignees);
-    if (isMaintainerAssociated(authorAssociation) || assignees.length > 0 || hasMaintainerLabel(labels)) return true;
-    if (commentCount(raw) > 0) return true;
+    if (isMaintainerAssociated(authorAssociation) || hasMaintainerLabel(labels)) return true;
     if (hasStatusBlockedLabel(labels)) return true;
+    if (hasChecksSuccessScopeBlocker(raw.title, labels)) return true;
   }
   if (raw.baseRefName && raw.baseRefName !== "main") return true;
   if (includeMergeRisk && mergeRisk) return false;
@@ -692,7 +692,9 @@ function classifyLowSignalCandidate(base, { body }) {
 function chooseBucket({ raw, title, labels, assignees, authorAssociation }) {
   if (strategy === "low-signal") return "low_signal_candidate";
   if (hasExactSecuritySignal({ title, labels })) return "security_route_candidate";
-  if (isMaintainerAssociated(authorAssociation) || assignees.length > 0) return "maintainer_owned";
+  if (isMaintainerAssociated(authorAssociation) || (!checksSuccessPreflight && assignees.length > 0)) {
+    return "maintainer_owned";
+  }
   if (Boolean(raw.isDraft)) return "draft";
   if (labels.some((label) => /needs-real-behavior-proof|needs proof|mock-only-proof|waiting on author/i.test(label))) {
     return "needs_proof";
@@ -793,7 +795,7 @@ function writeJob(batch, index) {
     )}`,
     `notes: ${quoteYaml(
       checksSuccessPreflight
-        ? `Generated from live GitHub checks-success PR inventory on ${now.toISOString()}; bucket=${bucket}; filtered for external merge preflight candidates with no obvious maintainer, status, comment, security, merge-risk, check, or mergeability blockers.`
+        ? `Generated from live GitHub checks-success PR inventory on ${now.toISOString()}; bucket=${bucket}; filtered for external merge preflight candidates with no obvious maintainer-author, status, security, merge-risk, check, or mergeability blockers.`
         : remediation
           ? `Generated from live GitHub open PR inventory on ${now.toISOString()}; bucket=${bucket}; ${
             autonomousRemediation
@@ -1048,6 +1050,11 @@ function hasMergeRiskLabel(labels) {
 
 function hasRemediationNoiseTitle(title) {
   return /^(?:test|tests|docs|doc|chore|refactor|style|lint|ci)(?:\(.+?\))?:/i.test(String(title ?? "").trim());
+}
+
+function hasChecksSuccessScopeBlocker(title, labels) {
+  if (hasRemediationNoiseTitle(title) || /^feat(?:\(.+?\))?:/i.test(String(title ?? "").trim())) return true;
+  return labels.some((label) => /^(?:app:\s*web-ui|docs|size:\s*XL|feature:)/i.test(String(label ?? "").trim()));
 }
 
 function isMaintainerAssociated(value) {

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -588,7 +588,9 @@ function buildMergeResult({ sourceJob, virtualJob, pull, issue, view, pullReques
           "Fresh deterministic security scan found no matching signal in the PR title, body, labels, issue comments, reviews, or inline review comments.",
         ],
         comments_status: "resolved",
-        comments_evidence: ["Fresh GitHub hydration found zero top-level issue comments, zero inline review comments, and zero unresolved review threads."],
+        comments_evidence: [
+          "Fresh GitHub hydration found no actionable top-level or inline comments and no unresolved review threads.",
+        ],
         bot_comments_status: "resolved",
         bot_comments_evidence: ["Fresh GitHub hydration found zero review-bot comments or review bodies requiring follow-up."],
         codex_review: {
@@ -689,7 +691,7 @@ function isActionableCommentEvidence(comment, { pull }) {
     );
   }
 
-  return hasActionableCommentConcern(body);
+  return Boolean(body);
 }
 
 function isNonBlockingCommentEvidence(comment, { pull }) {
@@ -700,7 +702,9 @@ function isNonBlockingCommentEvidence(comment, { pull }) {
   const normalized = body.toLowerCase();
 
   if (isBenignAutomationComment({ author, body: normalized, pull })) return true;
+  if (String(comment.state ?? "").toUpperCase() === "APPROVED") return true;
   if (isMaintainerCommandComment({ association, body: normalized })) return true;
+  if (isMaintainerApprovalComment({ association, body: normalized })) return true;
   if (isReviewRequestComment(normalized)) return true;
 
   const pullAuthor = String(pull?.user?.login ?? "").toLowerCase();
@@ -747,6 +751,13 @@ function isMaintainerCommandComment({ association, body }) {
   return (
     ["MEMBER", "OWNER", "COLLABORATOR"].includes(association) &&
     (/^\/(?:clownfish|clawsweeper)\b/.test(body) || /^<!--\s*(?:clownfish|clawsweeper)-command:/.test(body))
+  );
+}
+
+function isMaintainerApprovalComment({ association, body }) {
+  return (
+    ["MEMBER", "OWNER", "COLLABORATOR"].includes(association) &&
+    /^(?:lgtm|looks good(?: to me)?|approved|ship it|:\+1:|👍)[.! ]*$/.test(body)
   );
 }
 

--- a/test/import-github-pr-inventory.test.mjs
+++ b/test/import-github-pr-inventory.test.mjs
@@ -306,7 +306,12 @@ test("remediation inventory can hydrate only included refs", () => {
 
 test("checks-success remediation intake filters noisy preflight blockers", () => {
   const fixture = makeFixture();
-  writeFakeGh(fixture.gh, { includeChecksSuccessPreflight: true, includeNoisePrList: true });
+  writeFakeGh(fixture.gh, {
+    includeChecksSuccessPreflight: true,
+    includeNoisePrList: true,
+    requireSearchBase: true,
+  });
+  writeExistingJob(path.join(fixture.existing, "retry.md"), "#116");
 
   const result = runImport(
     fixture,
@@ -316,8 +321,6 @@ test("checks-success remediation intake filters noisy preflight blockers", () =>
     "--checks-success",
     "--limit",
     "all",
-    "--skip-existing",
-    "false",
   );
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const payload = JSON.parse(result.stdout);
@@ -332,6 +335,7 @@ test("checks-success remediation intake filters noisy preflight blockers", () =>
   assert.equal(refs.has("#115"), false);
   assert.equal(refs.has("#117"), false);
   assert.equal(refs.has("#118"), false);
+  assert.equal(refs.has("#120"), false);
 
   const job = fs.readFileSync(path.join(fixture.out, path.basename(payload.generated[0].path)), "utf8");
   assert.match(job, /Checks-Success PR External Preflight/);
@@ -619,7 +623,7 @@ function writeFakeGh(filePath, options = {}) {
     title: "checks success clean candidate",
     url: "https://github.com/openclaw/openclaw/pull/116",
     updatedAt: "2026-01-16T00:00:00Z",
-    labels: [{ name: "size: S" }],
+    labels: [{ name: "size: S" }, { name: "P2" }, { name: "rating: platinum hermit" }],
     commentsCount: 0,
   };
   const commentedChecksSuccessPull = {
@@ -646,9 +650,23 @@ function writeFakeGh(filePath, options = {}) {
     updatedAt: "2026-01-17T00:00:00Z",
     labels: [{ name: "maintainer" }],
   };
+  const assignedChecksSuccessPull = {
+    ...checksSuccessPull,
+    number: 120,
+    title: "assigned checks success candidate",
+    url: "https://github.com/openclaw/openclaw/pull/120",
+    updatedAt: "2026-01-20T00:00:00Z",
+    assignees: [{ login: "steipete" }],
+  };
   if (options.includeChecksSuccessPreflight) {
     searchPulls.push(
-      ...[commentedChecksSuccessPull, statusBlockedChecksSuccessPull, checksSuccessPull, maintainerChecksSuccessPull].map((pull) => ({
+      ...[
+        commentedChecksSuccessPull,
+        statusBlockedChecksSuccessPull,
+        checksSuccessPull,
+        maintainerChecksSuccessPull,
+        assignedChecksSuccessPull,
+      ].map((pull) => ({
         ...pull,
         labels: pull.labels,
         assignees: pull.assignees,
@@ -664,7 +682,13 @@ function writeFakeGh(filePath, options = {}) {
     ...(options.includeSecondRiskPrList ? [secondRiskPrListPull] : []),
     ...(options.includeNoisePrList ? [noisePrListPull] : []),
     ...(options.includeChecksSuccessPreflight
-      ? [commentedChecksSuccessPull, statusBlockedChecksSuccessPull, checksSuccessPull, maintainerChecksSuccessPull]
+      ? [
+          commentedChecksSuccessPull,
+          statusBlockedChecksSuccessPull,
+          checksSuccessPull,
+          maintainerChecksSuccessPull,
+          assignedChecksSuccessPull,
+        ]
       : []),
     cleanPrListPull,
   ];
@@ -682,6 +706,14 @@ if (process.argv[2] === "pr" && process.argv[3] === "view" && String(process.arg
       ? "GraphQL: Something went wrong while executing your query on 2026-07-01T08:35:56Z. Please include `EFAC:390CD1:97CD82:99C543:6A44D16B` when reporting this issue."
       : "HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)",
   )});
+  process.exit(1);
+}
+if (
+  process.argv[2] === "search" &&
+  ${JSON.stringify(Boolean(options.requireSearchBase))} &&
+  process.argv[process.argv.indexOf("--base") + 1] !== "main"
+) {
+  console.error("checks-success search must target base main");
   process.exit(1);
 }
 const payload = process.argv[2] === "search"

--- a/test/import-github-pr-inventory.test.mjs
+++ b/test/import-github-pr-inventory.test.mjs
@@ -306,7 +306,7 @@ test("remediation inventory can hydrate only included refs", () => {
 
 test("checks-success remediation intake filters noisy preflight blockers", () => {
   const fixture = makeFixture();
-  writeFakeGh(fixture.gh, { includeChecksSuccessPreflight: true });
+  writeFakeGh(fixture.gh, { includeChecksSuccessPreflight: true, includeNoisePrList: true });
 
   const result = runImport(
     fixture,
@@ -322,15 +322,16 @@ test("checks-success remediation intake filters noisy preflight blockers", () =>
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const payload = JSON.parse(result.stdout);
 
-  assert.equal(payload.options.inventory_source, "pr-list");
+  assert.equal(payload.options.inventory_source, "search");
   assert.equal(payload.options.bucket, "all");
   assert.equal(payload.options.checks_success_preflight, true);
 
   const refs = new Set(payload.candidates.map((candidate) => candidate.ref));
   assert.equal(refs.has("#116"), true);
-  assert.equal(refs.has("#114"), false);
+  assert.equal(refs.has("#114"), true);
   assert.equal(refs.has("#115"), false);
   assert.equal(refs.has("#117"), false);
+  assert.equal(refs.has("#118"), false);
 
   const job = fs.readFileSync(path.join(fixture.out, path.basename(payload.generated[0].path)), "utf8");
   assert.match(job, /Checks-Success PR External Preflight/);
@@ -604,6 +605,14 @@ function writeFakeGh(filePath, options = {}) {
     url: "https://github.com/openclaw/openclaw/pull/118",
     updatedAt: "2026-01-18T00:00:00Z",
   };
+  if (options.includeNoisePrList) {
+    searchPulls.push({
+      ...noisePrListPull,
+      labels: noisePrListPull.labels,
+      assignees: noisePrListPull.assignees,
+      commentsCount: noisePrListPull.commentsCount,
+    });
+  }
   const checksSuccessPull = {
     ...cleanPrListPull,
     number: 116,
@@ -637,6 +646,16 @@ function writeFakeGh(filePath, options = {}) {
     updatedAt: "2026-01-17T00:00:00Z",
     labels: [{ name: "maintainer" }],
   };
+  if (options.includeChecksSuccessPreflight) {
+    searchPulls.push(
+      ...[commentedChecksSuccessPull, statusBlockedChecksSuccessPull, checksSuccessPull, maintainerChecksSuccessPull].map((pull) => ({
+        ...pull,
+        labels: pull.labels,
+        assignees: pull.assignees,
+        commentsCount: pull.commentsCount,
+      })),
+    );
+  }
   const prListPulls = [
     existingPrListPull,
     dirtyPrListPull,

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -74,10 +74,12 @@ test("cluster worker chains blocked merge candidates through external preflight"
 
 test("daily checks-success intake feeds guarded external merge preflights", () => {
   assert.match(intakeWorkflow, /cron: "17 7 \* \* \*"/);
+  assert.match(intakeWorkflow, /CLOWNFISH_CHECKS_SUCCESS_PREFLIGHT_ENABLED == ''/);
   assert.match(intakeWorkflow, /CLOWNFISH_CHECKS_SUCCESS_PREFLIGHT_ENABLED != '0'/);
   assert.match(intakeWorkflow, /scripts\/import-github-pr-inventory\.mjs/);
   assert.match(intakeWorkflow, /--strategy remediation/);
   assert.match(intakeWorkflow, /--checks-success/);
+  assert.match(intakeWorkflow, /--sort recent/);
   assert.match(intakeWorkflow, /default: "30"/);
   assert.match(intakeWorkflow, /default: ubuntu-latest/);
   assert.match(intakeWorkflow, /git commit -m "chore: add daily checks-success preflight jobs"/);

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -271,12 +271,6 @@ test("external merge preflight tolerates non-actionable automation comments", ()
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-3",
       },
       {
-        author: { login: "external-reviewer" },
-        authorAssociation: "NONE",
-        body: "This seems like the right fix boundary and matches the reported behavior.",
-        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-4",
-      },
-      {
         author: { login: "contributor" },
         authorAssociation: "CONTRIBUTOR",
         body: "@clawsweeper re-review",
@@ -392,6 +386,37 @@ test("external merge preflight blocks actionable human comments", () => {
         author: { login: "reviewer" },
         authorAssociation: "NONE",
         body: "Please add a regression test before merge.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
+test("external merge preflight blocks non-keyword human objections", () => {
+  const fixture = makeFixture({
+    issueComments: [
+      {
+        author: { login: "reviewer" },
+        authorAssociation: "MEMBER",
+        body: "I am not convinced by this approach.",
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
       },
     ],


### PR DESCRIPTION
## Summary
- default scheduled intake to enabled when the repository variable is unset
- scan recent passing PRs through the lightweight search path
- keep exact-head preflight as the mutation gate while filtering risky/noise scopes

## Validation
- `node --test test/import-github-pr-inventory.test.mjs`
- `node --test test/preflight-external-pr-merge.test.mjs`
- `npm run validate`
- live dry-run selected current PRs #99894 and #99898