### PR TITLE
fix(automation): avoid stale preflight retries

### DIFF
--- a/scripts/import-github-pr-inventory.mjs
+++ b/scripts/import-github-pr-inventory.mjs
@@ -60,6 +60,7 @@ const prListFallbackSearchLimit = numberArg(
   Math.min(searchLimit, Math.max(limitForHydration * 12, 120)),
 );
 const lowSignalHydrateLimit = numberArg("low-signal-hydrate-limit", Math.max(limitForHydration * 12, 300));
+const checksSuccessRetryCooldownHours = numberArg("checks-success-retry-cooldown-hours", 72);
 const blockedLowSignalLabelPatterns = compileLabelPatterns(
   argValues(process.argv.slice(2), ["block-label", "block_label"], args["block-label"] ?? args.block_label ?? DEFAULT_LOW_SIGNAL_BLOCK_LABELS),
 );
@@ -79,6 +80,8 @@ if (!["all", "terminal"].includes(existingResultsActionPolicy)) die("--existing-
 
 const existingRefs = skipExisting ? existingRefsForStrategy() : new Set();
 if (skipExisting) mergeRefs(existingRefs, existingPublishedResultRefs(existingResultsDir, repo, existingResultsActionPolicy));
+const checksSuccessAttempts =
+  skipExisting && checksSuccessPreflight ? existingChecksSuccessAttempts(existingDir) : new Map();
 const rawOpenPullRequests = fetchOpenPullRequests();
 if (strategy === "low-signal") hydrateLowSignalPullRequestFiles(rawOpenPullRequests);
 const candidates = dedupeCandidates(
@@ -120,6 +123,7 @@ const payload = sanitizeJsonValue({
     include_security_candidates: includeSecurity,
     include_merge_risk_candidates: strategy === "remediation" ? includeMergeRisk : null,
     checks_success_preflight: strategy === "remediation" ? checksSuccessPreflight : null,
+    checks_success_retry_cooldown_hours: checksSuccessPreflight ? checksSuccessRetryCooldownHours : null,
     search_limit: inventorySource === "search" ? searchLimit : null,
     include_refs_file: includeRefs
       ? path.relative(repoRoot(), path.resolve(String(args["include-refs-file"] ?? args.include_refs_file)))
@@ -236,7 +240,35 @@ function fetchOpenPullRequestsFromSearch() {
   const pulls = ghJsonWithRetry(ghArgs, { operation: "search open pull request inventory" });
   if (!Array.isArray(pulls)) throw new Error("GitHub PR search returned a non-array payload");
   const normalized = pulls.map(normalizeSearchPullRequest);
-  return checksSuccessPreflight ? normalized.filter((pull) => !prListMergeBlocker(pull)) : normalized;
+  if (!checksSuccessPreflight) return normalized;
+  return hydrateChecksSuccessPullRequests(
+    normalized
+      .filter((pull) => !prListMergeBlocker(pull))
+      .filter((pull) => shouldRetryChecksSuccessPullRequest(pull)),
+  );
+}
+
+function hydrateChecksSuccessPullRequests(pulls) {
+  const hydratedPulls = [];
+  for (const pull of pulls) {
+    let hydrated;
+    try {
+      hydrated = hydratePullRequestForPrListFallback(pull.number);
+    } catch (error) {
+      const retryable = isRetryableGhError(error);
+      const missing = isMissingPullRequestError(error);
+      if (!retryable && !missing) throw error;
+      const failure = retryable ? "failed after retries" : "could not be hydrated";
+      console.error(`hydrate pull request #${pull.number} ${failure}; skipping candidate`);
+      continue;
+    }
+    if (!hydrated) continue;
+    const normalized = normalizePrListPullRequest(hydrated);
+    if (prListMergeBlocker(normalized)) continue;
+    hydratedPulls.push(normalized);
+    if (limit !== "all" && hydratedPulls.length >= limitForHydration) break;
+  }
+  return hydratedPulls;
 }
 
 function fetchOpenPullRequestsFromPrList() {
@@ -892,6 +924,43 @@ function existingRefsForStrategy() {
   return existingMentionedRefs([existingDir]);
 }
 
+function existingChecksSuccessAttempts(root) {
+  const attempts = new Map();
+  if (!fs.existsSync(root)) return attempts;
+  for (const file of markdownJobFiles(root)) {
+    const text = fs.readFileSync(file, "utf8");
+    if (!text.includes("# Checks-Success PR External Preflight")) continue;
+    try {
+      if (String(parseJob(file).frontmatter.repo ?? "") !== repo) continue;
+    } catch {
+      continue;
+    }
+    const generatedAt = Date.parse(
+      text.match(/Generated from live GitHub checks-success PR inventory on ([^;"]+)/)?.[1] ?? "",
+    );
+    if (!Number.isFinite(generatedAt)) continue;
+    for (const section of text.split(/^### /m).slice(1)) {
+      const ref = section.match(/^(#\d+)\b/)?.[1];
+      const updatedAt = section.match(/^- live updated:\s*(.+)$/m)?.[1]?.trim();
+      if (!ref || !updatedAt) continue;
+      const prior = attempts.get(ref);
+      if (!prior || generatedAt > prior.generatedAt) attempts.set(ref, { generatedAt, updatedAt });
+    }
+  }
+  return attempts;
+}
+
+function shouldRetryChecksSuccessPullRequest(pull) {
+  const ref = `#${pull.number}`;
+  if (existingRefs.has(ref)) return false;
+  const attempt = checksSuccessAttempts.get(ref);
+  if (!attempt) return true;
+  const updatedAt = String(pull.updatedAt ?? "");
+  if (!updatedAt || updatedAt !== attempt.updatedAt) return true;
+  const cooldownMs = checksSuccessRetryCooldownHours * 60 * 60 * 1000;
+  return Date.now() - attempt.generatedAt >= cooldownMs;
+}
+
 function existingLowSignalRefs() {
   const jobsDir = path.join(repoRoot(), "jobs");
   const refs = new Set();
@@ -1149,6 +1218,11 @@ function isRetryableGhError(error) {
   return /timed out|timeout|TLS handshake|connection reset|502 Bad Gateway|503 Service Unavailable|504 Gateway Timeout|secondary rate|Something went wrong while executing your query/i.test(
     message,
   );
+}
+
+function isMissingPullRequestError(error) {
+  const message = String(error?.stderr ?? error?.message ?? error);
+  return /Could not resolve to a PullRequest with the number of \d+\.|HTTP 404: Not Found/i.test(message);
 }
 
 function numberFromEnv(name, fallback) {

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -702,7 +702,12 @@ function isNonBlockingCommentEvidence(comment, { pull }) {
   const normalized = body.toLowerCase();
 
   if (isBenignAutomationComment({ author, body: normalized, pull })) return true;
-  if (String(comment.state ?? "").toUpperCase() === "APPROVED") return true;
+  if (
+    String(comment.state ?? "").toUpperCase() === "APPROVED" &&
+    !hasActionableApprovedReviewBody(normalized)
+  ) {
+    return true;
+  }
   if (isMaintainerCommandComment({ association, body: normalized })) return true;
   if (isMaintainerApprovalComment({ association, body: normalized })) return true;
   if (isReviewRequestComment(normalized)) return true;
@@ -710,6 +715,22 @@ function isNonBlockingCommentEvidence(comment, { pull }) {
   const pullAuthor = String(pull?.user?.login ?? "").toLowerCase();
   if (author && pullAuthor && author === pullAuthor && isAuthorStatusComment(normalized)) return true;
   return false;
+}
+
+function hasActionableApprovedReviewBody(body) {
+  const unresolved = body
+    .replace(/\b(?:no|without)\s+(?:blocking\s+)?(?:concerns?|issues?|findings?|blockers?)\b/gi, "")
+    .replace(/\bsecurity (?:checks?|review) (?:passed|cleared)\b/gi, "")
+    .replace(/\bsecurity (?:concerns?|issues?|risks?) (?:are )?(?:resolved|addressed|cleared)\b/gi, "");
+  return [
+    /\b(?:do not|don't|should not|shouldn't|cannot|can't)\s+(?:merge|land|ship)\b/i,
+    /\b(?:hold off|not ready|not convinced|changes? requested)\b/i,
+    /\b(?:this|it|the (?:pr|patch|change))\s+(?:breaks?|fails?|regresses?|leaks?|exposes?)\b/i,
+    /\b(?:needs?|requires?)\s+(?:changes?|fix(?:es)?|work|tests?|follow-?up)\b/i,
+    /\b(?:must|please)\s+(?:fix|address|change|add|remove|resolve)\b/i,
+    /\b(?:still blocking|blocker (?:remains|is unresolved))\b/i,
+    /\bsecurity\b.{0,60}\b(?:unclear|concern|issue|risk|blocker)\b/i,
+  ].some((pattern) => pattern.test(unresolved));
 }
 
 function isBenignAutomationComment({ author, body, pull }) {

--- a/test/import-github-pr-inventory.test.mjs
+++ b/test/import-github-pr-inventory.test.mjs
@@ -311,7 +311,10 @@ test("checks-success remediation intake filters noisy preflight blockers", () =>
     includeNoisePrList: true,
     requireSearchBase: true,
   });
-  writeExistingJob(path.join(fixture.existing, "retry.md"), "#116");
+  writeChecksSuccessJob(path.join(fixture.existing, "retry.md"), "#116", {
+    generatedAt: new Date().toISOString(),
+    updatedAt: "2026-01-16T00:00:00Z",
+  });
 
   const result = runImport(
     fixture,
@@ -328,19 +331,114 @@ test("checks-success remediation intake filters noisy preflight blockers", () =>
   assert.equal(payload.options.inventory_source, "search");
   assert.equal(payload.options.bucket, "all");
   assert.equal(payload.options.checks_success_preflight, true);
+  assert.equal(payload.options.checks_success_retry_cooldown_hours, 72);
 
   const refs = new Set(payload.candidates.map((candidate) => candidate.ref));
-  assert.equal(refs.has("#116"), true);
+  assert.equal(refs.has("#116"), false);
   assert.equal(refs.has("#114"), true);
   assert.equal(refs.has("#115"), false);
   assert.equal(refs.has("#117"), false);
   assert.equal(refs.has("#118"), false);
   assert.equal(refs.has("#120"), false);
+  assert.equal(refs.has("#121"), false);
 
   const job = fs.readFileSync(path.join(fixture.out, path.basename(payload.generated[0].path)), "utf8");
   assert.match(job, /Checks-Success PR External Preflight/);
   assert.match(job, /external-preflight shard/);
   assert.match(job, /external_merge_preflight_required/);
+});
+
+test("checks-success remediation retries changed or cooled-down candidates", () => {
+  const changedFixture = makeFixture();
+  writeFakeGh(changedFixture.gh, { includeChecksSuccessPreflight: true });
+  writeChecksSuccessJob(path.join(changedFixture.existing, "changed.md"), "#116", {
+    generatedAt: new Date().toISOString(),
+    updatedAt: "2026-01-15T00:00:00Z",
+  });
+  const changedResult = runImport(
+    changedFixture,
+    "--strategy",
+    "remediation",
+    "--checks-success",
+    "--limit",
+    "all",
+  );
+  assert.equal(changedResult.status, 0, changedResult.stderr || changedResult.stdout);
+  assert.equal(JSON.parse(changedResult.stdout).candidates.some((candidate) => candidate.ref === "#116"), true);
+
+  const cooledFixture = makeFixture();
+  writeFakeGh(cooledFixture.gh, { includeChecksSuccessPreflight: true });
+  writeChecksSuccessJob(path.join(cooledFixture.existing, "cooled.md"), "#116", {
+    generatedAt: new Date(Date.now() - 73 * 60 * 60 * 1000).toISOString(),
+    updatedAt: "2026-01-16T00:00:00Z",
+  });
+  const cooledResult = runImport(
+    cooledFixture,
+    "--strategy",
+    "remediation",
+    "--checks-success",
+    "--limit",
+    "all",
+  );
+  assert.equal(cooledResult.status, 0, cooledResult.stderr || cooledResult.stdout);
+  assert.equal(JSON.parse(cooledResult.stdout).candidates.some((candidate) => candidate.ref === "#116"), true);
+
+  const crossRepoFixture = makeFixture();
+  writeFakeGh(crossRepoFixture.gh, { includeChecksSuccessPreflight: true });
+  writeChecksSuccessJob(path.join(crossRepoFixture.existing, "cross-repo.md"), "#116", {
+    repo: "openclaw/clownfish",
+    generatedAt: new Date().toISOString(),
+    updatedAt: "2026-01-16T00:00:00Z",
+  });
+  const crossRepoResult = runImport(
+    crossRepoFixture,
+    "--strategy",
+    "remediation",
+    "--checks-success",
+    "--limit",
+    "all",
+  );
+  assert.equal(crossRepoResult.status, 0, crossRepoResult.stderr || crossRepoResult.stdout);
+  assert.equal(JSON.parse(crossRepoResult.stdout).candidates.some((candidate) => candidate.ref === "#116"), true);
+});
+
+test("checks-success remediation skips stale search results that cannot hydrate", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.gh, {
+    includeChecksSuccessPreflight: true,
+    failHydrateNumber: 116,
+    failHydrateNotFound: true,
+  });
+  const result = runImport(
+    fixture,
+    "--strategy",
+    "remediation",
+    "--checks-success",
+    "--limit",
+    "all",
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stderr, /hydrate pull request #116 could not be hydrated; skipping candidate/);
+  assert.equal(JSON.parse(result.stdout).candidates.some((candidate) => candidate.ref === "#116"), false);
+});
+
+test("checks-success remediation fails closed on hydration auth errors", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.gh, {
+    includeChecksSuccessPreflight: true,
+    failHydrateNumber: 116,
+    failHydrateAuth: true,
+  });
+  const result = runImport(
+    fixture,
+    "--strategy",
+    "remediation",
+    "--checks-success",
+    "--limit",
+    "all",
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /HTTP 401: Bad credentials/);
 });
 
 test("remediation inventory pr-list source falls back to per-PR hydration on GitHub 502s", () => {
@@ -658,6 +756,15 @@ function writeFakeGh(filePath, options = {}) {
     updatedAt: "2026-01-20T00:00:00Z",
     assignees: [{ login: "steipete" }],
   };
+  const conflictingChecksSuccessPull = {
+    ...checksSuccessPull,
+    number: 121,
+    title: "conflicting checks success candidate",
+    url: "https://github.com/openclaw/openclaw/pull/121",
+    updatedAt: "2026-01-21T00:00:00Z",
+    mergeable: "CONFLICTING",
+    mergeStateStatus: "DIRTY",
+  };
   if (options.includeChecksSuccessPreflight) {
     searchPulls.push(
       ...[
@@ -666,6 +773,7 @@ function writeFakeGh(filePath, options = {}) {
         checksSuccessPull,
         maintainerChecksSuccessPull,
         assignedChecksSuccessPull,
+        conflictingChecksSuccessPull,
       ].map((pull) => ({
         ...pull,
         labels: pull.labels,
@@ -688,6 +796,7 @@ function writeFakeGh(filePath, options = {}) {
           checksSuccessPull,
           maintainerChecksSuccessPull,
           assignedChecksSuccessPull,
+          conflictingChecksSuccessPull,
         ]
       : []),
     cleanPrListPull,
@@ -702,7 +811,11 @@ if (process.argv[2] === "pr" && process.argv[3] === "list" && ${JSON.stringify(B
 }
 if (process.argv[2] === "pr" && process.argv[3] === "view" && String(process.argv[4]) === ${JSON.stringify(String(options.failHydrateNumber ?? ""))}) {
   console.error(${JSON.stringify(
-    options.failHydrateIncident
+    options.failHydrateNotFound
+      ? "Could not resolve to a PullRequest with the number of 116."
+      : options.failHydrateAuth
+        ? "HTTP 401: Bad credentials"
+      : options.failHydrateIncident
       ? "GraphQL: Something went wrong while executing your query on 2026-07-01T08:35:56Z. Please include `EFAC:390CD1:97CD82:99C543:6A44D16B` when reporting this issue."
       : "HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)",
   )});
@@ -782,6 +895,33 @@ cluster_refs:
 ---
 
 ${notes}
+`,
+  );
+}
+
+function writeChecksSuccessJob(filePath, ref, { repo = "openclaw/openclaw", generatedAt, updatedAt }) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    `---
+repo: ${repo}
+cluster_id: checks-success-${ref.slice(1)}
+mode: autonomous
+candidates:
+  - "${ref}"
+cluster_refs:
+  - "${ref}"
+notes: "Generated from live GitHub checks-success PR inventory on ${generatedAt}; fixture"
+---
+
+# Checks-Success PR External Preflight 1
+
+## Inventory
+
+### ${ref} fixture candidate
+
+- live updated: ${updatedAt}
+- live url: https://github.com/openclaw/openclaw/pull/${ref.slice(1)}
 `,
   );
 }

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -441,6 +441,98 @@ test("external merge preflight blocks non-keyword human objections", () => {
   assert.match(report.reason, /actionable top-level issue comment/);
 });
 
+test("external merge preflight blocks objections inside approved review bodies", () => {
+  const fixture = makeFixture({
+    reviews: [
+      {
+        author: { login: "reviewer" },
+        authorAssociation: "MEMBER",
+        state: "APPROVED",
+        body: "Do not merge this yet; the security boundary is still unclear.",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable human review body comment/);
+});
+
+test("external merge preflight allows descriptive approved review bodies", () => {
+  const fixture = makeFixture({
+    reviews: [
+      {
+        author: { login: "reviewer" },
+        authorAssociation: "MEMBER",
+        state: "APPROVED",
+        body: "No blocking concerns; tested locally. Security review passed.",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "passed");
+});
+
+test("external merge preflight blocks contradictory approved review bodies", () => {
+  const fixture = makeFixture({
+    reviews: [
+      {
+        author: { login: "reviewer" },
+        authorAssociation: "MEMBER",
+        state: "APPROVED",
+        body: "This breaks Windows; don't land it yet.",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable human review body comment/);
+});
+
 test("external merge preflight blocks actionable comment findings", () => {
   const fixture = makeFixture({
     issueComments: [


### PR DESCRIPTION
## Summary

- hydrate checks-success candidates before dispatch so conflicts and review blockers do not consume runners
- suppress unchanged attempts for 72 hours while retrying updated PRs immediately
- fail closed on contradictory approved reviews and systemic hydration failures
- scope cooldown history by repository

## Validation

- `node --test test/preflight-external-pr-merge.test.mjs` (20/20)
- `node --test test/import-github-pr-inventory.test.mjs` (18/18)
- `npm run validate` (6,624 jobs)
- live checks-success dry-run: 10 candidates in 5 two-PR shards; conflicted #99416 excluded
- independent final diff review: no blockers