### PR TITLE
fix(automation): keep checks-success intake moving

### DIFF
--- a/scripts/import-github-pr-inventory.mjs
+++ b/scripts/import-github-pr-inventory.mjs
@@ -54,7 +54,10 @@ const hydrateIncludeRefs = Boolean(args["hydrate-include-refs"] ?? args.hydrate_
 const minScore = numberArg("min-score", 2);
 const maxFiles = numberArg("max-files", 120);
 const limitForHydration = limit === "all" ? 500 : Number(limit);
-const searchLimit = numberArg("search-limit", Math.min(Math.max(limitForHydration * 20, 200), 1000));
+const defaultSearchLimit = checksSuccessPreflight
+  ? 1000
+  : Math.min(Math.max(limitForHydration * 20, 200), 1000);
+const searchLimit = numberArg("search-limit", defaultSearchLimit);
 const prListFallbackSearchLimit = numberArg(
   "pr-list-fallback-search-limit",
   Math.min(searchLimit, Math.max(limitForHydration * 12, 120)),
@@ -253,7 +256,7 @@ function hydrateChecksSuccessPullRequests(pulls) {
   for (const pull of pulls) {
     let hydrated;
     try {
-      hydrated = hydratePullRequestForPrListFallback(pull.number);
+      hydrated = hydrateChecksSuccessPullRequest(pull.number);
     } catch (error) {
       const retryable = isRetryableGhError(error);
       const missing = isMissingPullRequestError(error);
@@ -264,11 +267,66 @@ function hydrateChecksSuccessPullRequests(pulls) {
     }
     if (!hydrated) continue;
     const normalized = normalizePrListPullRequest(hydrated);
-    if (prListMergeBlocker(normalized)) continue;
+    const hasUnsettledMergeability = hasUnknownMergeability(normalized);
+    const blockerView = hasUnsettledMergeability ? omitUnknownMergeability(normalized) : normalized;
+    if (prListMergeBlocker(blockerView)) {
+      console.error(`skip pull request #${pull.number} after hydration: ${hydratedPullRequestSummary(normalized)}`);
+      continue;
+    }
+    if (hasUnsettledMergeability) {
+      console.error(
+        `pull request #${pull.number} mergeability remains UNKNOWN after polling; deferring exact decision to external preflight`,
+      );
+    }
     hydratedPulls.push(normalized);
     if (limit !== "all" && hydratedPulls.length >= limitForHydration) break;
   }
   return hydratedPulls;
+}
+
+function hydrateChecksSuccessPullRequest(number) {
+  const attempts = numberFromEnv("CLOWNFISH_CHECKS_SUCCESS_MERGEABILITY_POLL_ATTEMPTS", 3);
+  const delayMs = nonNegativeNumberFromEnv("CLOWNFISH_CHECKS_SUCCESS_MERGEABILITY_POLL_DELAY_MS", 1_000);
+  let hydrated = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    hydrated = hydratePullRequestForPrListFallback(number);
+    if (!hasUnknownMergeability(hydrated)) return hydrated;
+    if (attempt < attempts) {
+      console.error(`pull request #${number} mergeability is UNKNOWN on attempt ${attempt}/${attempts}; polling`);
+      if (delayMs > 0) sleepMs(delayMs);
+    }
+  }
+  return hydrated;
+}
+
+function hasUnknownMergeability(pull) {
+  return [pull?.mergeable, pull?.mergeStateStatus].some(isUnknownMergeabilityValue);
+}
+
+function omitUnknownMergeability(pull) {
+  return {
+    ...pull,
+    mergeable: isUnknownMergeabilityValue(pull.mergeable) ? null : pull.mergeable,
+    mergeStateStatus: isUnknownMergeabilityValue(pull.mergeStateStatus) ? null : pull.mergeStateStatus,
+  };
+}
+
+function isUnknownMergeabilityValue(value) {
+  return String(value ?? "").toUpperCase() === "UNKNOWN";
+}
+
+function hydratedPullRequestSummary(pull) {
+  const failingChecks = latestStatusChecks(pull.statusCheckRollup ?? [])
+    .filter(isFailingCheck)
+    .map(checkName);
+  return [
+    `mergeable=${String(pull.mergeable ?? "missing")}`,
+    `merge_state=${String(pull.mergeStateStatus ?? "missing")}`,
+    `review=${String(pull.reviewDecision ?? "missing")}`,
+    `base=${String(pull.baseRefName ?? "missing")}`,
+    `draft=${Boolean(pull.isDraft)}`,
+    `failing_checks=${failingChecks.join(",") || "none"}`,
+  ].join(" ");
 }
 
 function fetchOpenPullRequestsFromPrList() {
@@ -1228,6 +1286,12 @@ function isMissingPullRequestError(error) {
 function numberFromEnv(name, fallback) {
   const value = Number(process.env[name] ?? fallback);
   if (!Number.isInteger(value) || value < 1) return fallback;
+  return value;
+}
+
+function nonNegativeNumberFromEnv(name, fallback) {
+  const value = Number(process.env[name] ?? fallback);
+  if (!Number.isInteger(value) || value < 0) return fallback;
   return value;
 }
 

--- a/test/import-github-pr-inventory.test.mjs
+++ b/test/import-github-pr-inventory.test.mjs
@@ -323,7 +323,7 @@ test("checks-success remediation intake filters noisy preflight blockers", () =>
     "remediation",
     "--checks-success",
     "--limit",
-    "all",
+    "30",
   );
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const payload = JSON.parse(result.stdout);
@@ -332,6 +332,7 @@ test("checks-success remediation intake filters noisy preflight blockers", () =>
   assert.equal(payload.options.bucket, "all");
   assert.equal(payload.options.checks_success_preflight, true);
   assert.equal(payload.options.checks_success_retry_cooldown_hours, 72);
+  assert.equal(payload.options.search_limit, 1000);
 
   const refs = new Set(payload.candidates.map((candidate) => candidate.ref));
   assert.equal(refs.has("#116"), false);
@@ -441,6 +442,94 @@ test("checks-success remediation fails closed on hydration auth errors", () => {
   assert.match(result.stderr, /HTTP 401: Bad credentials/);
 });
 
+test("checks-success remediation polls transient unknown mergeability", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.gh, {
+    includeChecksSuccessPreflight: true,
+    unknownHydrateNumber: 116,
+    unknownHydrateResponses: 2,
+  });
+  const result = runImport(
+    fixture,
+    "--strategy",
+    "remediation",
+    "--checks-success",
+    "--limit",
+    "all",
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stderr, /pull request #116 mergeability is UNKNOWN on attempt 1\/3; polling/);
+  assert.match(result.stderr, /pull request #116 mergeability is UNKNOWN on attempt 2\/3; polling/);
+  assert.equal(JSON.parse(result.stdout).candidates.some((candidate) => candidate.ref === "#116"), true);
+});
+
+test("checks-success remediation defers persistent unknown mergeability to external preflight", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.gh, {
+    includeChecksSuccessPreflight: true,
+    unknownHydrateNumber: 116,
+    unknownHydrateResponses: 3,
+  });
+  const result = runImport(
+    fixture,
+    "--strategy",
+    "remediation",
+    "--checks-success",
+    "--limit",
+    "all",
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(
+    result.stderr,
+    /pull request #116 mergeability remains UNKNOWN after polling; deferring exact decision to external preflight/,
+  );
+  assert.equal(JSON.parse(result.stdout).candidates.some((candidate) => candidate.ref === "#116"), true);
+});
+
+test("checks-success remediation still blocks known conflicts when another mergeability field is unknown", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.gh, {
+    includeChecksSuccessPreflight: true,
+    unknownHydrateNumber: 116,
+    unknownHydrateResponses: 3,
+    unknownMergeableValue: "CONFLICTING",
+    unknownMergeStateStatusValue: "UNKNOWN",
+  });
+  const result = runImport(
+    fixture,
+    "--strategy",
+    "remediation",
+    "--checks-success",
+    "--limit",
+    "all",
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stderr, /skip pull request #116 after hydration: mergeable=CONFLICTING merge_state=UNKNOWN/);
+  assert.equal(JSON.parse(result.stdout).candidates.some((candidate) => candidate.ref === "#116"), false);
+});
+
+test("checks-success remediation still blocks known dirty state when mergeable is unknown", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.gh, {
+    includeChecksSuccessPreflight: true,
+    unknownHydrateNumber: 116,
+    unknownHydrateResponses: 3,
+    unknownMergeableValue: "UNKNOWN",
+    unknownMergeStateStatusValue: "DIRTY",
+  });
+  const result = runImport(
+    fixture,
+    "--strategy",
+    "remediation",
+    "--checks-success",
+    "--limit",
+    "all",
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stderr, /skip pull request #116 after hydration: mergeable=UNKNOWN merge_state=DIRTY/);
+  assert.equal(JSON.parse(result.stdout).candidates.some((candidate) => candidate.ref === "#116"), false);
+});
+
 test("remediation inventory pr-list source falls back to per-PR hydration on GitHub 502s", () => {
   const fixture = makeFixture();
   writeFakeGh(fixture.gh, { failPrList: true });
@@ -515,7 +604,14 @@ function runImport(fixture, ...extraArgs) {
       "--json",
       ...args,
     ],
-    { cwd: repoRoot, encoding: "utf8" },
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CLOWNFISH_CHECKS_SUCCESS_MERGEABILITY_POLL_DELAY_MS: "0",
+      },
+    },
   );
 }
 
@@ -804,6 +900,7 @@ function writeFakeGh(filePath, options = {}) {
   fs.writeFileSync(
     filePath,
     `#!/usr/bin/env node
+import fs from "node:fs";
 const prListPulls = ${JSON.stringify(prListPulls)};
 if (process.argv[2] === "pr" && process.argv[3] === "list" && ${JSON.stringify(Boolean(options.failPrList))}) {
   console.error("HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)");
@@ -829,13 +926,27 @@ if (
   console.error("checks-success search must target base main");
   process.exit(1);
 }
-const payload = process.argv[2] === "search"
-  ? ${JSON.stringify(searchPulls)}
-  : process.argv[2] === "pr" && process.argv[3] === "view"
-    ? prListPulls.find((pull) => String(pull.number) === String(process.argv[4])) ?? null
-    : process.argv[2] === "pr"
-      ? prListPulls
-      : ${JSON.stringify({
+let payload;
+if (process.argv[2] === "search") {
+  payload = ${JSON.stringify(searchPulls)};
+} else if (process.argv[2] === "pr" && process.argv[3] === "view") {
+  payload = prListPulls.find((pull) => String(pull.number) === String(process.argv[4])) ?? null;
+  if (String(process.argv[4]) === ${JSON.stringify(String(options.unknownHydrateNumber ?? ""))} && payload) {
+    const countPath = ${JSON.stringify(path.join(path.dirname(filePath), "unknown-mergeability-count"))};
+    const count = fs.existsSync(countPath) ? Number(fs.readFileSync(countPath, "utf8")) : 0;
+    fs.writeFileSync(countPath, String(count + 1));
+    if (count < ${JSON.stringify(Number(options.unknownHydrateResponses ?? 0))}) {
+      payload = {
+        ...payload,
+        mergeable: ${JSON.stringify(String(options.unknownMergeableValue ?? "UNKNOWN"))},
+        mergeStateStatus: ${JSON.stringify(String(options.unknownMergeStateStatusValue ?? "UNKNOWN"))},
+      };
+    }
+  }
+} else if (process.argv[2] === "pr") {
+  payload = prListPulls;
+} else {
+  payload = ${JSON.stringify({
   data: {
     repository: {
       pullRequests: {
@@ -845,6 +956,7 @@ const payload = process.argv[2] === "search"
     },
   },
 })};
+}
 console.log(JSON.stringify(payload));
 `,
     { mode: 0o755 },


### PR DESCRIPTION
## Summary

- search the full 1,000-result checks-success window so retry cooldowns do not starve intake
- poll transient GitHub mergeability, then defer persistent `UNKNOWN` state to the guarded exact-head preflight
- keep known conflicts, dirty state, auth failures, and other blockers fail-closed

## Verification

- `node --test test/import-github-pr-inventory.test.mjs` (22/22)
- `node --test test/preflight-external-pr-merge.test.mjs` (20/20)
- `npm run validate` (6,624 jobs)
- live read-only intake: 10 candidates in five shards against current OpenClaw main