### PR TITLE
fix(automation): ignore superseded PR evidence

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -64,13 +64,18 @@ let report = {
 try {
   pull = stage("hydrate GitHub state", () => ghJson(["api", `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}`]));
   const issue = stage("hydrate issue state", () => ghJson(["api", `repos/${sourceJob.frontmatter.repo}/issues/${pullRequest}`]));
+  const issueComments = stage("hydrate issue comments", () =>
+    ghJson(["api", `repos/${sourceJob.frontmatter.repo}/issues/${pullRequest}/comments?per_page=100`]),
+  );
   view = stage("poll mergeability", () => fetchSettledPullRequestView({ repo: sourceJob.frontmatter.repo, pullRequest }));
 
   const virtualJob = writePreflightJob({ sourceJob, pull, pullRequest, runDir });
   preflightJobPath = virtualJob.path;
   plan = buildPlan({ sourceJob, virtualJob, pull, issue, view, pullRequest, baseBranch });
 
-  const blockers = stage("read-only blockers", () => readOnlyBlockers({ sourceJob, pull, view, pullRequest }));
+  const blockers = stage("read-only blockers", () =>
+    readOnlyBlockers({ sourceJob, pull, view, issueComments, pullRequest }),
+  );
   if (blockers.length > 0) {
     writeBlockedArtifacts({ reason: blockers.join("; ") });
     process.exit(0);
@@ -332,16 +337,18 @@ function hasUnknownMergeability(view) {
   return ["", "UNKNOWN"].includes(String(view?.mergeable ?? "").toUpperCase()) || ["", "UNKNOWN"].includes(String(view?.mergeStateStatus ?? "").toUpperCase());
 }
 
-function readOnlyBlockers({ sourceJob, pull, view, pullRequest }) {
+function readOnlyBlockers({ sourceJob, pull, view, issueComments, pullRequest }) {
   const blockers = [];
-  const issueComments = Array.isArray(view.comments) ? view.comments : [];
+  const trustedAuthorEvidenceApprovalAt = trustedAuthorEvidenceApprovalTimestamp(issueComments, { pull });
   const reviewComments = ghJson(["api", `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}/comments?per_page=100`]);
   const threads = fetchReviewThreads({ repo: sourceJob.frontmatter.repo, pullRequest });
   const texts = [
     pull.title,
     pull.body,
     ...(pull.labels ?? []).map((label) => label.name),
-    ...issueComments.filter((comment) => !isNonBlockingCommentEvidence(comment, { pull })).map((comment) => comment.body),
+    ...issueComments
+      .filter((comment) => !isNonBlockingCommentEvidence(comment, { pull, trustedAuthorEvidenceApprovalAt }))
+      .map((comment) => comment.body),
     ...(view.reviews ?? []).filter((review) => !isNonBlockingCommentEvidence(review, { pull })).map((review) => review.body),
     ...reviewComments.map((comment) => comment.body),
   ];
@@ -366,7 +373,12 @@ function readOnlyBlockers({ sourceJob, pull, view, pullRequest }) {
   if (threads.hasNextPage) blockers.push("PR has more than 100 review threads");
   const unresolved = threads.nodes.filter((thread) => !thread.isResolved);
   if (unresolved.length > 0) blockers.push(`PR has ${unresolved.length} unresolved review thread(s)`);
-  const actionableIssueComments = issueComments.filter((comment) => isActionableCommentEvidence(comment, { pull }));
+  if (issueComments.length >= 100) blockers.push("PR has at least 100 top-level issue comments; comment history may be truncated");
+  const actionableIssueComments = issueComments.filter(
+    (comment, index) =>
+      !isSupersededDependencyGuardNotice(comment, issueComments.slice(index + 1), { pull, view }) &&
+      isActionableCommentEvidence(comment, { pull, trustedAuthorEvidenceApprovalAt }),
+  );
   if (actionableIssueComments.length > 0) {
     blockers.push(
       `PR has ${actionableIssueComments.length} actionable top-level issue comment(s): ${evidenceExamples(actionableIssueComments).join(", ")}`,
@@ -679,8 +691,8 @@ function isReviewBot(review) {
   return REVIEW_BOT_PATTERN.test(`${review.author?.login ?? ""}\n${review.body ?? ""}`);
 }
 
-function isActionableCommentEvidence(comment, { pull }) {
-  if (isNonBlockingCommentEvidence(comment, { pull })) return false;
+function isActionableCommentEvidence(comment, { pull, trustedAuthorEvidenceApprovalAt = null }) {
+  if (isNonBlockingCommentEvidence(comment, { pull, trustedAuthorEvidenceApprovalAt })) return false;
 
   const body = String(comment.body ?? "").trim();
   const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
@@ -691,10 +703,15 @@ function isActionableCommentEvidence(comment, { pull }) {
     );
   }
 
+  const pullAuthor = String(pull?.user?.login ?? "").toLowerCase();
+  if (author && pullAuthor && author === pullAuthor) {
+    return !isCommentCoveredByTrustedApproval(comment, trustedAuthorEvidenceApprovalAt);
+  }
+
   return Boolean(body);
 }
 
-function isNonBlockingCommentEvidence(comment, { pull }) {
+function isNonBlockingCommentEvidence(comment, { pull, trustedAuthorEvidenceApprovalAt = null }) {
   const body = String(comment.body ?? "").trim();
   if (!body) return true;
   const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
@@ -710,10 +727,18 @@ function isNonBlockingCommentEvidence(comment, { pull }) {
   }
   if (isMaintainerCommandComment({ association, body: normalized })) return true;
   if (isMaintainerApprovalComment({ association, body: normalized })) return true;
+  if (isMaintainerEvidenceApprovalComment(comment)) return true;
   if (isReviewRequestComment(normalized)) return true;
 
   const pullAuthor = String(pull?.user?.login ?? "").toLowerCase();
-  if (author && pullAuthor && author === pullAuthor && isAuthorStatusComment(normalized)) return true;
+  if (
+    author &&
+    pullAuthor &&
+    author === pullAuthor &&
+    isCommentCoveredByTrustedApproval(comment, trustedAuthorEvidenceApprovalAt)
+  ) {
+    return true;
+  }
   return false;
 }
 
@@ -814,20 +839,73 @@ function isAutomationAuthor(author) {
   );
 }
 
-function isAuthorStatusComment(body) {
-  return /\b(addressed|updated|added|fixed|ready for maintainer|marked `proof: sufficient`|please take a look|take a look when|would you mind taking a look|merge if)\b/.test(
-    body,
+function trustedAuthorEvidenceApprovalTimestamp(comments, { pull }) {
+  const headSha = String(pull?.head?.sha ?? "").toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(headSha)) return null;
+  const timestamps = comments
+    .filter((comment) => isMaintainerEvidenceApprovalComment(comment, { headSha }))
+    .map(commentTimestamp)
+    .filter(Number.isFinite);
+  return timestamps.length > 0 ? Math.max(...timestamps) : null;
+}
+
+function isCommentCoveredByTrustedApproval(comment, trustedAuthorEvidenceApprovalAt) {
+  if (!Number.isFinite(trustedAuthorEvidenceApprovalAt)) return false;
+  const timestamp = commentTimestamp(comment);
+  return Number.isFinite(timestamp) && timestamp < trustedAuthorEvidenceApprovalAt;
+}
+
+function commentTimestamp(comment) {
+  const value = Date.parse(
+    String(comment.updated_at ?? comment.updatedAt ?? comment.created_at ?? comment.createdAt ?? ""),
   );
+  return Number.isFinite(value) ? value : Number.NaN;
+}
+
+function isMaintainerEvidenceApprovalComment(comment, { headSha = null } = {}) {
+  const association = String(comment.author_association ?? comment.authorAssociation ?? "").toUpperCase();
+  if (!["MEMBER", "OWNER", "COLLABORATOR"].includes(association)) return false;
+  const match = String(comment.body ?? "")
+    .trim()
+    .match(/^<!--\s*clownfish-author-evidence-approved\s+sha=([0-9a-f]{40})\s*-->$/i);
+  if (!match) return false;
+  return !headSha || match[1].toLowerCase() === headSha;
+}
+
+function isSupersededDependencyGuardNotice(comment, laterComments, { pull, view }) {
+  const body = String(comment.body ?? "").trim();
+  const marker = /^<!--\s*dependency-guard-rebase-needed-backfill\s*-->\s*/i;
+  if (!marker.test(body)) return false;
+  if (
+    view?.mergeable !== "MERGEABLE" ||
+    !isAcceptableMergeState(view) ||
+    latestStatusChecks(view.statusCheckRollup ?? []).some(isFailingCheck)
+  ) {
+    return false;
+  }
+  const notice = body.replace(marker, "").trim();
+  if (
+    !/^heads up: this pr needs to be updated against current `?main`? before (?:the new required )?dependency guard check can pass\.?$/i.test(
+      notice,
+    )
+  ) {
+    return false;
+  }
+
+  const pullAuthor = String(pull?.user?.login ?? "").toLowerCase();
+  return laterComments.some((later) => {
+    const author = String(later.user?.login ?? later.author?.login ?? "").toLowerCase();
+    const laterBody = String(later.body ?? "");
+    return (
+      author === pullAuthor &&
+      (/\brebased onto (?:current )?(?:`main`|main)(?:\s|[.,]|$)/i.test(laterBody) ||
+        /\bdependency guard\b.{0,40}\bshould pass\b/i.test(laterBody))
+    );
+  });
 }
 
 function isReviewRequestComment(body) {
-  return /^@clawsweeper\s+(?:re-review|re-run|review)\b/.test(body);
-}
-
-function hasActionableCommentConcern(body) {
-  return /\b(?:requested changes|changes requested|needs changes?|needs fix|please fix|please add|please update|please address|must fix|must add|must update|blocking|blocker|regression|breaks?|broken|failing|failure|conflict|security|secret|credential|token|vulnerability|unsafe|do not merge|don't merge|hold off|not ready)\b/i.test(
-    body,
-  );
+  return /^@clawsweeper\s+(?:re-review|re-run|review)\s*$/.test(body);
 }
 
 function evidenceExamples(items) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -348,14 +348,150 @@ test("external merge preflight tolerates ready ClawSweeper docs reviews without 
 test("external merge preflight tolerates author take-a-look status comments", () => {
   const fixture = makeFixture({
     pullUser: { login: "contributor" },
+    pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
     issueComments: [
       {
         author: { login: "contributor" },
         authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T00:00:00Z",
         body: [
           "This one and #456 are the remaining two, both with regression tests and ClawSweeper approval.",
           "Would you mind taking a look when you have a chance? Thanks!",
         ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T01:00:00Z",
+        updatedAt: "2026-06-19T01:00:00Z",
+        body: [
+          "Codex review: needs maintainer review before merge.",
+          "",
+          "**Review metrics:** none identified.",
+          "Result: ready for maintainer review.",
+          "",
+          `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+          "<!-- clawsweeper-review item=123 -->",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+      {
+        author: { login: "maintainer" },
+        authorAssociation: "MEMBER",
+        createdAt: "2026-06-18T02:00:00Z",
+        body: `<!-- clownfish-author-evidence-approved sha=${"a".repeat(40)} -->`,
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-3",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "passed", report.reason);
+});
+
+test("external merge preflight tolerates author explanations and superseded dependency notices", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+    issueComments: [
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T00:00:00Z",
+        body: "This fixes the installer signal handling bug and includes the exact reproduction steps.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T00:30:00Z",
+        body: "### Update: dashboard gating fix + existing-config doctor guard",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1a",
+      },
+      {
+        author: { login: "maintainer" },
+        authorAssociation: "MEMBER",
+        createdAt: "2026-06-18T01:00:00Z",
+        body: [
+          "<!-- dependency-guard-rebase-needed-backfill -->",
+          "Heads up: this PR needs to be updated against current `main` before the new required Dependency Guard check can pass.",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T02:00:00Z",
+        body: "Rebased onto current `main`. The Dependency Guard check should pass now.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-3",
+      },
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T03:00:00Z",
+        updatedAt: "2026-06-19T01:00:00Z",
+        body: [
+          "Codex review: needs maintainer review before merge.",
+          "",
+          "**Review metrics:** none identified.",
+          "Result: ready for maintainer review.",
+          "",
+          `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+          "<!-- clawsweeper-review item=123 -->",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-4",
+      },
+      {
+        author: { login: "maintainer" },
+        authorAssociation: "MEMBER",
+        createdAt: "2026-06-19T02:00:00Z",
+        body: `<!-- clownfish-author-evidence-approved sha=${"a".repeat(40)} -->`,
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-5",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "passed", report.reason);
+});
+
+test("external merge preflight still blocks author-reported current concerns", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    issueComments: [
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        body: "Do not merge yet; the latest head still has a failing regression test.",
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
       },
     ],
@@ -376,7 +512,404 @@ test("external merge preflight tolerates author take-a-look status comments", ()
   assert.equal(child.status, 0, child.stderr || child.stdout);
 
   const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
-  assert.equal(report.status, "passed");
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
+test("external merge preflight blocks author hesitation newer than a trusted exact-head approval", () => {
+  for (const body of [
+    "I am not convinced this is ready.",
+    "Could we pause before landing this?",
+    "I would rather not merge this yet.",
+    "We should pause before merging.",
+    "Let's pause before landing.",
+    "I would prefer we not merge.",
+    "I have concerns about merging this.",
+    "I don't want to merge this.",
+  ]) {
+    const fixture = makeFixture({
+      pullUser: { login: "contributor" },
+      pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+      issueComments: [
+        {
+          author: { login: "maintainer" },
+          authorAssociation: "MEMBER",
+          createdAt: "2026-06-17T23:00:00Z",
+          body: `<!-- clownfish-author-evidence-approved sha=${"a".repeat(40)} -->`,
+          url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-0",
+        },
+        {
+          author: { login: "contributor" },
+          authorAssociation: "CONTRIBUTOR",
+          createdAt: "2026-06-18T00:00:00Z",
+          body,
+          url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+        },
+        {
+          author: { login: "clawsweeper[bot]" },
+          authorAssociation: "CONTRIBUTOR",
+          createdAt: "2026-06-18T01:00:00Z",
+          body: [
+            "Codex review: needs maintainer review before merge.",
+            "",
+            "**Review metrics:** none identified.",
+            "Result: ready for maintainer review.",
+            "",
+            `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+            "<!-- clawsweeper-review item=123 -->",
+          ].join("\n"),
+          url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+        },
+      ],
+    });
+    const child = spawnSync(
+      process.execPath,
+      ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+          CLOWNFISH_ALLOWED_OWNER: "openclaw",
+        },
+      },
+    );
+    assert.equal(child.status, 0, child.stderr || child.stdout);
+
+    const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+    assert.equal(report.status, "blocked", body);
+    assert.match(report.reason, /actionable top-level issue comment/, body);
+  }
+});
+
+test("external merge preflight blocks author prose without a trusted exact-head approval", () => {
+  for (const body of [
+    "I have one more thought about this.",
+    "I haven't fixed everything in the migration.",
+    "Update: I am worried about the migration.",
+    "Update: the fix is incomplete.",
+    "Update: still investigating the fix.",
+    "Update: nothing was fixed in the migration.",
+    "Update: migration behavior is unclear + I need more time.",
+  ]) {
+    const fixture = makeFixture({
+      pullUser: { login: "contributor" },
+      pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+      issueComments: [
+        {
+          author: { login: "contributor" },
+          authorAssociation: "CONTRIBUTOR",
+          createdAt: "2026-06-18T00:00:00Z",
+          body,
+          url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+        },
+        {
+          author: { login: "clawsweeper[bot]" },
+          authorAssociation: "CONTRIBUTOR",
+          createdAt: "2026-06-18T01:00:00Z",
+          body: [
+            "Codex review: needs maintainer review before merge.",
+            "",
+            "**Review metrics:** none identified.",
+            "Result: ready for maintainer review.",
+            "",
+            `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+            "<!-- clawsweeper-review item=123 -->",
+          ].join("\n"),
+          url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+        },
+      ],
+    });
+    const child = spawnSync(
+      process.execPath,
+      ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+          CLOWNFISH_ALLOWED_OWNER: "openclaw",
+        },
+      },
+    );
+    assert.equal(child.status, 0, child.stderr || child.stdout);
+
+    const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+    assert.equal(report.status, "blocked", body);
+    assert.match(report.reason, /actionable top-level issue comment/, body);
+  }
+});
+
+test("external merge preflight rejects stale and untrusted author-evidence approval markers", () => {
+  for (const approval of [
+    {
+      author: { login: "maintainer" },
+      authorAssociation: "MEMBER",
+      body: `<!-- clownfish-author-evidence-approved sha=${"b".repeat(40)} -->`,
+    },
+    {
+      author: { login: "contributor" },
+      authorAssociation: "CONTRIBUTOR",
+      body: `<!-- clownfish-author-evidence-approved sha=${"a".repeat(40)} -->`,
+    },
+  ]) {
+    const fixture = makeFixture({
+      pullUser: { login: "contributor" },
+      issueComments: [
+        {
+          author: { login: "contributor" },
+          authorAssociation: "CONTRIBUTOR",
+          createdAt: "2026-06-18T00:00:00Z",
+          body: "This is old author context.",
+          url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+        },
+        {
+          ...approval,
+          createdAt: "2026-06-18T01:00:00Z",
+          url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+        },
+      ],
+    });
+    const child = spawnSync(
+      process.execPath,
+      ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+          CLOWNFISH_ALLOWED_OWNER: "openclaw",
+        },
+      },
+    );
+    assert.equal(child.status, 0, child.stderr || child.stdout);
+
+    const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, /actionable top-level issue comment/);
+  }
+});
+
+test("external merge preflight blocks author comments with ambiguous approval ordering", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    issueComments: [
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T01:00:00Z",
+        body: "This comment may be newer than the approval.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "maintainer" },
+        authorAssociation: "MEMBER",
+        createdAt: "2026-06-18T01:00:00Z",
+        body: `<!-- clownfish-author-evidence-approved sha=${"a".repeat(40)} -->`,
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
+test("external merge preflight blocks objections appended to review requests", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    issueComments: [
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        body: "@clawsweeper review\nDo not merge; this is broken.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
+test("external merge preflight blocks unclassified pull-author objections", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    issueComments: [
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        body: "Please wait; I found another issue.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
+test("external merge preflight blocks objections mixed into pull-author evidence", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    issueComments: [
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        body: "This fixes the installer signal handling bug. Please wait; I found another issue.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
+test("external merge preflight does not accept dependency confirmation from another commenter", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    issueComments: [
+      {
+        author: { login: "maintainer" },
+        authorAssociation: "MEMBER",
+        body: [
+          "<!-- dependency-guard-rebase-needed-backfill -->",
+          "Heads up: this PR needs to be updated against current `main` before the new required Dependency Guard check can pass.",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "reviewer" },
+        authorAssociation: "MEMBER",
+        body: "Dependency Guard should pass now.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
+test("external merge preflight blocks dependency notices with appended concerns", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    issueComments: [
+      {
+        author: { login: "maintainer" },
+        authorAssociation: "MEMBER",
+        body: [
+          "<!-- dependency-guard-rebase-needed-backfill -->",
+          "Heads up: this PR needs to be updated against current main before Dependency Guard can pass.",
+          "Do not merge; the credential handling is still unsafe.",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        body: "Rebased onto current main. The Dependency Guard check should pass now.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /security-sensitive signal|actionable top-level issue comment/);
 });
 
 test("external merge preflight blocks actionable human comments", () => {
@@ -408,6 +941,35 @@ test("external merge preflight blocks actionable human comments", () => {
   const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
   assert.equal(report.status, "blocked");
   assert.match(report.reason, /actionable top-level issue comment/);
+});
+
+test("external merge preflight blocks potentially truncated issue comment history", () => {
+  const fixture = makeFixture({
+    issueComments: Array.from({ length: 100 }, (_, index) => ({
+      author: { login: "dependabot[bot]" },
+      authorAssociation: "NONE",
+      body: `automated status ${index + 1}`,
+      url: `https://github.com/openclaw/openclaw/pull/123#issuecomment-${index + 1}`,
+    })),
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /comment history may be truncated/);
 });
 
 test("external merge preflight blocks non-keyword human objections", () => {
@@ -770,6 +1332,10 @@ if (args[0] === "api" && args[1] === "graphql") {
 }
 if (args[0] === "api" && args[1].includes("/pulls/123/comments")) {
   console.log(${JSON.stringify(JSON.stringify(reviewComments))});
+  process.exit(0);
+}
+if (args[0] === "api" && args[1].includes("/issues/123/comments")) {
+  console.log(${JSON.stringify(JSON.stringify(issueComments))});
   process.exit(0);
 }
 if (args[0] === "api" && args[1].endsWith("/issues/123")) {


### PR DESCRIPTION
## Summary
- hydrate top-level PR comments with stable REST timestamps
- keep pull-author comments fail-closed unless an exact-current-head approval marker is posted by a MEMBER, OWNER, or COLLABORATOR
- narrowly suppress resolved Dependency Guard notices while keeping stale, spoofed, ambiguous-order, or newer evidence blocking
- fail closed when top-level comment history may be truncated

## Validation
- `node --test test/preflight-external-pr-merge.test.mjs` (32 passed)
- `npm test` (305 passed before the final deterministic marker regressions; focused suite rerun after them)
- `npm run validate` (6,629 jobs)
- independent fail-closed review: clean
- hosted checks: passed