### PR TITLE
fix(automation): tolerate exact-head review metadata drift

### DIFF
--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -462,16 +462,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       live_updated_at: live.updated_at,
     };
   }
-  if (expectedUpdatedAt && expectedUpdatedAt !== live.updated_at) {
-    return {
-      ...base,
-      status: "blocked",
-      reason: "target changed since worker review",
-      expected_updated_at: expectedUpdatedAt,
-      live_updated_at: live.updated_at,
-      live_state: live.state,
-    };
-  }
+  const metadataDrifted = Boolean(expectedUpdatedAt && expectedUpdatedAt !== live.updated_at);
 
   const pullRequest = fetchPullRequest(result.repo, target);
   const view = fetchSettledPullRequestView(result.repo, target);
@@ -508,6 +499,24 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       live_head_sha: liveHeadSha || null,
       live_state: live.state,
       live_updated_at: live.updated_at,
+    };
+  }
+  if (
+    metadataDrifted &&
+    !isBenignExactHeadClawSweeperUpdate({
+      repo: result.repo,
+      target,
+      live,
+      expectedHeadSha,
+    })
+  ) {
+    return {
+      ...base,
+      status: "blocked",
+      reason: "target changed since worker review",
+      expected_updated_at: expectedUpdatedAt,
+      live_updated_at: live.updated_at,
+      live_state: live.state,
     };
   }
 
@@ -1056,6 +1065,49 @@ function findExistingComment(repo, number, marker, body) {
 function commentMatchesLiveUpdatedAt(comment, live) {
   const liveUpdatedAt = String(live?.updated_at ?? "");
   return Boolean(liveUpdatedAt && [comment?.updated_at, comment?.created_at].includes(liveUpdatedAt));
+}
+
+function isBenignExactHeadClawSweeperUpdate({ repo, target, live, expectedHeadSha }) {
+  const comments = ghPaged(`repos/${repo}/issues/${target}/comments?per_page=100`).filter((comment) =>
+    commentMatchesLiveUpdatedAt(comment, live),
+  );
+  if (comments.length === 0) return false;
+  return comments.every((comment) => {
+    const author = String(comment.user?.login ?? "").toLowerCase();
+    const body = String(comment.body ?? "");
+    if (!["clawsweeper", "clawsweeper[bot]"].includes(author)) return false;
+    const verdicts = parseClawSweeperMarkers(body, "verdict");
+    const actions = parseClawSweeperMarkers(body, "action");
+    const results = [...body.matchAll(/^Result:\s*(.+?)\s*$/gim)].map((match) =>
+      String(match[1] ?? "").toLowerCase(),
+    );
+    if (verdicts.length !== 1 || actions.length !== 0 || results.length !== 1) return false;
+    const [verdict] = verdicts;
+    return (
+      verdict.valid &&
+      verdict.action === "needs-human" &&
+      verdict.attrs.item === String(target) &&
+      verdict.attrs.sha?.toLowerCase() === expectedHeadSha.toLowerCase() &&
+      verdict.attrs.confidence === "high" &&
+      results[0] === "ready for maintainer review."
+    );
+  });
+}
+
+function parseClawSweeperMarkers(body, kind) {
+  const markers = [];
+  const pattern = new RegExp(`<!--\\s*clawsweeper-${kind}:\\s*([a-z0-9_-]+)([^>]*)-->`, "gi");
+  for (const match of String(body ?? "").matchAll(pattern)) {
+    const attrs = {};
+    let valid = true;
+    for (const attr of String(match[2] ?? "").matchAll(/([a-z0-9_-]+)=("[^"]*"|'[^']*'|[^\s>]+)/gi)) {
+      const key = attr[1].toLowerCase();
+      if (Object.hasOwn(attrs, key)) valid = false;
+      attrs[key] = String(attr[2] ?? "").replace(/^["']|["']$/g, "");
+    }
+    markers.push({ action: match[1].toLowerCase(), attrs, valid });
+  }
+  return markers;
 }
 
 function postIssueComment(repo, number, body) {

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -366,6 +366,147 @@ test("apply-result blocks a merge when the PR head changed after worker review",
   assert.equal(report.actions[0].live_head_sha, CHANGED_HEAD_SHA);
 });
 
+test("apply-result tolerates trusted exact-head automation metadata drift", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    issueUpdatedAt: "2026-06-11T06:11:25Z",
+    issueComments: [
+      {
+        user: { login: "clawsweeper[bot]" },
+        created_at: "2026-06-11T05:00:00Z",
+        updated_at: "2026-06-11T06:11:25Z",
+        body: [
+          "Codex review: needs maintainer review before merge.",
+          "",
+          "**Merge readiness**",
+          "Result: ready for maintainer review.",
+          "",
+          "**Security**",
+          "Cleared: no security-sensitive surface.",
+          "",
+          `<!-- clawsweeper-verdict:needs-human item=60063 sha=${EXPECTED_HEAD_SHA} confidence=high reviewed_at=2026-06-11T06:10:16.679Z -->`,
+        ].join("\n"),
+      },
+    ],
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "executed");
+  assert.equal(report.actions[0].reason, "merged by projectclownfish");
+});
+
+test("apply-result blocks untrusted metadata drift even when the head is unchanged", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    issueUpdatedAt: "2026-06-11T06:11:25Z",
+    issueComments: [
+      {
+        user: { login: "reviewer" },
+        created_at: "2026-06-11T06:11:25Z",
+        updated_at: "2026-06-11T06:11:25Z",
+        body: "Please take another look before merging.",
+      },
+    ],
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(report.actions[0].reason, "target changed since worker review");
+});
+
+for (const [name, body] of [
+  [
+    "without an exact ready verdict",
+    [
+      "Result: changes requested.",
+      `<!-- clawsweeper-verdict:needs-human item=60063 sha=${EXPECTED_HEAD_SHA} confidence=high -->`,
+    ].join("\n"),
+  ],
+  [
+    "with contradictory durable evidence",
+    [
+      "Result: ready for maintainer review.",
+      "Result: changes requested.",
+      `<!-- clawsweeper-verdict:needs-human item=60063 sha=${EXPECTED_HEAD_SHA} confidence=high -->`,
+      `<!-- clawsweeper-action:fix-required item=60063 sha=${EXPECTED_HEAD_SHA} confidence=high -->`,
+    ].join("\n"),
+  ],
+  [
+    "with malformed confidence",
+    [
+      "Result: ready for maintainer review.",
+      `<!-- clawsweeper-verdict:needs-human item=60063 sha=${EXPECTED_HEAD_SHA} confidence=high-risk -->`,
+    ].join("\n"),
+  ],
+  [
+    "with duplicate marker attributes",
+    [
+      "Result: ready for maintainer review.",
+      `<!-- clawsweeper-verdict:needs-human item=60063 sha=${EXPECTED_HEAD_SHA} confidence=low confidence=high -->`,
+    ].join("\n"),
+  ],
+]) {
+  test(`apply-result blocks ClawSweeper metadata drift ${name}`, () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+    const binDir = path.join(tmp, "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    writeReadyMergeGhStub(binDir, {
+      headSha: EXPECTED_HEAD_SHA,
+      issueUpdatedAt: "2026-06-11T06:11:25Z",
+      issueComments: [
+        {
+          user: { login: "clawsweeper[bot]" },
+          created_at: "2026-06-11T05:00:00Z",
+          updated_at: "2026-06-11T06:11:25Z",
+          body,
+        },
+      ],
+    });
+
+    const jobPath = path.join(tmp, "job.md");
+    const resultPath = path.join(tmp, "result.json");
+    const reportPath = path.join(tmp, "apply-report.json");
+    fs.writeFileSync(jobPath, mergeJobMarkdown());
+    fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson(), null, 2)}\n`);
+
+    const result = apply(jobPath, resultPath, reportPath, binDir);
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "blocked");
+    assert.equal(report.actions[0].reason, "target changed since worker review");
+  });
+}
+
 test("apply-result pins a clean merge to the reviewed PR head", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");
@@ -677,6 +818,8 @@ function writeReadyMergeGhStub(
     transientViewFailures = 0,
     statusCheckRollup = [{ name: "CI", status: "COMPLETED", conclusion: "SUCCESS" }],
     labels = [],
+    issueUpdatedAt = "2026-06-11T05:07:30Z",
+    issueComments = [],
   },
 ) {
   const ghPath = path.join(binDir, "gh");
@@ -698,7 +841,7 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
     number: 60063,
     state: "open",
     title: "streaming fix",
-    updated_at: "2026-06-11T05:07:30Z",
+    updated_at: ${JSON.stringify(issueUpdatedAt)},
     labels: ${JSON.stringify(labels)},
     author_association: "NONE",
     pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/60063" }
@@ -716,7 +859,7 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
     merge_commit_sha: merged ? "c".repeat(40) : null
   });
 } else if (args[0] === "api" && args[1].startsWith("repos/openclaw/openclaw/issues/60063/comments")) {
-  write([]);
+  write([${JSON.stringify(issueComments)}]);
 } else if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/ref/heads/main") {
   write({ object: { sha: "current-main" } });
 } else if (args[0] === "api" && args[1] === "graphql") {


### PR DESCRIPTION
## Summary

- tolerate issue metadata drift only when it is caused by one trusted ClawSweeper exact-head ready-review update
- reject contradictory results, action markers, malformed attributes, duplicate attributes, stale heads, or unrelated commenters
- preserve the existing exact-head, mergeability, checks, review-thread, and current-base gates before merge

## Validation

- `npm test` (317/317)
- `npm run validate` (6,629 jobs)
- `node --test test/apply-result.test.mjs` (25/25)
- independent adversarial review: no P0/P1/P2 findings

## Context

A ClawSweeper durable review can be edited after the worker records `target_updated_at`, even when the reviewed PR head is unchanged. The applicator previously blocked that benign update as `target changed since worker review`, wasting an otherwise exact-head guarded run.