### PR TITLE
fix(automation): trust exact-head author status reviews

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -340,6 +340,7 @@ function hasUnknownMergeability(view) {
 function readOnlyBlockers({ sourceJob, pull, view, issueComments, pullRequest }) {
   const blockers = [];
   const trustedAuthorEvidenceApprovalAt = trustedAuthorEvidenceApprovalTimestamp(issueComments, { pull });
+  const trustedAuthorProgressApprovalAt = trustedAuthorProgressApprovalTimestamp(issueComments, { pull });
   const reviewComments = ghJson(["api", `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}/comments?per_page=100`]);
   const threads = fetchReviewThreads({ repo: sourceJob.frontmatter.repo, pullRequest });
   const texts = [
@@ -347,7 +348,14 @@ function readOnlyBlockers({ sourceJob, pull, view, issueComments, pullRequest })
     pull.body,
     ...(pull.labels ?? []).map((label) => label.name),
     ...issueComments
-      .filter((comment) => !isNonBlockingCommentEvidence(comment, { pull, trustedAuthorEvidenceApprovalAt }))
+      .filter(
+        (comment) =>
+          !isNonBlockingCommentEvidence(comment, {
+            pull,
+            trustedAuthorEvidenceApprovalAt,
+            trustedAuthorProgressApprovalAt,
+          }),
+      )
       .map((comment) => comment.body),
     ...(view.reviews ?? []).filter((review) => !isNonBlockingCommentEvidence(review, { pull })).map((review) => review.body),
     ...reviewComments.map((comment) => comment.body),
@@ -377,7 +385,11 @@ function readOnlyBlockers({ sourceJob, pull, view, issueComments, pullRequest })
   const actionableIssueComments = issueComments.filter(
     (comment, index) =>
       !isSupersededDependencyGuardNotice(comment, issueComments.slice(index + 1), { pull, view }) &&
-      isActionableCommentEvidence(comment, { pull, trustedAuthorEvidenceApprovalAt }),
+      isActionableCommentEvidence(comment, {
+        pull,
+        trustedAuthorEvidenceApprovalAt,
+        trustedAuthorProgressApprovalAt,
+      }),
   );
   if (actionableIssueComments.length > 0) {
     blockers.push(
@@ -691,8 +703,19 @@ function isReviewBot(review) {
   return REVIEW_BOT_PATTERN.test(`${review.author?.login ?? ""}\n${review.body ?? ""}`);
 }
 
-function isActionableCommentEvidence(comment, { pull, trustedAuthorEvidenceApprovalAt = null }) {
-  if (isNonBlockingCommentEvidence(comment, { pull, trustedAuthorEvidenceApprovalAt })) return false;
+function isActionableCommentEvidence(
+  comment,
+  { pull, trustedAuthorEvidenceApprovalAt = null, trustedAuthorProgressApprovalAt = null },
+) {
+  if (
+    isNonBlockingCommentEvidence(comment, {
+      pull,
+      trustedAuthorEvidenceApprovalAt,
+      trustedAuthorProgressApprovalAt,
+    })
+  ) {
+    return false;
+  }
 
   const body = String(comment.body ?? "").trim();
   const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
@@ -711,7 +734,10 @@ function isActionableCommentEvidence(comment, { pull, trustedAuthorEvidenceAppro
   return Boolean(body);
 }
 
-function isNonBlockingCommentEvidence(comment, { pull, trustedAuthorEvidenceApprovalAt = null }) {
+function isNonBlockingCommentEvidence(
+  comment,
+  { pull, trustedAuthorEvidenceApprovalAt = null, trustedAuthorProgressApprovalAt = null },
+) {
   const body = String(comment.body ?? "").trim();
   if (!body) return true;
   const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
@@ -735,7 +761,9 @@ function isNonBlockingCommentEvidence(comment, { pull, trustedAuthorEvidenceAppr
     author &&
     pullAuthor &&
     author === pullAuthor &&
-    isCommentCoveredByTrustedApproval(comment, trustedAuthorEvidenceApprovalAt)
+    (isCommentCoveredByTrustedApproval(comment, trustedAuthorEvidenceApprovalAt) ||
+      (isAuthorProgressEvidenceComment(body) &&
+        isCommentCoveredByTrustedApproval(comment, trustedAuthorProgressApprovalAt)))
   ) {
     return true;
   }
@@ -849,10 +877,95 @@ function trustedAuthorEvidenceApprovalTimestamp(comments, { pull }) {
   return timestamps.length > 0 ? Math.max(...timestamps) : null;
 }
 
+function trustedAuthorProgressApprovalTimestamp(comments, { pull }) {
+  const timestamps = comments
+    .filter((comment) => isTrustedExactHeadReadyReviewComment(comment, { pull }))
+    .map(commentTimestamp)
+    .filter(Number.isFinite);
+  return timestamps.length > 0 ? Math.max(...timestamps) : null;
+}
+
 function isCommentCoveredByTrustedApproval(comment, trustedAuthorEvidenceApprovalAt) {
   if (!Number.isFinite(trustedAuthorEvidenceApprovalAt)) return false;
   const timestamp = commentTimestamp(comment);
   return Number.isFinite(timestamp) && timestamp < trustedAuthorEvidenceApprovalAt;
+}
+
+function isTrustedExactHeadReadyReviewComment(comment, { pull }) {
+  const body = String(comment.body ?? "").trim();
+  const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
+  if (!isClawSweeperReadyReviewComment({ author, body: body.toLowerCase(), pull })) return false;
+  if (/<!--\s*clawsweeper-action:/i.test(body)) return false;
+
+  const verdictOpeners = body.match(/<!--\s*clawsweeper-verdict:/gi) ?? [];
+  if (verdictOpeners.length !== 1) return false;
+  const verdicts = [...body.matchAll(/<!--\s*clawsweeper-verdict:([a-z-]+)\s+([^>]*)-->/gi)];
+  if (verdicts.length !== 1 || verdicts[0][1].toLowerCase() !== "needs-human") return false;
+
+  const attributes = parseMarkerAttributes(verdicts[0][2]);
+  if (!attributes) return false;
+  const headSha = String(pull?.head?.sha ?? "").toLowerCase();
+  const pullNumber = String(pull?.number ?? "");
+  return (
+    /^[0-9a-f]{40}$/.test(headSha) &&
+    attributes.sha?.toLowerCase() === headSha &&
+    attributes.item === pullNumber &&
+    attributes.confidence === "high"
+  );
+}
+
+function parseMarkerAttributes(input) {
+  const attributes = {};
+  const tokens = String(input).trim().split(/\s+/);
+  if (tokens.length === 0) return null;
+  for (const token of tokens) {
+    const match = token.match(/^([a-z_]+)=([^\s=]+)$/i);
+    if (!match) return null;
+    const key = match[1].toLowerCase();
+    if (Object.hasOwn(attributes, key)) return null;
+    attributes[key] = match[2];
+  }
+  return attributes;
+}
+
+function isAuthorProgressEvidenceComment(body) {
+  const normalized = String(body ?? "").trim().toLowerCase();
+  if (!normalized || isAuthorObjectionComment(normalized)) return false;
+  const lines = normalized
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines.length > 0 && lines.every(isSafeAuthorProgressLine);
+}
+
+function isSafeAuthorProgressLine(line) {
+  return [
+    /^@clawsweeper\s+(?:re-review|re-run|review)$/,
+    /^rebased onto (?:current )?(?:`main`|main)[.!]?$/,
+    /^the dependency guard check should pass now[.!]?$/,
+    /^changes made[.!]?$/,
+    /^(?:tests?|checks?) (?:are )?(?:green|passing|passed)[.!]?$/,
+    /^(?:verified|verification complete)[.!]?$/,
+    /^(?:would you mind (?:taking|to take)|please (?:take|have)) a look[.!?]?$/,
+    /^ready for (?:another )?(?:look|review)[.!]?$/,
+    /^thanks?[.!]?$/,
+  ].some((pattern) => pattern.test(line));
+}
+
+function isAuthorObjectionComment(body) {
+  if (hasSecuritySensitiveText(body)) return true;
+  if (hasActionableApprovedReviewBody(body)) return true;
+  return [
+    /\b(?:pause|wait|hold)(?:\s+off)?\b/,
+    /\b(?:not|isn't|aren't)\s+(?:ready|complete|fixed|resolved)\b/,
+    /\b(?:incomplete|unfinished|still investigating|need more time|one more thought|worried|concerns?|unclear)\b/,
+    /\b(?:haven't|hasn't|nothing was)\s+fixed\b/,
+    /\b(?:rather|prefer)\b.{0,40}\bnot (?:merge|land|ship)\b/,
+    /\b(?:withdraw|withdrawn|abandon|abandoned|cancel|cancelled|superseded|obsolete)\b/,
+    /\b(?:close|stop)\s+(?:this|the)\s+(?:pr|pull request)\b/,
+    /\bno longer (?:want|need|support)\b/,
+    /\bwrong (?:approach|direction|fix)\b/,
+  ].some((pattern) => pattern.test(body));
 }
 
 function commentTimestamp(comment) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -345,7 +345,7 @@ test("external merge preflight tolerates ready ClawSweeper docs reviews without 
   assert.equal(report.status, "passed");
 });
 
-test("external merge preflight tolerates author take-a-look status comments", () => {
+test("external merge preflight lets an exact-head ready review cover earlier author status comments", () => {
   const fixture = makeFixture({
     pullUser: { login: "contributor" },
     pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
@@ -354,10 +354,7 @@ test("external merge preflight tolerates author take-a-look status comments", ()
         author: { login: "contributor" },
         authorAssociation: "CONTRIBUTOR",
         createdAt: "2026-06-18T00:00:00Z",
-        body: [
-          "This one and #456 are the remaining two, both with regression tests and ClawSweeper approval.",
-          "Would you mind taking a look when you have a chance? Thanks!",
-        ].join("\n"),
+        body: ["Ready for review.", "Thanks!"].join("\n"),
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
       },
       {
@@ -375,13 +372,6 @@ test("external merge preflight tolerates author take-a-look status comments", ()
           "<!-- clawsweeper-review item=123 -->",
         ].join("\n"),
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
-      },
-      {
-        author: { login: "maintainer" },
-        authorAssociation: "MEMBER",
-        createdAt: "2026-06-18T02:00:00Z",
-        body: `<!-- clownfish-author-evidence-approved sha=${"a".repeat(40)} -->`,
-        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-3",
       },
     ],
   });
@@ -404,7 +394,7 @@ test("external merge preflight tolerates author take-a-look status comments", ()
   assert.equal(report.status, "passed", report.reason);
 });
 
-test("external merge preflight tolerates author explanations and superseded dependency notices", () => {
+test("external merge preflight lets an exact-head ready review cover earlier author progress evidence", () => {
   const fixture = makeFixture({
     pullUser: { login: "contributor" },
     pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
@@ -413,14 +403,14 @@ test("external merge preflight tolerates author explanations and superseded depe
         author: { login: "contributor" },
         authorAssociation: "CONTRIBUTOR",
         createdAt: "2026-06-18T00:00:00Z",
-        body: "This fixes the installer signal handling bug and includes the exact reproduction steps.",
+        body: "Changes made.",
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
       },
       {
         author: { login: "contributor" },
         authorAssociation: "CONTRIBUTOR",
         createdAt: "2026-06-18T00:30:00Z",
-        body: "### Update: dashboard gating fix + existing-config doctor guard",
+        body: "Tests are passing.",
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1a",
       },
       {
@@ -437,7 +427,7 @@ test("external merge preflight tolerates author explanations and superseded depe
         author: { login: "contributor" },
         authorAssociation: "CONTRIBUTOR",
         createdAt: "2026-06-18T02:00:00Z",
-        body: "Rebased onto current `main`. The Dependency Guard check should pass now.",
+        body: ["Rebased onto current `main`.", "The Dependency Guard check should pass now."].join("\n"),
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-3",
       },
       {
@@ -455,13 +445,6 @@ test("external merge preflight tolerates author explanations and superseded depe
           "<!-- clawsweeper-review item=123 -->",
         ].join("\n"),
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-4",
-      },
-      {
-        author: { login: "maintainer" },
-        authorAssociation: "MEMBER",
-        createdAt: "2026-06-19T02:00:00Z",
-        body: `<!-- clownfish-author-evidence-approved sha=${"a".repeat(40)} -->`,
-        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-5",
       },
     ],
   });
@@ -639,6 +622,269 @@ test("external merge preflight blocks author prose without a trusted exact-head 
     const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
     assert.equal(report.status, "blocked", body);
     assert.match(report.reason, /actionable top-level issue comment/, body);
+  }
+});
+
+test("external merge preflight blocks author progress newer than the exact-head ready review", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+    issueComments: [
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T00:00:00Z",
+        body: [
+          "Codex review: needs maintainer review before merge.",
+          "",
+          "**Review metrics:** none identified.",
+          "Result: ready for maintainer review.",
+          "",
+          `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+          "<!-- clawsweeper-review item=123 -->",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T01:00:00Z",
+        body: "Updated the proof and tests after the review.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
+test("external merge preflight never lets a ready review suppress an author security concern", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+    issueComments: [
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T00:00:00Z",
+        body: "Updated the patch, but this may expose an API token.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T01:00:00Z",
+        body: [
+          "Codex review: needs maintainer review before merge.",
+          "",
+          "**Review metrics:** none identified.",
+          "Result: ready for maintainer review.",
+          "",
+          `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+          "<!-- clawsweeper-review item=123 -->",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /security-sensitive signal/);
+});
+
+test("external merge preflight never lets a ready review suppress author withdrawal", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+    issueComments: [
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T00:00:00Z",
+        body: "Updated the patch, but I withdraw this PR for now.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T01:00:00Z",
+        body: [
+          "Codex review: needs maintainer review before merge.",
+          "",
+          "**Review metrics:** none identified.",
+          "Result: ready for maintainer review.",
+          "",
+          `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+          "<!-- clawsweeper-review item=123 -->",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
+test("external merge preflight blocks unknown prose appended to a review request", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+    issueComments: [
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T00:00:00Z",
+        body: "@clawsweeper re-review\nUpdate: I retract this submission.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T01:00:00Z",
+        body: [
+          "Codex review: needs maintainer review before merge.",
+          "",
+          "**Review metrics:** none identified.",
+          "Result: ready for maintainer review.",
+          "",
+          `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+          "<!-- clawsweeper-review item=123 -->",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
+test("external merge preflight rejects malformed exact-head ready review approvals", () => {
+  for (const marker of [
+    `<!-- clawsweeper-verdict:needs-human item=123 sha=${"b".repeat(40)} confidence=high -->`,
+    `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=medium -->`,
+    `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high confidence =low -->`,
+    [
+      `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+      `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+    ].join("\n"),
+    [
+      `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+      `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high`,
+    ].join("\n"),
+    [
+      `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+      `<!-- clawsweeper-action:fix-required item=123 sha=${"a".repeat(40)} confidence=high -->`,
+    ].join("\n"),
+  ]) {
+    const fixture = makeFixture({
+      pullUser: { login: "contributor" },
+      pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+      issueComments: [
+        {
+          author: { login: "contributor" },
+          authorAssociation: "CONTRIBUTOR",
+          createdAt: "2026-06-18T00:00:00Z",
+          body: "Updated the proof and tests.",
+          url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+        },
+        {
+          author: { login: "clawsweeper[bot]" },
+          authorAssociation: "CONTRIBUTOR",
+          createdAt: "2026-06-18T01:00:00Z",
+          body: [
+            "Codex review: needs maintainer review before merge.",
+            "",
+            "**Review metrics:** none identified.",
+            "Result: ready for maintainer review.",
+            "",
+            marker,
+            "<!-- clawsweeper-review item=123 -->",
+          ].join("\n"),
+          url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+        },
+      ],
+    });
+    const child = spawnSync(
+      process.execPath,
+      ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+          CLOWNFISH_ALLOWED_OWNER: "openclaw",
+        },
+      },
+    );
+    assert.equal(child.status, 0, child.stderr || child.stdout);
+
+    const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+    assert.equal(report.status, "blocked", marker);
+    assert.match(report.reason, /actionable top-level issue comment/, marker);
   }
 });
 
@@ -1343,7 +1589,7 @@ if (args[0] === "api" && args[1].endsWith("/issues/123")) {
   process.exit(0);
 }
 if (args[0] === "api" && args[1].endsWith("/pulls/123")) {
-  console.log(JSON.stringify({ state: "open", draft: false, title: "fix: fixture", body: "", html_url: "https://github.com/openclaw/openclaw/pull/123", updated_at: ${JSON.stringify(pullUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, user: ${JSON.stringify(pullUser)}, head: { sha: head, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: base, ref: "main" } }));
+  console.log(JSON.stringify({ number: 123, state: "open", draft: false, title: "fix: fixture", body: "", html_url: "https://github.com/openclaw/openclaw/pull/123", updated_at: ${JSON.stringify(pullUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, user: ${JSON.stringify(pullUser)}, head: { sha: head, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: base, ref: "main" } }));
   process.exit(0);
 }
 process.stderr.write("unexpected gh command: " + args.join(" "));


### PR DESCRIPTION
## Summary
- let a trusted exact-head ClawSweeper ready verdict supersede older author status comments
- restrict eligible author status text to a closed whole-line grammar
- fail closed on security concerns, withdrawal language, newer comments, stale heads, malformed markers, duplicate verdicts, and action markers

## Validation
- `npm test` (322 passed)
- `node --test test/preflight-external-pr-merge.test.mjs` (37 passed)
- `npm run validate` (6,633 jobs)
- `git diff --check`