### PR TITLE
chore(jobs): add autonomous cluster drip

### DIFF
--- a/jobs/openclaw/inbox/gitcrawl-11386-autonomous-drip.md
+++ b/jobs/openclaw/inbox/gitcrawl-11386-autonomous-drip.md
@@ -1,0 +1,70 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-11386-autonomous-drip
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - fix
+  - raise_pr
+blocked_actions:
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#63352"
+candidates:
+  - "#64426"
+cluster_refs:
+  - "#63352"
+  - "#64426"
+overlap_policy: "skip-any"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: true
+require_fix_before_close: true
+canonical_hint: "gitcrawl representative #63352 is closed; worker must verify whether an open canonical should replace it."
+notes: "Generated from gitcrawl run cluster 11386 on 2026-07-06."
+---
+
+# Gitcrawl Cluster 11386
+
+Generated from local gitcrawl run cluster 11386 for `openclaw/openclaw`.
+
+Display title:
+
+> [Proposal]: Soft repeated file-reread loop detector in exec runtime to reduce quota burn and timeout failures
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 2
+- pull requests: 0
+- open candidates in local store: 1
+- representative: #63352, currently closed in local store
+- latest member update: 2026-06-18T12:12:21.099093436Z
+
+## Goal
+
+Run one live autonomous classification pass. Classify open candidates only, verify live GitHub state, choose the current canonical issue or PR if the representative is obsolete, and emit only high-confidence planned close/comment/label actions. Closed context refs are evidence only and must not receive close actions.
+
+## Member Inventory
+
+Closed context refs:
+
+- #63352 [Proposal]: Soft repeated file-reread loop detector in exec runtime to reduce quota burn and timeout failures
+
+Open candidates:
+
+- #64426 [Proposal]: Add same-turn reread guard for first-class read tool to reduce token burn

--- a/jobs/openclaw/inbox/gitcrawl-4663-autonomous-drip.md
+++ b/jobs/openclaw/inbox/gitcrawl-4663-autonomous-drip.md
@@ -1,0 +1,70 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-4663-autonomous-drip
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - fix
+  - raise_pr
+blocked_actions:
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#40759"
+candidates:
+  - "#56227"
+cluster_refs:
+  - "#40759"
+  - "#56227"
+overlap_policy: "skip-any"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: true
+require_fix_before_close: true
+canonical_hint: "gitcrawl representative #40759 is closed; worker must verify whether an open canonical should replace it."
+notes: "Generated from gitcrawl run cluster 4663 on 2026-07-06."
+---
+
+# Gitcrawl Cluster 4663
+
+Generated from local gitcrawl run cluster 4663 for `openclaw/openclaw`.
+
+Display title:
+
+> Gateway restart fails with state_dir migration conflict
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 2
+- pull requests: 0
+- open candidates in local store: 1
+- representative: #40759, currently closed in local store
+- latest member update: 2026-06-18T09:04:19.546665658Z
+
+## Goal
+
+Run one live autonomous classification pass. Classify open candidates only, verify live GitHub state, choose the current canonical issue or PR if the representative is obsolete, and emit only high-confidence planned close/comment/label actions. Closed context refs are evidence only and must not receive close actions.
+
+## Member Inventory
+
+Closed context refs:
+
+- #40759 Gateway restart fails with state_dir migration conflict
+
+Open candidates:
+
+- #56227 Gateway restart failure should keep previous instance running to avoid total disconnect

--- a/jobs/openclaw/inbox/gitcrawl-4804-autonomous-drip.md
+++ b/jobs/openclaw/inbox/gitcrawl-4804-autonomous-drip.md
@@ -1,0 +1,70 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-4804-autonomous-drip
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - fix
+  - raise_pr
+blocked_actions:
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#41264"
+candidates:
+  - "#58523"
+cluster_refs:
+  - "#41264"
+  - "#58523"
+overlap_policy: "skip-any"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: true
+require_fix_before_close: true
+canonical_hint: "gitcrawl representative #41264 is closed; worker must verify whether an open canonical should replace it."
+notes: "Generated from gitcrawl run cluster 4804 on 2026-07-06."
+---
+
+# Gitcrawl Cluster 4804
+
+Generated from local gitcrawl run cluster 4804 for `openclaw/openclaw`.
+
+Display title:
+
+> [Bug]: Slack multi-account public-channel root mentions still fail for non-default personas (DM works)
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 2
+- pull requests: 0
+- open candidates in local store: 1
+- representative: #41264, currently closed in local store
+- latest member update: 2026-06-17T07:04:59.171760866Z
+
+## Goal
+
+Run one live autonomous classification pass. Classify open candidates only, verify live GitHub state, choose the current canonical issue or PR if the representative is obsolete, and emit only high-confidence planned close/comment/label actions. Closed context refs are evidence only and must not receive close actions.
+
+## Member Inventory
+
+Closed context refs:
+
+- #41264 [Bug]: Slack multi-account public-channel root mentions still fail for non-default personas (DM works)
+
+Open candidates:
+
+- #58523 [Bug]: Slack multi-workspace: outbound works on second workspace but inbound DM replies never reach OpenClaw

--- a/jobs/openclaw/inbox/gitcrawl-5197-autonomous-drip.md
+++ b/jobs/openclaw/inbox/gitcrawl-5197-autonomous-drip.md
@@ -1,0 +1,70 @@
+---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-5197-autonomous-drip
+mode: autonomous
+allowed_actions:
+  - comment
+  - label
+  - close
+  - merge
+  - fix
+  - raise_pr
+blocked_actions:
+  - force_push
+  - bypass_checks
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#42630"
+candidates:
+  - "#63531"
+cluster_refs:
+  - "#42630"
+  - "#63531"
+overlap_policy: "skip-any"
+security_policy: central_security_only
+import_security_policy: "skip-full"
+security_sensitive: false
+allow_instant_close: true
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: true
+require_fix_before_close: true
+canonical_hint: "gitcrawl representative #42630 is closed; worker must verify whether an open canonical should replace it."
+notes: "Generated from gitcrawl run cluster 5197 on 2026-07-06."
+---
+
+# Gitcrawl Cluster 5197
+
+Generated from local gitcrawl run cluster 5197 for `openclaw/openclaw`.
+
+Display title:
+
+> Talk Mode: Support on-device TTS (iOS AVSpeechSynthesizer) as alternative to ElevenLabs
+
+Cluster shape from gitcrawl:
+
+- total members: 2
+- issues: 2
+- pull requests: 0
+- open candidates in local store: 1
+- representative: #42630, currently closed in local store
+- latest member update: 2026-06-16T23:06:11.149585276Z
+
+## Goal
+
+Run one live autonomous classification pass. Classify open candidates only, verify live GitHub state, choose the current canonical issue or PR if the representative is obsolete, and emit only high-confidence planned close/comment/label actions. Closed context refs are evidence only and must not receive close actions.
+
+## Member Inventory
+
+Closed context refs:
+
+- #42630 Talk Mode: Support on-device TTS (iOS AVSpeechSynthesizer) as alternative to ElevenLabs
+
+Open candidates:
+
+- #63531 [Feature]: Add MLX Talk provider MVP for local macOS TTS


### PR DESCRIPTION
## Summary

- add four live-filtered issue clusters from the newer gitcrawl portable snapshot
- keep closed representatives as evidence only
- enable guarded autonomous classification and close/fix follow-through

## Validation

- `npm run validate` (6,608 jobs)
- targeted `npm run validate:job` for all four jobs
- `git diff --check`

## Source

Local shortlist first, then live GitHub state filtering on only the selected cluster IDs.