### PR TITLE
fix(preflight): trust dependency guard approvals

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -789,12 +789,23 @@ function hasActionableApprovedReviewBody(body) {
 function isBenignAutomationComment({ author, body, pull }) {
   if (isStaleAutomationReviewComment({ author, body, pull })) return true;
   if (!isAutomationAuthor(author)) return false;
+  if (isDependencyGuardAutomationComment({ body, pull })) return true;
   if (isClawSweeperReadyReviewComment({ author, body, pull })) return true;
   return (
     /clawsweeper pr egg|hatched:|hatch command|automatically marked as stale|clawsweeper-command-status|re-review requested|clownfish is on the reef|tagged `clownfish:automerge`/.test(
       body,
     ) || /^<!--\s*(?:clawsweeper|clownfish)-command/.test(body)
   );
+}
+
+function isDependencyGuardAutomationComment({ body, pull }) {
+  if (/^<!--\s*openclaw:dependency-guard\s*-->/.test(body)) return true;
+  if (!/^<!--\s*openclaw:dependency-graph-guard\s*-->/.test(body)) return false;
+  if (!/### dependency graph change authorized\b/.test(body)) return false;
+  const headSha = String(pull?.head?.sha ?? "").toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(headSha)) return false;
+  const approvedSha = body.match(/\bapproved sha:\s*`([0-9a-f]{40})`/)?.[1];
+  return approvedSha === headSha;
 }
 
 function isStaleAutomationReviewComment({ author, body, pull }) {
@@ -824,7 +835,9 @@ function commentReviewShas(body) {
 function isMaintainerCommandComment({ association, body }) {
   return (
     ["MEMBER", "OWNER", "COLLABORATOR"].includes(association) &&
-    (/^\/(?:clownfish|clawsweeper)\b/.test(body) || /^<!--\s*(?:clownfish|clawsweeper)-command:/.test(body))
+    (/^\/(?:clownfish|clawsweeper)\b/.test(body) ||
+      /^\/allow-dependencies-change(?:\s|$)/.test(body) ||
+      /^<!--\s*(?:clownfish|clawsweeper)-command:/.test(body))
   );
 }
 

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -1116,6 +1116,99 @@ test("external merge preflight does not accept dependency confirmation from anot
   assert.match(report.reason, /actionable top-level issue comment/);
 });
 
+test("external merge preflight accepts exact-head dependency guard authorization", () => {
+  const headSha = "a".repeat(40);
+  const fixture = makeFixture({
+    headSha,
+    pullUser: { login: "contributor" },
+    issueComments: [
+      {
+        author: { login: "github-actions[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: [
+          "<!-- openclaw:dependency-guard -->",
+          "This PR changes the dependency graph. A maintainer must authorize the change.",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "maintainer" },
+        authorAssociation: "MEMBER",
+        body: "/allow-dependencies-change intentional parser dependency",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+      {
+        author: { login: "github-actions[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: [
+          "<!-- openclaw:dependency-graph-guard -->",
+          "### Dependency graph change authorized",
+          "",
+          `Approved SHA: \`${headSha}\``,
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-3",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "passed", report.reason);
+  const result = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "result.json"), "utf8"));
+  assert.equal(result.actions[0]?.action, "merge_canonical");
+});
+
+test("external merge preflight blocks stale dependency guard authorization", () => {
+  const fixture = makeFixture({
+    headSha: "a".repeat(40),
+    pullUser: { login: "contributor" },
+    issueComments: [
+      {
+        author: { login: "github-actions[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: [
+          "<!-- openclaw:dependency-graph-guard -->",
+          "### Dependency graph change authorized",
+          "",
+          `Approved SHA: \`${"c".repeat(40)}\``,
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
 test("external merge preflight blocks dependency notices with appended concerns", () => {
   const fixture = makeFixture({
     pullUser: { login: "contributor" },


### PR DESCRIPTION
## Summary

- treat the known dependency-awareness marker as non-blocking automation evidence
- accept dependency authorization only when the bot-reported approved SHA matches the exact PR head
- recognize maintainer `/allow-dependencies-change` commands without suppressing stale approvals or human concerns

This unblocks the guarded external merge preflight for https://github.com/openclaw/openclaw/pull/98095 without weakening exact-head review evidence.

## Validation

- `node --test test/preflight-external-pr-merge.test.mjs` (39 passed)
- `npm test` (324 passed)
- `npm run validate` (6,608 jobs valid)
- `git diff --check`