### PR TITLE
chore(jobs): add next remediation drip

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T074223-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T074223-001.md
@@ -1,0 +1,94 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T074223-001
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#100341"
+  - "#99873"
+  - "#99151"
+  - "#99917"
+cluster_refs:
+  - "#100341"
+  - "#99873"
+  - "#99151"
+  - "#99917"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T07:42:23.890Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #100341 fix(crestodian): catch rejection from async respond in sendChat
+
+- bucket: ready_for_maintainer
+- author: cxbAsDev
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-05T15:46:38Z
+- live url: https://github.com/openclaw/openclaw/pull/100341
+
+### #99873 fix(android): accept boolean flag aliases in node invoke params
+
+- bucket: ready_for_maintainer
+- author: ly85206559
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: app: android, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-05T13:59:06Z
+- live url: https://github.com/openclaw/openclaw/pull/99873
+
+### #99151 fix(qa-lab): bound Telegram live transport JSON response reads
+
+- bucket: ready_for_maintainer
+- author: hugenshen
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, extensions: qa-lab, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-05T02:17:32Z
+- live url: https://github.com/openclaw/openclaw/pull/99151
+
+### #99917 fix(commands): guard shortenText against non-positive maxLen
+
+- bucket: ready_for_maintainer
+- author: Super-Cabbage
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: XS, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-04T11:29:58Z
+- live url: https://github.com/openclaw/openclaw/pull/99917

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T074223-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T074223-002.md
@@ -1,0 +1,81 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T074223-002
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#99842"
+  - "#99845"
+  - "#99602"
+cluster_refs:
+  - "#99842"
+  - "#99845"
+  - "#99602"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T07:42:23.891Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 2
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #99842 improve(health): surface dead-lettered delivery queue entries
+
+- bucket: ready_for_maintainer
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, commands, size: M, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-04T06:42:03Z
+- live url: https://github.com/openclaw/openclaw/pull/99842
+
+### #99845 fix: reject Telegram topic sessions_send targets before dispatch
+
+- bucket: ready_for_maintainer
+- author: NianJiuZst
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-04T06:40:36Z
+- live url: https://github.com/openclaw/openclaw/pull/99845
+
+### #99602 improve(cron): show consecutive failure count and last error in cron CLI output
+
+- bucket: ready_for_maintainer
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-03T17:13:51Z
+- live url: https://github.com/openclaw/openclaw/pull/99602


### PR DESCRIPTION
## Summary

- add two autonomous remediation shards covering seven live maintainer-ready PRs
- exclude red, conflicting large, and architecturally stale candidates from the autonomous wave
- keep repair-shaped candidates behind the normal exact-head executor gates

## Validation

- `npm run validate`
- rendered both jobs in autonomous mode