### PR TITLE
chore(jobs): add next remediation drip

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T075502-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T075502-001.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T075502-001
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#99598"
+  - "#99179"
+  - "#98852"
+  - "#98505"
+  - "#99012"
+cluster_refs:
+  - "#99598"
+  - "#99179"
+  - "#98852"
+  - "#98505"
+  - "#99012"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T07:55:02.361Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #99598 improve(status): show why plugins are disabled in /status plugins
+
+- bucket: ready_for_maintainer
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-03T16:41:36Z
+- live url: https://github.com/openclaw/openclaw/pull/99598
+
+### #99179 fix #98866: Embedded local agent runs should serialize globally across session keys when sharing one app-server
+
+- bucket: ready_for_maintainer
+- author: mushuiyu886
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-07-03T10:44:57Z
+- live url: https://github.com/openclaw/openclaw/pull/99179
+
+### #98852 fix(proxy-capture): wrap deletePathBasedSessions in transaction
+
+- bucket: ready_for_maintainer
+- author: zhangLei99586
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-03T06:39:41Z
+- live url: https://github.com/openclaw/openclaw/pull/98852
+
+### #98505 fix(ports): ignore malformed lsof listener pids
+
+- bucket: ready_for_maintainer
+- author: QiuYuang
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-03T05:45:01Z
+- live url: https://github.com/openclaw/openclaw/pull/98505
+
+### #99012 fix: report failed pr worktree cleanup
+
+- bucket: ready_for_maintainer
+- author: ooiuuii
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: scripts, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-03T03:44:14Z
+- live url: https://github.com/openclaw/openclaw/pull/99012

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T075502-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T075502-002.md
@@ -1,0 +1,68 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T075502-002
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#98800"
+  - "#99267"
+cluster_refs:
+  - "#98800"
+  - "#99267"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T07:55:02.368Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 2
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #98800 fix(gateway): guard parseJsonStringArray JSON.parse against malformed env input
+
+- bucket: ready_for_maintainer
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-03T03:29:19Z
+- live url: https://github.com/openclaw/openclaw/pull/98800
+
+### #99267 Surface config hot-reload watcher status in health
+
+- bucket: ready_for_maintainer
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, commands, size: M, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-07-03T01:18:30Z
+- live url: https://github.com/openclaw/openclaw/pull/99267


### PR DESCRIPTION
## Summary

- add two autonomous remediation shards for seven audited OpenClaw contributor PRs
- keep each worker bounded to at most five independent candidates
- stage the jobs for dispatch after the current older-sha runs complete

## Validation

- `npm run validate` (6,614 jobs)
- rendered both jobs in autonomous mode