### PR TITLE
chore(jobs): add next remediation drip

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T081538-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T081538-001.md
@@ -1,0 +1,107 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T081538-001
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#100684"
+  - "#88103"
+  - "#99488"
+  - "#99456"
+  - "#99094"
+cluster_refs:
+  - "#100684"
+  - "#88103"
+  - "#99488"
+  - "#99456"
+  - "#99094"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T08:15:38.157Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #100684 fix(compaction): annotate partial summaries with chunk order and source time range
+
+- bucket: ready_for_maintainer
+- author: zw-xysk
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-06T07:50:43Z
+- live url: https://github.com/openclaw/openclaw/pull/100684
+
+### #88103 Update Teams CLI install command
+
+- bucket: ready_for_maintainer
+- author: heyitsaamir
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, channel: msteams, size: XS, triage: low-signal-docs, proof: supplied, P3, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-07-05T18:10:09Z
+- live url: https://github.com/openclaw/openclaw/pull/88103
+
+### #99488 fix(mcp-grant): guard sessionKey.trim() against undefined input
+
+- bucket: ready_for_maintainer
+- author: zhangLei99586
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: XS, proof: sufficient, P3, rating: gold shrimp, status: ready for maintainer look, proof: screenshot
+- live updated: 2026-07-03T10:15:35Z
+- live url: https://github.com/openclaw/openclaw/pull/99488
+
+### #99456 fix(hooks): flag hook event names that no core trigger emits
+
+- bucket: ready_for_maintainer
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: docs, cli, commands, size: S, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-03T09:35:08Z
+- live url: https://github.com/openclaw/openclaw/pull/99456
+
+### #99094 fix(tts): log and back up corrupted prefs file before resetting
+
+- bucket: ready_for_maintainer
+- author: LeonidasLux
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-03T09:29:38Z
+- live url: https://github.com/openclaw/openclaw/pull/99094


### PR DESCRIPTION
## Summary

Adds one autonomous remediation shard for five fresh maintainer-ready OpenClaw PRs.

## Validation

- `npm run validate` (6615 jobs)
- autonomous prompt render
- `git diff --check`

## Scope

Excludes held #99045 and broad/high-risk candidates from the same inventory scan.