### PR TITLE
fix(workflows): fail retryable mutation gaps

### DIFF
--- a/.github/workflows/cluster-worker.yml
+++ b/.github/workflows/cluster-worker.yml
@@ -596,6 +596,10 @@ jobs:
         if: ${{ always() && env.CLOWNFISH_ALLOW_EXECUTE == '1' && needs.prepare.outputs.allow_labels == '1' }}
         run: npm run tag-clownfish -- .projectclownfish/runs --apply --live --open-branches false --report .projectclownfish/runs/clownfish-label-report.json
 
+      - name: Verify mutation integrity
+        if: ${{ always() && env.CLOWNFISH_ALLOW_EXECUTE == '1' }}
+        run: npm run assert-mutation-integrity -- .projectclownfish/runs
+
       - name: Upload final worker artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/external-merge-preflight.yml
+++ b/.github/workflows/external-merge-preflight.yml
@@ -145,6 +145,10 @@ jobs:
           run_dir=".projectclownfish/external-merge-preflight"
           npm run apply-result -- "$run_dir/preflight-job.md" "$run_dir/result.json" --report "$run_dir/apply-report.json"
 
+      - name: Verify mutation integrity
+        if: always()
+        run: npm run assert-mutation-integrity -- .projectclownfish/external-merge-preflight
+
       - name: Upload apply artifact
         if: always()
         uses: actions/upload-artifact@v7

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "import-low-signal": "node scripts/import-gitcrawl-low-signal-prs.mjs",
     "worker": "node scripts/run-worker.mjs",
     "apply-result": "node scripts/apply-result.mjs",
+    "assert-mutation-integrity": "node scripts/assert-mutation-integrity.mjs",
     "execute-fix": "node scripts/execute-fix-artifact.mjs",
     "preflight-external-merge": "node scripts/preflight-external-pr-merge.mjs",
     "run-external-merge-preflights": "node scripts/run-external-merge-preflights.mjs",

--- a/scripts/assert-mutation-integrity.mjs
+++ b/scripts/assert-mutation-integrity.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const RETRYABLE_STATUSES = new Set(["blocked", "failed"]);
+const REPORT_NAMES = new Set([
+  "apply-report.json",
+  "clownfish-label-report.json",
+  "external-merge-preflight-report.json",
+  "fix-execution-report.json",
+  "post-flight-report.json",
+]);
+
+const root = path.resolve(process.argv[2] ?? ".projectclownfish/runs");
+const reports = findReports(root);
+const failures = uniqueFailures(
+  reports.flatMap((reportPath) => {
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    return terminalActions(reportPath, report).filter(isRetryableFailure).map((failure) => ({
+      report: path.relative(process.cwd(), reportPath),
+      target: failure.target ?? failure.pr ?? null,
+      action: failure.action ?? null,
+      status: failure.status,
+      transient_error: failure.transient_error ?? null,
+      reason: failure.reason ?? null,
+    }));
+  }),
+);
+
+if (failures.length > 0) {
+  console.error(
+    JSON.stringify(
+      {
+        status: "failed",
+        reason: "retryable mutation failures require another run",
+        failures,
+      },
+      null,
+      2,
+    ),
+  );
+  process.exitCode = 1;
+} else {
+  console.log(JSON.stringify({ status: "passed", reports_checked: reports.length }, null, 2));
+}
+
+function findReports(inputPath) {
+  if (!fs.existsSync(inputPath)) return [];
+  const stat = fs.statSync(inputPath);
+  if (stat.isFile()) return REPORT_NAMES.has(path.basename(inputPath)) ? [inputPath] : [];
+
+  const reports = [];
+  for (const entry of fs.readdirSync(inputPath, { withFileTypes: true })) {
+    const entryPath = path.join(inputPath, entry.name);
+    if (entry.isDirectory()) {
+      reports.push(...findReports(entryPath));
+    } else if (entry.isFile() && REPORT_NAMES.has(entry.name)) {
+      reports.push(entryPath);
+    }
+  }
+  return reports.sort();
+}
+
+function terminalActions(reportPath, report) {
+  switch (path.basename(reportPath)) {
+    case "external-merge-preflight-report.json":
+      return (report?.actions ?? []).flatMap((action) => action?.apply_actions ?? [action]);
+    case "clownfish-label-report.json":
+      return report?.targets ?? [];
+    default:
+      return report?.actions ?? [];
+  }
+}
+
+function isRetryableFailure(action) {
+  return (
+    action?.retry_recommended === true &&
+    RETRYABLE_STATUSES.has(String(action.status ?? ""))
+  );
+}
+
+function uniqueFailures(rows) {
+  const byFailure = new Map();
+  for (const row of rows) {
+    const key = JSON.stringify([
+      row.target,
+      row.action,
+      row.status,
+      row.transient_error,
+      row.reason,
+    ]);
+    if (!byFailure.has(key)) byFailure.set(key, row);
+  }
+  return [...byFailure.values()];
+}

--- a/scripts/publish-result.mjs
+++ b/scripts/publish-result.mjs
@@ -107,6 +107,9 @@ function publishResult(resultPath) {
   const runDir = path.dirname(resultPath);
   const result = readJson(resultPath);
   const applyReport = readSiblingJson(runDir, "apply-report.json") ?? { actions: [] };
+  const externalPreflightReport = readSiblingJson(runDir, "external-merge-preflight-report.json") ?? {
+    actions: [],
+  };
   const postFlightReport = readSiblingJson(runDir, "post-flight-report.json") ?? { actions: [] };
   const fixReport = readSiblingJson(runDir, "fix-execution-report.json") ?? { actions: [] };
   const clusterPlan = readSiblingJson(runDir, "cluster-plan.json");
@@ -129,6 +132,7 @@ function publishResult(resultPath) {
   const workflowStatus = String(metadata?.status ?? previousRecord?.workflow_status ?? "");
   const applyAuditActions = [
     ...readApplyAuditActions(applyReport),
+    ...readExternalPreflightApplyActions(externalPreflightReport),
     ...(postFlightReport.actions ?? [])
       .filter(isPostFlightApplyAction)
       .map(postFlightToApplyAction)
@@ -816,7 +820,20 @@ function sanitizeApplyAction(action) {
     apply_attempt: action.apply_attempt ?? null,
     applied_at: action.applied_at ?? null,
     report_source: action.report_source ?? null,
+    retry_recommended: action.retry_recommended ?? null,
+    transient_error: action.transient_error ?? null,
   };
+}
+
+function readExternalPreflightApplyActions(report) {
+  return (report?.actions ?? []).flatMap((preflight) =>
+    (preflight?.apply_actions ?? []).map((action) => ({
+      ...action,
+      target: action.target ?? preflight.target ?? null,
+      expected_head_sha: action.expected_head_sha ?? preflight.expected_head_sha ?? null,
+      report_source: "external_merge_preflight",
+    })),
+  );
 }
 
 function readApplyAuditActions(report) {

--- a/scripts/self-heal-selection.mjs
+++ b/scripts/self-heal-selection.mjs
@@ -7,6 +7,12 @@ function runSortKey(record) {
 const PRE_BRANCH_RETRY_CODES = new Set(["source_pr_head_fetch_failed"]);
 
 export function failedChildReason(record) {
+  const retryableApplyActions = (record.apply_actions ?? []).filter(
+    (action) => ["failed", "blocked"].includes(action.status) && action.retry_recommended === true,
+  );
+  if (retryableApplyActions.length > 0) {
+    return "retryable mutation apply failed";
+  }
   if (hasTerminalRecovery(record)) return null;
   const retryableActions = (record.fix_actions ?? []).filter(
     (action) => ["failed", "blocked"].includes(action.status) && action.retry_recommended === true,

--- a/test/assert-mutation-integrity.test.mjs
+++ b/test/assert-mutation-integrity.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const script = path.join(repoRoot, "scripts", "assert-mutation-integrity.mjs");
+
+test("mutation integrity fails on retryable applicator blocks", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-mutation-integrity-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.writeFileSync(
+    path.join(root, "apply-report.json"),
+    `${JSON.stringify(
+      {
+        actions: [
+          {
+            target: "#99842",
+            action: "merge_canonical",
+            status: "blocked",
+            retry_recommended: true,
+            transient_error: "github_rate_limit",
+            reason: "GitHub rate limit while applying action",
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const result = spawnSync(process.execPath, [script, root], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /retryable mutation failures require another run/);
+  assert.match(result.stderr, /github_rate_limit/);
+});
+
+test("mutation integrity accepts terminal and non-retryable report rows", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-mutation-integrity-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.writeFileSync(
+    path.join(root, "external-merge-preflight-report.json"),
+    `${JSON.stringify(
+      {
+        actions: [
+          {
+            target: "#99842",
+            status: "executed",
+            apply_actions: [
+              {
+                target: "#99842",
+                action: "merge_canonical",
+                status: "executed",
+              },
+            ],
+          },
+          {
+            target: "#98852",
+            action: "merge_canonical",
+            status: "blocked",
+            retry_recommended: false,
+            reason: "merge conflict",
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  fs.writeFileSync(
+    path.join(root, "apply-report.json"),
+    `${JSON.stringify(
+      {
+        actions: [
+          {
+            target: "#99842",
+            action: "merge_canonical",
+            status: "executed",
+          },
+        ],
+        apply_attempts: [
+          {
+            actions: [
+              {
+                target: "#99842",
+                action: "merge_canonical",
+                status: "blocked",
+                retry_recommended: true,
+                transient_error: "github_rate_limit",
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const result = spawnSync(process.execPath, [script, root], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /"status": "passed"/);
+});

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -51,6 +51,8 @@ test("external merge workflow validates before guarded apply", () => {
   assert.match(workflow, /runs-on: \$\{\{ inputs\.runner \}\}/);
   assert.match(workflow, /external-merge-preflight\/preflight-report\.json/);
   assert.match(workflow, /npm run apply-result/);
+  assert.match(workflow, /- name: Verify mutation integrity[\s\S]*?npm run assert-mutation-integrity/);
+  assert.match(workflow, /- name: Verify mutation integrity[\s\S]*?- name: Upload apply artifact/);
   assert.match(workflow, /permission-pull-requests: write/);
 });
 
@@ -70,6 +72,10 @@ test("cluster worker chains blocked merge candidates through external preflight"
     /npm run run-external-merge-preflights -- "\$\{\{ needs\.prepare\.outputs\.job \}\}" --latest --max-prs "\$\{\{ vars\.CLOWNFISH_EXTERNAL_PREFLIGHT_MAX_PRS \|\| '5' \}\}"/,
   );
   assert.match(clusterWorkflow, /- name: Run external merge preflights[\s\S]*?- name: Apply safe closure actions/);
+  assert.match(
+    clusterWorkflow,
+    /- name: Tag Clownfish targets[\s\S]*?- name: Verify mutation integrity[\s\S]*?- name: Upload final worker artifacts/,
+  );
 });
 
 test("daily checks-success intake feeds guarded external merge preflights", () => {

--- a/test/publish-result.test.mjs
+++ b/test/publish-result.test.mjs
@@ -397,6 +397,43 @@ test("publish-result keeps external preflight child run records separate from pa
       2,
     )}\n`,
   );
+  fs.writeFileSync(
+    path.join(parentDir, "cluster-plan.json"),
+    `${JSON.stringify(
+      {
+        cluster_id: parentClusterId,
+        source_job: "jobs/openclaw/inbox/external-preflight-parent.md",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  fs.writeFileSync(
+    path.join(parentDir, "external-merge-preflight-report.json"),
+    `${JSON.stringify(
+      {
+        actions: [
+          {
+            target: "#98354",
+            expected_head_sha: "abc123",
+            status: "blocked",
+            apply_actions: [
+              {
+                target: "#98354",
+                action: "merge_canonical",
+                status: "blocked",
+                retry_recommended: true,
+                transient_error: "github_rate_limit",
+                reason: "GitHub rate limit while applying action",
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
 
   const child = spawnSync(
     process.execPath,
@@ -405,7 +442,13 @@ test("publish-result keeps external preflight child run records separate from pa
   );
 
   assert.equal(child.status, 0, child.stderr || child.stdout);
-  assert.equal(JSON.parse(fs.readFileSync(parentRunRecordPath, "utf8")).cluster_id, parentClusterId);
+  const parentRecord = JSON.parse(fs.readFileSync(parentRunRecordPath, "utf8"));
+  assert.equal(parentRecord.cluster_id, parentClusterId);
+  assert.equal(parentRecord.source_job, "jobs/openclaw/inbox/external-preflight-parent.md");
+  assert.equal(parentRecord.apply_actions[0].status, "blocked");
+  assert.equal(parentRecord.apply_actions[0].retry_recommended, true);
+  assert.equal(parentRecord.apply_actions[0].transient_error, "github_rate_limit");
+  assert.equal(parentRecord.apply_actions[0].report_source, "external_merge_preflight");
   const childRecord = JSON.parse(fs.readFileSync(childRunRecordPath, "utf8"));
   assert.equal(childRecord.cluster_id, childClusterId);
   assert.deepEqual(childRecord.apply_counts, { executed: 1 });

--- a/test/self-heal-selection.test.mjs
+++ b/test/self-heal-selection.test.mjs
@@ -68,11 +68,23 @@ test("self-heal retries only explicit recoverable executor failures", () => {
         },
       ],
     }),
+    record(10, {
+      apply_actions: [
+        {
+          action: "merge_canonical",
+          status: "blocked",
+          retry_recommended: true,
+          transient_error: "github_rate_limit",
+        },
+        { action: "merge_canonical", status: "executed" },
+      ],
+    }),
   ]);
 
   assert.deepEqual(
     candidates.map((candidate) => [candidate.run_id, candidate.self_heal_reason]),
     [
+      ["10", "retryable mutation apply failed"],
       ["9", "retryable source PR head fetch failed"],
       ["5", "recoverable fix execution failed"],
     ],


### PR DESCRIPTION
## Summary
- fail worker runs when terminal mutation reports contain retryable blocked or failed actions
- publish external preflight applicator failures on the parent inbox job record
- let self-heal redispatch retryable merge applicator failures

## Validation
- npm test (329 passed)
- npm run validate (6,615 jobs)
- focused workflow/publisher/self-heal tests (50 passed)
- verified the integrity gate rejects run 28775939002's real GitHub rate-limit artifact