### PR TITLE
chore(jobs): prune stale remediation refs

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T084426-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T084426-001.md
@@ -20,10 +20,8 @@ require_human_for:
 canonical: []
 candidates:
   - "#100570"
-  - "#98095"
 cluster_refs:
   - "#100570"
-  - "#98095"
 security_policy: central_security_only
 security_sensitive: false
 allow_instant_close: false
@@ -32,7 +30,7 @@ allow_merge: true
 allow_post_merge_close: false
 require_fix_before_close: false
 canonical_hint: "This is a fresh PR external-preflight shard. Classify each PR independently. If the PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex review, emit a blocked merge_candidate with reason external_merge_preflight_required."
-notes: "Generated from live GitHub checks-success PR inventory on 2026-07-06T08:44:26.893Z; bucket=ready_for_maintainer; filtered for external merge preflight candidates with no obvious maintainer-author, status, security, merge-risk, check, or mergeability blockers."
+notes: "Generated from live GitHub checks-success PR inventory on 2026-07-06T08:44:26.893Z; narrowed to #100570 after live dedupe removed #98095 because an active maintainer lane already owns it."
 ---
 
 # Checks-Success PR External Preflight 1
@@ -55,14 +53,3 @@ Hydrate live GitHub state for each listed PR and produce a current finalization 
 - labels: channel: telegram, size: S, proof: sufficient, mantis: telegram-visible-proof, P2, rating: platinum hermit, status: ready for maintainer look
 - live updated: 2026-07-06T08:41:11Z
 - live url: https://github.com/openclaw/openclaw/pull/100570
-
-### #98095 fix(memory-wiki): strip fenced code and inline code before wikilink extraction
-
-- bucket: ready_for_maintainer
-- author: zhangqueping
-- author association: unknown
-- draft: no
-- assignees: vincentkoc
-- labels: size: M, extensions: memory-wiki, triage: blank-template, proof: sufficient, dependencies-changed, P2, rating: platinum hermit, status: ready for maintainer look
-- live updated: 2026-07-06T07:46:36Z
-- live url: https://github.com/openclaw/openclaw/pull/98095

--- a/jobs/openclaw/outbox/stale/live-pr-inventory-20260706T062519-002.md
+++ b/jobs/openclaw/outbox/stale/live-pr-inventory-20260706T062519-002.md
@@ -1,6 +1,6 @@
 ---
 repo: openclaw/openclaw
-cluster_id: live-pr-inventory-20260706T065923-001
+cluster_id: live-pr-inventory-20260706T062519-002
 mode: autonomous
 allowed_actions:
   - "merge"
@@ -19,9 +19,11 @@ require_human_for:
   - "active_author_followup"
 canonical: []
 candidates:
-  - "#98095"
+  - "#98988"
+  - "#98381"
 cluster_refs:
-  - "#98095"
+  - "#98988"
+  - "#98381"
 security_policy: central_security_only
 security_sensitive: false
 allow_instant_close: false
@@ -30,10 +32,10 @@ allow_merge: true
 allow_post_merge_close: false
 require_fix_before_close: false
 canonical_hint: "This is a fresh PR external-preflight shard. Classify each PR independently. If the PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex review, emit a blocked merge_candidate with reason external_merge_preflight_required."
-notes: "Generated from live GitHub checks-success PR inventory on 2026-07-06T06:59:23.627Z; bucket=ready_for_maintainer; filtered for external merge preflight candidates with no obvious maintainer-author, status, security, merge-risk, check, or mergeability blockers."
+notes: "Archived without dispatch after live verification showed #98988 and #98381 were already merged."
 ---
 
-# Checks-Success PR External Preflight 1
+# Checks-Success PR External Preflight 2
 
 This is a high-volume autonomous external-preflight shard over fresh checks-success pull requests.
 
@@ -43,13 +45,24 @@ Hydrate live GitHub state for each listed PR and produce a current finalization 
 
 ## Inventory
 
-### #98095 fix(memory-wiki): strip fenced code and inline code before wikilink extraction
+### #98988 fix(tools-manager): replace spawnSync extraction with safe extractArchive API
 
 - bucket: ready_for_maintainer
-- author: zhangqueping
+- author: LeonidasLux
 - author association: unknown
 - draft: no
 - assignees: none
-- labels: size: M, extensions: memory-wiki, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
-- live updated: 2026-07-06T06:40:40Z
-- live url: https://github.com/openclaw/openclaw/pull/98095
+- labels: agents, size: M, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-03T01:35:02Z
+- live url: https://github.com/openclaw/openclaw/pull/98988
+
+### #98381 fix(memory-core): guard qmd mcporter JSON.parse against non-JSON stdout
+
+- bucket: ready_for_maintainer
+- author: miorbnli
+- author association: unknown
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-03T00:58:42Z
+- live url: https://github.com/openclaw/openclaw/pull/98381

--- a/jobs/openclaw/outbox/stale/live-pr-inventory-20260706T065923-001.md
+++ b/jobs/openclaw/outbox/stale/live-pr-inventory-20260706T065923-001.md
@@ -1,6 +1,6 @@
 ---
 repo: openclaw/openclaw
-cluster_id: live-pr-inventory-20260706T062519-002
+cluster_id: live-pr-inventory-20260706T065923-001
 mode: autonomous
 allowed_actions:
   - "merge"
@@ -19,11 +19,9 @@ require_human_for:
   - "active_author_followup"
 canonical: []
 candidates:
-  - "#98988"
-  - "#98381"
+  - "#98095"
 cluster_refs:
-  - "#98988"
-  - "#98381"
+  - "#98095"
 security_policy: central_security_only
 security_sensitive: false
 allow_instant_close: false
@@ -32,10 +30,10 @@ allow_merge: true
 allow_post_merge_close: false
 require_fix_before_close: false
 canonical_hint: "This is a fresh PR external-preflight shard. Classify each PR independently. If the PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex review, emit a blocked merge_candidate with reason external_merge_preflight_required."
-notes: "Generated from live GitHub checks-success PR inventory on 2026-07-06T06:25:19.168Z; bucket=ready_for_maintainer; filtered for external merge preflight candidates with no obvious maintainer-author, status, security, merge-risk, check, or mergeability blockers."
+notes: "Archived without dispatch because #98095 is already owned by an active maintainer repair lane."
 ---
 
-# Checks-Success PR External Preflight 2
+# Checks-Success PR External Preflight 1
 
 This is a high-volume autonomous external-preflight shard over fresh checks-success pull requests.
 
@@ -45,24 +43,13 @@ Hydrate live GitHub state for each listed PR and produce a current finalization 
 
 ## Inventory
 
-### #98988 fix(tools-manager): replace spawnSync extraction with safe extractArchive API
+### #98095 fix(memory-wiki): strip fenced code and inline code before wikilink extraction
 
 - bucket: ready_for_maintainer
-- author: LeonidasLux
+- author: zhangqueping
 - author association: unknown
 - draft: no
 - assignees: none
-- labels: agents, size: M, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
-- live updated: 2026-07-03T01:35:02Z
-- live url: https://github.com/openclaw/openclaw/pull/98988
-
-### #98381 fix(memory-core): guard qmd mcporter JSON.parse against non-JSON stdout
-
-- bucket: ready_for_maintainer
-- author: miorbnli
-- author association: unknown
-- draft: no
-- assignees: none
-- labels: extensions: memory-core, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
-- live updated: 2026-07-03T00:58:42Z
-- live url: https://github.com/openclaw/openclaw/pull/98381
+- labels: size: M, extensions: memory-wiki, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-06T06:40:40Z
+- live url: https://github.com/openclaw/openclaw/pull/98095


### PR DESCRIPTION
## Summary

- archive the checks-success shard whose two PRs are already merged
- archive the duplicate #98095 shard because an active maintainer lane owns it
- narrow the fresh remediation shard to unowned PR #100570

## Validation

- live state re-fetched for #98988, #98381, #98095, and #100570
- `npm run validate:job -- jobs/openclaw/inbox/live-pr-inventory-20260706T084426-001.md`
- queue status: one unattempted autonomous job / one ref