### PR TITLE
chore(jobs): add next remediation drip

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T085013-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T085013-001.md
@@ -1,0 +1,68 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T085013-001
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#98857"
+  - "#99045"
+cluster_refs:
+  - "#98857"
+  - "#99045"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T08:50:13.486Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates. Dispatch on ubuntu-latest; do not rerun #99045 on Blacksmith."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #98857 fix(codex-supervisor): guard loadCodexSupervisorEndpoints JSON.parse against malformed env input
+
+- bucket: ready_for_maintainer
+- author: lsr911
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look, extensions: codex-supervisor
+- live updated: 2026-07-06T08:13:35Z
+- live url: https://github.com/openclaw/openclaw/pull/98857
+
+### #99045 fix(config): return empty string for undefined in safeStringify
+
+- bucket: ready_for_maintainer
+- author: lzyyzznl
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-05T14:21:17Z
+- live url: https://github.com/openclaw/openclaw/pull/99045


### PR DESCRIPTION
## Summary

- queue #98857 and #99045 for autonomous remediation
- keep merge/fix mutations behind deterministic gates
- pin execution to `ubuntu-latest`; #99045 must not be rerun on Blacksmith

## Validation

- live PR state re-fetched
- `npm run validate:job -- jobs/openclaw/inbox/live-pr-inventory-20260706T085013-001.md`