### PR TITLE
fix(queue): preserve unresolved jobs in offline prune

### DIFF
--- a/scripts/prune-inbox-jobs.mjs
+++ b/scripts/prune-inbox-jobs.mjs
@@ -35,7 +35,7 @@ for (const entry of parsedJobs) {
   const openCandidates = candidates.filter((ref) => isOpenRef(statuses[ref]));
   const closedCandidates = candidates.filter((ref) => statuses[ref] && !isOpenRef(statuses[ref]));
   const closedCanonical = canonical.filter((ref) => statuses[ref] && !isOpenRef(statuses[ref]));
-  const action = classify({ fm, exactResultExists, candidates, openCandidates, closedCanonical });
+  const action = classify({ fm, exactResultExists, candidates, openCandidates, closedCanonical, live });
   const destination = destinationFor(job, action);
   rows.push({
     job: job.relativePath,
@@ -81,10 +81,10 @@ if (json) {
   }
 }
 
-function classify({ fm, exactResultExists, candidates, openCandidates, closedCanonical }) {
+function classify({ fm, exactResultExists, candidates, openCandidates, closedCanonical, live }) {
   if (isExampleJobId(fm.cluster_id)) return "example";
   if (exactResultExists) return "already_resulted";
-  if (candidates.length > 0 && openCandidates.length === 0) return "all_candidates_closed";
+  if (live && candidates.length > 0 && openCandidates.length === 0) return "all_candidates_closed";
   if (fm.mode === "plan" && openCandidates.length === 1) return "single_open_candidate";
   if (closedCanonical.length > 0 && openCandidates.length > 1) return "needs_recanonicalize";
   return "dispatchable";

--- a/test/queue-prune-examples.test.mjs
+++ b/test/queue-prune-examples.test.mjs
@@ -226,6 +226,30 @@ test("prune-inbox preserves example jobs even when writing", () => {
   assert.equal(fs.existsSync(examplePath), true);
 });
 
+test("prune-inbox offline mode preserves unresolved jobs", () => {
+  const fixture = makeFixture();
+  const unresolvedPath = path.join(fixture.inbox, "offline-unresolved.md");
+  writeJob(unresolvedPath, {
+    clusterId: "test-offline-unresolved-prune",
+    mode: "autonomous",
+    refs: ["#1", "#2"],
+  });
+
+  const result = spawnSync(
+    process.execPath,
+    ["scripts/prune-inbox-jobs.mjs", "--inbox", fixture.inbox, "--live", "false", "--write", "--json"],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.summary.dispatchable, 1);
+  assert.equal(payload.summary.movable, 0);
+  assert.equal(payload.rows[0].action, "dispatchable");
+  assert.equal(payload.rows[0].destination, null);
+  assert.equal(fs.existsSync(unresolvedPath), true);
+});
+
 test("prune-inbox keeps a positional job path after --write", () => {
   const fixture = makeFixture();
   const targetPath = path.join(fixture.inbox, "target-example.md");


### PR DESCRIPTION
## Summary

- stop `prune-inbox --live=false` from treating missing live status as proof that every candidate is closed
- continue archiving jobs with exact result artifacts offline
- add regression coverage for write mode preserving unresolved jobs

## Validation

- `node --test test/queue-prune-examples.test.mjs`
- `npm test` (330/330)
- `npm run prune-inbox -- --json --live=false`
- `node --check scripts/prune-inbox-jobs.mjs`
- `git diff --check`