### PR TITLE
chore(jobs): refresh stale CLI remediation

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T090631-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T090631-001.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T090631-001
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#77904"
+cluster_refs:
+  - "#77904"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T09:06:31.894Z; bucket=ready_for_maintainer; autonomous remediation assessment. This deliberately refreshes a previously plan-only PR against current main so its live lint blocker can be repaired or cleared. Mutations are limited to deterministic merge/fix gates. Dispatch plan and execution on ubuntu-latest while Blacksmith capacity is unavailable."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #77904 fix(cli): exit after model inspection output
+
+- bucket: ready_for_maintainer
+- author: dorukardahan
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: cli, commands, size: S, proof: supplied, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-06T08:19:19Z
+- live url: https://github.com/openclaw/openclaw/pull/77904


### PR DESCRIPTION
## Summary

- refresh OpenClaw #77904 against current main after earlier plan-only classifications
- allow bounded merge/fix execution for its live lint blocker
- keep closure/comment powers disabled and use ubuntu-latest while Blacksmith is unavailable

## Validation

- `npm run validate:job -- jobs/openclaw/inbox/live-pr-inventory-20260706T090631-001.md`
- `npm run render -- jobs/openclaw/inbox/live-pr-inventory-20260706T090631-001.md --mode autonomous`
- `git diff --check`