### PR TITLE
fix(actions): report external preflight heartbeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ The workflow needs:
 - optional `CLOWNFISH_MODEL` override for dispatch scripts; default Codex model is `gpt-5.5`
 - optional `CLOWNFISH_MAX_LIVE_WORKERS` variable for dispatch/requeue/self-heal worker fan-out; default is `32`
 - optional `CLOWNFISH_EXTERNAL_PREFLIGHT_CONCURRENCY` variable for parallel read-only external merge validation inside each cluster worker; default is `3`. Guarded merge application remains sequential so concurrent preflights cannot race mutations against a moving base.
+- optional `CLOWNFISH_EXTERNAL_PREFLIGHT_HEARTBEAT_MS` variable for progress output while buffered external preflight children run; default is `60000` ms. Each child logs its start, elapsed heartbeat, and finish without exposing captured command output or credentials.
 - optional `CLOWNFISH_MAX_ACTIVE_PRS_PER_AREA` variable for replacement PR backpressure; default is `50` open Clownfish PRs per touched area, `0` disables the area cap, and common changelog/release-note files are ignored for this check
 - ClawSweeper commit-finding repair PRs are labeled `clownfish:commit-finding`
 - optional `CLOWNFISH_CODEX_TIMEOUT_MS`, `CLOWNFISH_FIX_CODEX_TIMEOUT_MS`, and `CLOWNFISH_FIX_STEP_TIMEOUT_MS` variables; worker planning defaults to 30 minutes, while fix execution defaults to a 20 minute Codex budget inside a 40 minute executor step so timeout artifacts can be written

--- a/scripts/run-external-merge-preflights.mjs
+++ b/scripts/run-external-merge-preflights.mjs
@@ -13,10 +13,16 @@ const jobPath = args._[0];
 const resultPathArg = args._[1];
 const latest = Boolean(args.latest);
 const dryRun = Boolean(args["dry-run"]);
-const maxPrs = positiveInteger(args["max-prs"] ?? args.limit, Infinity);
+const maxPrs = positiveInteger(args["max-prs"] ?? args.limit, Infinity, "--max-prs");
 const concurrency = positiveInteger(
   args.concurrency ?? process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_CONCURRENCY,
   3,
+  "--concurrency",
+);
+const childHeartbeatMs = positiveInteger(
+  process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_HEARTBEAT_MS,
+  60_000,
+  "CLOWNFISH_EXTERNAL_PREFLIGHT_HEARTBEAT_MS",
 );
 const runRootArg = args["run-root"];
 
@@ -190,6 +196,13 @@ async function applyReviewedPreflight(action) {
 }
 
 async function runNode(commandArgs) {
+  const label = nodeCommandLabel(commandArgs);
+  const started = Date.now();
+  console.error(`${label}: started`);
+  const heartbeat = setInterval(() => {
+    console.error(`${label}: still running after ${Math.round((Date.now() - started) / 1000)}s`);
+  }, childHeartbeatMs);
+  heartbeat.unref();
   try {
     const { stdout = "", stderr = "" } = await execFileAsync(process.execPath, commandArgs, {
       cwd: repoRoot(),
@@ -204,6 +217,9 @@ async function runNode(commandArgs) {
       stdout: String(error?.stdout ?? ""),
       stderr: String(error?.stderr ?? error?.message ?? error),
     };
+  } finally {
+    clearInterval(heartbeat);
+    console.error(`${label}: finished after ${Math.round((Date.now() - started) / 1000)}s`);
   }
 }
 
@@ -235,11 +251,21 @@ function cleanupPreflightTarget(runDir) {
   fs.rmSync(path.join(runDir, "target"), { recursive: true, force: true });
 }
 
-function positiveInteger(value, fallback) {
+function positiveInteger(value, fallback, label) {
   if (value === undefined || value === null || value === "") return fallback;
   const number = Number(value);
-  if (!Number.isInteger(number) || number < 1) throw new Error("--max-prs must be a positive integer");
+  if (!Number.isInteger(number) || number < 1) throw new Error(`${label} must be a positive integer`);
   return number;
+}
+
+function nodeCommandLabel(commandArgs) {
+  const script = path.basename(String(commandArgs[0] ?? "node child"));
+  const pullRequestIndex = commandArgs.indexOf("--pr");
+  const pullRequest =
+    pullRequestIndex >= 0 && /^[1-9][0-9]*$/.test(String(commandArgs[pullRequestIndex + 1] ?? ""))
+      ? ` PR #${commandArgs[pullRequestIndex + 1]}`
+      : "";
+  return `${script}${pullRequest}`;
 }
 
 async function mapLimit(values, limit, mapper) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -72,6 +72,9 @@ test("cluster worker chains blocked merge candidates through external preflight"
     /for \(const action of reviewedActions\) \{\s*report\.actions\.push\(await applyReviewedPreflight\(action\)\);\s*\}/,
   );
   assert.match(runnerScript, /const execFileAsync = promisify\(execFile\)/);
+  assert.match(runnerScript, /CLOWNFISH_EXTERNAL_PREFLIGHT_HEARTBEAT_MS/);
+  assert.match(runnerScript, /still running after/);
+  assert.match(runnerScript, /clearInterval\(heartbeat\)/);
   assert.match(clusterWorkflow, /- name: Run external merge preflights/);
   assert.match(
     clusterWorkflow,


### PR DESCRIPTION
## Summary

- emit start, elapsed heartbeat, and finish messages for buffered external-preflight child commands
- identify PR-specific preflight children without printing command output or credentials
- make the heartbeat interval configurable, defaulting to 60 seconds

## Validation

- `node --test test/preflight-external-pr-merge.test.mjs` (39/39)
- `npm test` (330/330)
- `node --check scripts/run-external-merge-preflights.mjs`
- `git diff --check`