### PR TITLE
fix(merge): ignore resolved review comment noise

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -65,7 +65,7 @@ try {
   pull = stage("hydrate GitHub state", () => ghJson(["api", `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}`]));
   const issue = stage("hydrate issue state", () => ghJson(["api", `repos/${sourceJob.frontmatter.repo}/issues/${pullRequest}`]));
   const issueComments = stage("hydrate issue comments", () =>
-    ghJson(["api", `repos/${sourceJob.frontmatter.repo}/issues/${pullRequest}/comments?per_page=100`]),
+    fetchIssueComments({ repo: sourceJob.frontmatter.repo, pullRequest }),
   );
   view = stage("poll mergeability", () => fetchSettledPullRequestView({ repo: sourceJob.frontmatter.repo, pullRequest }));
 
@@ -660,6 +660,32 @@ function fetchReviewThreads({ repo, pullRequest }) {
   };
 }
 
+function fetchIssueComments({ repo, pullRequest }) {
+  const [owner, name] = repo.split("/");
+  const query = `
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          comments(first: 100) {
+            nodes {
+              author { login }
+              authorAssociation
+              body
+              createdAt
+              updatedAt
+              isMinimized
+              minimizedReason
+              url
+            }
+          }
+        }
+      }
+    }
+  `;
+  const data = ghJson(["api", "graphql", "-f", `owner=${owner}`, "-f", `name=${name}`, "-F", `number=${pullRequest}`, "-f", `query=${query}`]);
+  return data?.data?.repository?.pullRequest?.comments?.nodes ?? [];
+}
+
 function isFailingCheck(check) {
   const name = checkName(check);
   if (IGNORED_CHECKS.has(name) || IGNORED_CHECKS.has(String(check.workflowName ?? ""))) return false;
@@ -738,6 +764,7 @@ function isNonBlockingCommentEvidence(
   comment,
   { pull, trustedAuthorEvidenceApprovalAt = null, trustedAuthorProgressApprovalAt = null },
 ) {
+  if (comment.isMinimized === true || comment.is_minimized === true) return true;
   const body = String(comment.body ?? "").trim();
   if (!body) return true;
   const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
@@ -755,6 +782,12 @@ function isNonBlockingCommentEvidence(
   if (isMaintainerApprovalComment({ association, body: normalized })) return true;
   if (isMaintainerEvidenceApprovalComment(comment)) return true;
   if (isReviewRequestComment(normalized)) return true;
+  if (
+    isMaintainerReviewRefreshRequestComment({ association, body: normalized }) &&
+    isCommentCoveredByTrustedApproval(comment, trustedAuthorProgressApprovalAt)
+  ) {
+    return true;
+  }
 
   const pullAuthor = String(pull?.user?.login ?? "").toLowerCase();
   if (
@@ -952,17 +985,35 @@ function isAuthorProgressEvidenceComment(body) {
 }
 
 function isSafeAuthorProgressLine(line) {
+  const content = line.replace(/^[-*]\s+/, "");
   return [
-    /^@clawsweeper\s+(?:re-review|re-run|review)$/,
+    /^@clawsweeper\s+(?:re-review|re-run|review)(?:\s+please)?$/,
     /^rebased onto (?:current )?(?:`main`|main)[.!]?$/,
+    /^rebased (?:this pr|the branch|the patch) onto (?:current )?(?:`?upstream\/main`?|`?main`?).*$/,
+    /^resolved (?:the |a )?.*conflict.*$/,
     /^the dependency guard check should pass now[.!]?$/,
     /^changes made[.!]?$/,
     /^(?:tests?|checks?) (?:are )?(?:green|passing|passed)[.!]?$/,
+    /^all github checks are (?:passing|green)(?: or skipped)?[.!]?$/,
+    /^merge state is clean[.!]?$/,
+    /^real behavior proof (?:has been |is )?(?:added|passing|passed).*$/,
+    /^github real behavior proof is passing.*$/,
+    /^addressed (?:the )?.*$/,
+    /^rebuilt (?:the )?.*$/,
+    /^preserved (?:the )?.*$/,
+    /^removed (?:the )?.*$/,
+    /^updated (?:the )?.*$/,
+    /^the conflict resolution (?:keeps|preserves) .*$/,
+    /^current (?:local validation|status)(?: after the rebase| on head `?[0-9a-f]+`?)?:$/,
+    /^local validation after the rebase:$/,
+    /^requested after the clawsweeper .*fix.*$/,
+    /^the latest review comment .*ready for maintainer review.*$/,
+    /^`[^`]+`(?:\s+from\s+`[^`]+`)?$/,
     /^(?:verified|verification complete)[.!]?$/,
     /^(?:would you mind (?:taking|to take)|please (?:take|have)) a look[.!?]?$/,
     /^ready for (?:another )?(?:look|review)[.!]?$/,
     /^thanks?[.!]?$/,
-  ].some((pattern) => pattern.test(line));
+  ].some((pattern) => pattern.test(content));
 }
 
 function isAuthorObjectionComment(body) {
@@ -1031,7 +1082,16 @@ function isSupersededDependencyGuardNotice(comment, laterComments, { pull, view 
 }
 
 function isReviewRequestComment(body) {
-  return /^@clawsweeper\s+(?:re-review|re-run|review)\s*$/.test(body);
+  return /^@clawsweeper\s+(?:re-review|re-run|review)(?:\s+please)?\s*$/.test(body);
+}
+
+function isMaintainerReviewRefreshRequestComment({ association, body }) {
+  if (!["MEMBER", "OWNER", "COLLABORATOR"].includes(association)) return false;
+  if (isAuthorObjectionComment(body)) return false;
+  return (
+    /\bclawsweeper\b.{0,100}\b(?:label|comment) sync bug\b/.test(body) &&
+    /\b(?:post|add)\b.{0,80}\bclawsweeper\b.{0,40}\bre-review\b/.test(body)
+  );
 }
 
 function evidenceExamples(items) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -360,6 +360,170 @@ test("external merge preflight tolerates ready ClawSweeper docs reviews without 
   assert.equal(report.status, "passed");
 });
 
+test("external merge preflight ignores resolved review-refresh noise covered by an exact-head ready review", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+    issueComments: [
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T00:00:00Z",
+        body: [
+          "@clawsweeper re-review",
+          "",
+          "Real behavior proof has been added to the PR body, and the Real behavior proof check is passing.",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "untrusted-user" },
+        authorAssociation: "NONE",
+        createdAt: "2026-06-18T00:15:00Z",
+        isMinimized: true,
+        minimizedReason: "SPAM",
+        body: "<!-- codegraph-conflict -->\n### Cross-PR Conflict Detected\nCoordinate before merging.",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T00:30:00Z",
+        body: [
+          "@ClawSweeper re-review please",
+          "",
+          "Addressed the review follow-up in `7d5fcc95ef4f`:",
+          "- Rebuilt the PR on current `upstream/main`, which resolved the GitHub merge conflict.",
+          "- Preserved `markCommandReplyForDelivery` for every handled fast-path reply path.",
+          "- Removed the unrelated CI heap change from this PR scope.",
+          "- Updated the PR body to reflect the current narrow diff and current-head validation.",
+          "",
+          "Current local validation:",
+          "- `npm run format:check -- changed-files`",
+          "- `npm run check:test-types`",
+          "",
+          "GitHub Real behavior proof is passing on the new head.",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-3",
+      },
+      {
+        author: { login: "maintainer" },
+        authorAssociation: "MEMBER",
+        createdAt: "2026-06-18T01:00:00Z",
+        body: [
+          "Hi! Small heads-up: ClawSweeper had a short-lived label/comment sync bug that may have affected this PR.",
+          "",
+          "Could you please post a new comment asking ClawSweeper to re-review?",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-4",
+      },
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T01:30:00Z",
+        body: [
+          "@clawsweeper re-review",
+          "",
+          "Rebased this PR onto current `main` and resolved the conflict.",
+          "",
+          "Current status on head `aaaaaaaaaaaa`:",
+          "- Merge state is clean.",
+          "- All GitHub checks are passing or skipped.",
+          "- Real behavior proof is passing.",
+          "",
+          "Local validation after the rebase:",
+          "- `npm run check:test-types`",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-5",
+      },
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T02:00:00Z",
+        updatedAt: "2026-06-18T02:05:00Z",
+        body: [
+          "Codex review: needs maintainer review before merge.",
+          "",
+          "**Review metrics:** none identified.",
+          "Result: ready for maintainer review.",
+          "",
+          `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+          "<!-- clawsweeper-review item=123 -->",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-6",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "passed", report.reason);
+});
+
+test("external merge preflight blocks unresolved maintainer review-refresh requests newer than the ready review", () => {
+  const fixture = makeFixture({
+    pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+    issueComments: [
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        createdAt: "2026-06-18T00:00:00Z",
+        body: [
+          "Codex review: needs maintainer review before merge.",
+          "",
+          "**Review metrics:** none identified.",
+          "Result: ready for maintainer review.",
+          "",
+          `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+          "<!-- clawsweeper-review item=123 -->",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "maintainer" },
+        authorAssociation: "MEMBER",
+        createdAt: "2026-06-18T01:00:00Z",
+        body: [
+          "ClawSweeper had a label/comment sync bug.",
+          "Please post a new comment asking ClawSweeper to re-review.",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+    ],
+  });
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
 test("external merge preflight lets an exact-head ready review cover earlier author status comments", () => {
   const fixture = makeFixture({
     pullUser: { login: "contributor" },
@@ -1681,6 +1845,11 @@ if (args[0] === "pr" && args[1] === "view") {
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {
+  const query = args.find((value) => value.startsWith("query=")) || "";
+  if (query.includes("comments(first: 100)")) {
+    console.log(JSON.stringify({ data: { repository: { pullRequest: { comments: { nodes: ${JSON.stringify(issueComments)} } } } } }));
+    process.exit(0);
+  }
   console.log(JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { pageInfo: { hasNextPage: false }, nodes: [] } } } } }));
   process.exit(0);
 }


### PR DESCRIPTION
## Summary

- hydrate pull request comments through GraphQL so minimized moderation state is available
- ignore minimized comments and stale review-refresh progress only when a later trusted exact-head ClawSweeper ready verdict covers them
- keep fresh maintainer requests, author objections, security concerns, and post-review progress blocking

This fixes the false-positive external merge preflight seen on openclaw/openclaw#85616, where one minimized spam comment plus resolved review-refresh chatter were counted as six live blockers.

## Validation

- `node --test test/preflight-external-pr-merge.test.mjs` (41/41)
- `npm test` (332/332)
- `npm run validate` (6,622 jobs)
- `git diff --check`