### PR TITLE
fix(queue): archive resolved security jobs

### DIFF
--- a/scripts/sweep-openclaw-jobs.mjs
+++ b/scripts/sweep-openclaw-jobs.mjs
@@ -105,6 +105,15 @@ function classifyJob(jobPath) {
   if (isExampleJob(job)) {
     return { ...row, status: "keep", reason: "example job is referenced by local run docs" };
   }
+  if (
+    openPrs.length === 0 &&
+    verifyTargetRefsLive &&
+    row.live_target_refs_total > 0 &&
+    row.live_target_refs_missing === 0 &&
+    row.live_target_refs_open === 0
+  ) {
+    return { ...row, status: "move_to_outbox", reason: "all target issue/PR refs are closed in live GitHub state" };
+  }
   if (job.frontmatter.security_sensitive === true || hasSecuritySignalText(job.raw)) {
     return { ...row, status: "security_hold", reason: "security-sensitive job stays out of automation cleanup" };
   }
@@ -116,11 +125,6 @@ function classifyJob(jobPath) {
   }
   if (latest && latestOpenedFixPrsAreMerged(latest, liveFixPrs)) {
     return { ...row, status: "move_to_outbox", reason: "opened Clownfish fix PR is merged in live GitHub state" };
-  }
-  if (verifyTargetRefsLive && row.live_target_refs_total > 0 && row.live_target_refs_missing === 0) {
-    if (row.live_target_refs_open === 0) {
-      return { ...row, status: "move_to_outbox", reason: "all target issue/PR refs are closed in live GitHub state" };
-    }
   }
   if (isTestJob(job) && latest) {
     return { ...row, status: "delete_test_job", reason: "old smoke/test job has a published result and no open clownfish PR" };

--- a/test/sweep-openclaw-jobs.test.mjs
+++ b/test/sweep-openclaw-jobs.test.mjs
@@ -61,6 +61,27 @@ test("sweep-openclaw-jobs finalizes jobs whose target refs are all closed", () =
   assert.equal(fs.existsSync(path.join(fixture.inbox, "mixed.md")), true);
 });
 
+test("sweep-openclaw-jobs finalizes security-sensitive jobs whose target refs are all closed", () => {
+  const fixture = makeFixture();
+  writeJob(path.join(fixture.inbox, "closed-security.md"), {
+    clusterId: "closed-security-cluster",
+    canonical: ["#5"],
+    candidates: ["#5"],
+    clusterRefs: ["#5"],
+    body: "# Test Job\n\nSecurity review required.",
+  });
+
+  const liveRefReport = path.join(fixture.root, "live-refs.json");
+  fs.writeFileSync(liveRefReport, `${JSON.stringify({ refs: [liveRef(5, "CLOSED")] }, null, 2)}\n`);
+
+  const applied = sweep(fixture, liveRefReport, "--apply-outbox");
+  assert.equal(applied.status, 0, applied.stderr || applied.stdout);
+  const report = JSON.parse(fs.readFileSync(fixture.report, "utf8"));
+  assert.equal(report.totals.move_to_outbox, 1);
+  assert.equal(report.totals.security_hold ?? 0, 0);
+  assert.equal(fs.existsSync(path.join(fixture.outbox, "closed-security.md")), true);
+});
+
 test("sweep-openclaw-jobs uses newest run id when published_at is absent", () => {
   const fixture = makeFixture();
   writeJob(path.join(fixture.inbox, "blocked.md"), {
@@ -252,7 +273,7 @@ function makeFixture() {
   return { root, inbox, outbox, stuck, runs, report };
 }
 
-function writeJob(filePath, { clusterId, canonical, candidates, clusterRefs }) {
+function writeJob(filePath, { clusterId, canonical, candidates, clusterRefs, body = "# Test Job" }) {
   fs.writeFileSync(
     filePath,
     `---
@@ -279,7 +300,7 @@ allow_merge: false
 security_sensitive: false
 ---
 
-# Test Job
+${body}
 `,
   );
 }


### PR DESCRIPTION
## Summary
- archive jobs once every hydrated target ref is closed, even when the job carries a security signal
- keep open security-sensitive refs quarantined
- preserve active Clownfish PR ownership before archiving

## Validation
- `node --test test/sweep-openclaw-jobs.test.mjs`
- `npm test` (333/333)
- `npm run validate` (6,622 jobs)
- `git diff --check`