### PR TITLE
fix(automation): bind merge proof to exact PR state

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -822,30 +822,28 @@ function executeRepairBranch({ fixArtifact, job, targetDir, scopeBlock = null, r
     // already been edited, so a requeue should validate and review it instead.
     allowExistingChanges: !forceFreshRepair && ((rebaseOnly && rebased) || resumedRepairCheckpoint),
     allowReviewFixes: !rebaseOnly,
-    refreshBaseBeforeReview: rebaseOnly,
+    refreshBaseBeforeReview: true,
     allowedFixFiles,
     pushCheckpoint: dryRun ? null : pushRepairCheckpoint,
   });
   if (refreshValidatedBranchBase({ targetDir, branch, baseBranch })) {
     rebased = true;
-    if (rebaseOnly) {
-      prep = editValidatePrepareMerge({
-        fixArtifact,
-        targetDir,
-        branch,
-        mode: "repair",
-        baseBranch,
-        allowExistingChanges: true,
-        allowReviewFixes: false,
-        refreshBaseBeforeReview: true,
-        allowedFixFiles,
-        pushCheckpoint: dryRun ? null : pushRepairCheckpoint,
-      });
-      if (refreshValidatedBranchBase({ targetDir, branch, baseBranch })) {
-        throw new Error("base branch advanced again during rebase-only validation; requeue before pushing");
-      }
-    } else {
-      prep.commit = currentHead(targetDir);
+    const priorCheckpointCommits = prep.checkpoint_commits;
+    prep = editValidatePrepareMerge({
+      fixArtifact,
+      targetDir,
+      branch,
+      mode: "repair",
+      baseBranch,
+      allowExistingChanges: true,
+      allowReviewFixes: !rebaseOnly,
+      refreshBaseBeforeReview: true,
+      allowedFixFiles,
+      pushCheckpoint: dryRun ? null : pushRepairCheckpoint,
+    });
+    prep.checkpoint_commits = uniqueStrings([...priorCheckpointCommits, ...prep.checkpoint_commits]);
+    if (refreshValidatedBranchBase({ targetDir, branch, baseBranch })) {
+      throw new Error("base branch advanced again after validation; requeue before pushing");
     }
   }
   prep.merge_preflight.target = `#${sourcePr.number}`;
@@ -973,7 +971,20 @@ function executeReplacementBranch({ fixArtifact, targetDir, supersedeSources, fa
 
   if (!dryRun) ghAuthSetupGit(targetDir);
   const pushedCheckpointCommits = [];
-  const prep = editValidatePrepareMerge({
+  const pushReplacementCheckpoint = dryRun
+    ? null
+    : () => {
+        pushRecoverableBranch({ targetDir, branch });
+        const commit = currentHead(targetDir);
+        pushedCheckpointCommits.push(commit);
+        noteFixProgress({
+          ...branchProgress,
+          commit,
+          checkpoint_commits: uniqueStrings(pushedCheckpointCommits),
+          recoverable_branch_pushed: true,
+        });
+      };
+  let prep = editValidatePrepareMerge({
     fixArtifact,
     targetDir,
     branch,
@@ -982,22 +993,27 @@ function executeReplacementBranch({ fixArtifact, targetDir, supersedeSources, fa
     baseBranch,
     contributorCredits,
     allowExistingChanges: branchState.resumed && branchHasBaseDiff({ targetDir, baseBranch }),
-    pushCheckpoint: dryRun
-      ? null
-      : () => {
-          pushRecoverableBranch({ targetDir, branch });
-          const commit = currentHead(targetDir);
-          pushedCheckpointCommits.push(commit);
-          noteFixProgress({
-            ...branchProgress,
-            commit,
-            checkpoint_commits: uniqueStrings(pushedCheckpointCommits),
-            recoverable_branch_pushed: true,
-          });
-        },
+    refreshBaseBeforeReview: true,
+    pushCheckpoint: pushReplacementCheckpoint,
   });
   if (refreshValidatedBranchBase({ targetDir, branch, baseBranch })) {
-    prep.commit = currentHead(targetDir);
+    const priorCheckpointCommits = prep.checkpoint_commits;
+    prep = editValidatePrepareMerge({
+      fixArtifact,
+      targetDir,
+      branch,
+      mode: "replacement",
+      fallbackReason,
+      baseBranch,
+      contributorCredits,
+      allowExistingChanges: true,
+      refreshBaseBeforeReview: true,
+      pushCheckpoint: pushReplacementCheckpoint,
+    });
+    prep.checkpoint_commits = uniqueStrings([...priorCheckpointCommits, ...prep.checkpoint_commits]);
+    if (refreshValidatedBranchBase({ targetDir, branch, baseBranch })) {
+      throw new Error("base branch advanced again after validation; requeue before pushing");
+    }
   }
   const provenance = externalMessageProvenance({
     model,
@@ -1385,7 +1401,12 @@ function editValidatePrepareMerge({
   return {
     commit,
     checkpoint_commits: checkpointCommits,
-    merge_preflight: buildMergePreflight({ fixArtifact, codexReview }),
+    merge_preflight: buildMergePreflight({
+      fixArtifact,
+      codexReview,
+      headSha: commit,
+      baseSha: run("git", ["rev-parse", `origin/${baseBranch}`], { cwd: targetDir }).trim(),
+    }),
   };
 }
 
@@ -1782,7 +1803,7 @@ function validateAndReviewLoop({
       baseRefreshes += 1;
       noteFixStage("base_refresh_before_review", { mode, attempt, base_refreshes: baseRefreshes });
       if (baseRefreshes > 1) {
-        throw new Error("base branch advanced again during rebase-only validation; requeue before review");
+        throw new Error("base branch advanced again during validation; requeue before review");
       }
       continue;
     }
@@ -2145,12 +2166,14 @@ function isCleanCodexReview(review) {
   return ["passed", "clean"].includes(status) && findings.length === 0 && review?.findings_addressed === true;
 }
 
-function buildMergePreflight({ fixArtifact, codexReview }) {
+function buildMergePreflight({ fixArtifact, codexReview, headSha, baseSha }) {
   const validationCommands = codexReview.validation_commands_run?.length
     ? codexReview.validation_commands_run
     : fixArtifact.validation_commands;
   return {
     target: null,
+    head_sha: headSha,
+    base_sha: baseSha,
     security_status: "cleared",
     security_evidence: ["ProjectClownfish scoped security scan found no security-sensitive fix target, source PR, or fix artifact scope."],
     comments_status: "resolved",

--- a/scripts/post-flight-checks.mjs
+++ b/scripts/post-flight-checks.mjs
@@ -1,5 +1,6 @@
 const PASSING_CHECK_CONCLUSIONS = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"]);
 const DEFAULT_IGNORED_CHECKS = ["auto-response", "Labeler", "Stale"];
+const FULL_GIT_SHA = /^[0-9a-f]{40}$/i;
 
 export function shouldRequirePrChecks(value = process.env.CLOWNFISH_POST_FLIGHT_REQUIRE_PR_CHECKS) {
   return value !== "0";
@@ -36,6 +37,24 @@ export function shouldWaitForMergeReadiness({ mergeBlock, view, ignored = ignore
   if (message.includes("merge state status is unstable")) return hasPendingChecks(view.statusCheckRollup ?? [], ignored);
   if (message.includes("checks are not clean")) return hasPendingChecks(view.statusCheckRollup ?? [], ignored);
   return false;
+}
+
+export function validateMergePreflightBinding({ preflight, headSha, baseSha }) {
+  const reviewedHeadSha = String(preflight?.head_sha ?? "");
+  const reviewedBaseSha = String(preflight?.base_sha ?? "");
+  const liveHeadSha = String(headSha ?? "");
+  const liveBaseSha = String(baseSha ?? "");
+  if (!FULL_GIT_SHA.test(reviewedHeadSha)) return "merge_preflight head_sha is missing or invalid";
+  if (!FULL_GIT_SHA.test(reviewedBaseSha)) return "merge_preflight base_sha is missing or invalid";
+  if (!FULL_GIT_SHA.test(liveHeadSha)) return "live pull request head SHA is unavailable";
+  if (!FULL_GIT_SHA.test(liveBaseSha)) return "live pull request base SHA is unavailable";
+  if (reviewedHeadSha.toLowerCase() !== liveHeadSha.toLowerCase()) {
+    return "merge_preflight head_sha does not match live pull request head";
+  }
+  if (reviewedBaseSha.toLowerCase() !== liveBaseSha.toLowerCase()) {
+    return "merge_preflight base_sha does not match live pull request base";
+  }
+  return "";
 }
 
 export function ignoredCheckNames(value = process.env.CLOWNFISH_POST_FLIGHT_IGNORE_CHECKS) {

--- a/scripts/post-flight.mjs
+++ b/scripts/post-flight.mjs
@@ -4,7 +4,12 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { assertAllowedOwner, hasDeterministicSecuritySignal, parseArgs, parseJob, repoRoot, validateJob } from "./lib.mjs";
 import { externalMessageProvenance, postMergeCloseoutComment } from "./external-messages.mjs";
-import { shouldRequirePrChecks, shouldWaitForMergeReadiness, validateStatusChecks } from "./post-flight-checks.mjs";
+import {
+  shouldRequirePrChecks,
+  shouldWaitForMergeReadiness,
+  validateMergePreflightBinding,
+  validateStatusChecks,
+} from "./post-flight-checks.mjs";
 
 const CLEAN_MERGE_STATES = new Set(["CLEAN", "HAS_HOOKS"]);
 const FIX_PR_MERGE_STATES = new Set(["CLEAN", "HAS_HOOKS", "UNSTABLE"]);
@@ -350,7 +355,10 @@ function validateMergeableFixPr({ pull, view, preflight }) {
     return `review decision is ${view.reviewDecision}`;
   }
 
-  const preflightBlock = validateMergePreflight(preflight);
+  const preflightBlock = validateMergePreflight(preflight, {
+    headSha: pull.head?.sha,
+    baseSha: pull.base?.sha,
+  });
   if (preflightBlock) return preflightBlock;
 
   const threadBlock = validateResolvedReviewThreads(result.repo, pull.number);
@@ -362,8 +370,10 @@ function validateMergeableFixPr({ pull, view, preflight }) {
   return "";
 }
 
-function validateMergePreflight(preflight) {
+function validateMergePreflight(preflight, binding) {
   if (!preflight || typeof preflight !== "object") return "merge_preflight is missing";
+  const bindingBlock = validateMergePreflightBinding({ preflight, ...binding });
+  if (bindingBlock) return bindingBlock;
   if (preflight.security_status !== "cleared") return "security preflight is not cleared";
   if (!Array.isArray(preflight.security_evidence) || preflight.security_evidence.length === 0) {
     return "security preflight evidence is missing";

--- a/scripts/post-flight.mjs
+++ b/scripts/post-flight.mjs
@@ -125,6 +125,8 @@ function finalizeFixPr(action) {
   for (;;) {
     pull = fetchPullRequest(result.repo, parsed.number);
     view = fetchPullRequestView(result.repo, parsed.number);
+    const baseRef = String(view.baseRefName ?? pull.base?.ref ?? "");
+    const liveBaseSha = baseRef === "main" ? fetchBranchHeadSha(result.repo, baseRef) : "";
     prBase = { ...base, pr: `#${parsed.number}`, title: view.title ?? pull.title ?? null };
     const mergedAt = pull.merged_at ?? view.mergedAt ?? null;
     if (mergedAt) {
@@ -138,7 +140,7 @@ function finalizeFixPr(action) {
       };
     }
 
-    mergeBlock = validateMergeableFixPr({ pull, view, preflight: action.merge_preflight });
+    mergeBlock = validateMergeableFixPr({ pull, view, preflight: action.merge_preflight, liveBaseSha });
     if (!mergeBlock) break;
     if (dryRun || !shouldWaitForMergeReadiness({ mergeBlock, view }) || Date.now() >= deadline) {
       return {
@@ -340,7 +342,7 @@ function hasLiveSecuritySignal(number, labels) {
   return hasDeterministicSecuritySignal({ comments: [bodies] });
 }
 
-function validateMergeableFixPr({ pull, view, preflight }) {
+function validateMergeableFixPr({ pull, view, preflight, liveBaseSha }) {
   if (pull.state !== "open") return `pull request is ${pull.state}`;
   if (pull.draft || view.isDraft) return "pull request is draft";
   if (String(view.baseRefName ?? pull.base?.ref ?? "") !== "main") return "pull request base is not main";
@@ -357,7 +359,7 @@ function validateMergeableFixPr({ pull, view, preflight }) {
 
   const preflightBlock = validateMergePreflight(preflight, {
     headSha: pull.head?.sha,
-    baseSha: pull.base?.sha,
+    baseSha: liveBaseSha,
   });
   if (preflightBlock) return preflightBlock;
 
@@ -452,6 +454,11 @@ function fetchPullRequest(repo, number) {
 
 function fetchIssue(repo, number) {
   return ghJson(["api", `repos/${repo}/issues/${number}`]);
+}
+
+function fetchBranchHeadSha(repo, branch) {
+  const ref = ghJson(["api", `repos/${repo}/git/ref/heads/${branch}`]);
+  return String(ref?.object?.sha ?? "");
 }
 
 function fetchPullRequestView(repo, number) {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -664,9 +664,19 @@ test("execute-fix-artifact preserves review budget across one rebase-only base r
   assert.match(source, /let reviewAttempts = 0;/);
   assert.match(source, /let baseRefreshes = 0;/);
   assert.match(source, /baseRefreshes \+= 1;/);
-  assert.match(source, /if \(baseRefreshes > 1\) \{\s*throw new Error\("base branch advanced again during rebase-only validation; requeue before review"\)/);
+  assert.match(source, /if \(baseRefreshes > 1\) \{\s*throw new Error\("base branch advanced again during validation; requeue before review"\)/);
   assert.match(source, /reviewAttempts \+= 1;\s*noteFixStage\("codex_review_start"/);
   assert.match(source, /Codex \/review did not pass after \$\{reviewAttempts\} attempt\(s\):/);
+});
+
+test("execute-fix-artifact revalidates late base refreshes and binds merge proof", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "execute-fix-artifact.mjs"), "utf8");
+
+  assert.equal(source.match(/refreshBaseBeforeReview: true,/g)?.length >= 4, true);
+  assert.equal(source.match(/base branch advanced again after validation; requeue before pushing/g)?.length, 2);
+  assert.match(source, /merge_preflight: buildMergePreflight\(\{[\s\S]*?headSha: commit,[\s\S]*?baseSha:/);
+  assert.match(source, /function buildMergePreflight\(\{ fixArtifact, codexReview, headSha, baseSha \}\)/);
+  assert.match(source, /head_sha: headSha,\s*base_sha: baseSha,/);
 });
 
 test("execute-fix-artifact bounds and traces rebase-only repair execution", () => {
@@ -683,7 +693,7 @@ test("execute-fix-artifact bounds and traces rebase-only repair execution", () =
   assert.match(source, /ensureCodexWritePreflight\?\.\(\);/);
   assert.match(source, /validation_command_start/);
   assert.match(source, /codex_review_start/);
-  assert.match(source, /refreshBaseBeforeReview: rebaseOnly/);
+  assert.match(source, /refreshBaseBeforeReview: true/);
   assert.match(source, /noteFixStage\("base_refresh_before_review"/);
   assert.match(source, /refreshBaseBeforeReview && branch && refreshValidatedBranchBase/);
   assert.match(source, /do not rerun pnpm, npm, corepack, test, lint, build, or other validation commands/);

--- a/test/post-flight-checks.test.mjs
+++ b/test/post-flight-checks.test.mjs
@@ -4,8 +4,12 @@ import test from "node:test";
 import {
   shouldRequirePrChecks,
   shouldWaitForMergeReadiness,
+  validateMergePreflightBinding,
   validateStatusChecks,
 } from "../scripts/post-flight-checks.mjs";
+
+const HEAD_SHA = "a".repeat(40);
+const BASE_SHA = "b".repeat(40);
 
 test("post-flight requires PR checks unless explicitly disabled", () => {
   assert.equal(shouldRequirePrChecks(undefined), true);
@@ -43,4 +47,42 @@ test("post-flight waits for pending checks and blocks terminal failures", () => 
 test("post-flight accepts completed passing checks", () => {
   const passing = [{ name: "CI", status: "COMPLETED", conclusion: "SUCCESS" }];
   assert.equal(validateStatusChecks(passing), "");
+});
+
+test("post-flight binds merge preflight to the reviewed head and base", () => {
+  assert.equal(
+    validateMergePreflightBinding({
+      preflight: { head_sha: HEAD_SHA, base_sha: BASE_SHA },
+      headSha: HEAD_SHA,
+      baseSha: BASE_SHA,
+    }),
+    "",
+  );
+  assert.match(
+    validateMergePreflightBinding({
+      preflight: { head_sha: "c".repeat(40), base_sha: BASE_SHA },
+      headSha: HEAD_SHA,
+      baseSha: BASE_SHA,
+    }),
+    /head_sha does not match/,
+  );
+  assert.match(
+    validateMergePreflightBinding({
+      preflight: { head_sha: HEAD_SHA, base_sha: "c".repeat(40) },
+      headSha: HEAD_SHA,
+      baseSha: BASE_SHA,
+    }),
+    /base_sha does not match/,
+  );
+});
+
+test("post-flight rejects unbound merge preflight evidence", () => {
+  assert.match(
+    validateMergePreflightBinding({
+      preflight: {},
+      headSha: HEAD_SHA,
+      baseSha: BASE_SHA,
+    }),
+    /head_sha is missing or invalid/,
+  );
 });

--- a/test/post-flight-checks.test.mjs
+++ b/test/post-flight-checks.test.mjs
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -10,6 +12,7 @@ import {
 
 const HEAD_SHA = "a".repeat(40);
 const BASE_SHA = "b".repeat(40);
+const repoRoot = path.resolve(import.meta.dirname, "..");
 
 test("post-flight requires PR checks unless explicitly disabled", () => {
   assert.equal(shouldRequirePrChecks(undefined), true);
@@ -85,4 +88,12 @@ test("post-flight rejects unbound merge preflight evidence", () => {
     }),
     /head_sha is missing or invalid/,
   );
+});
+
+test("post-flight compares reviewed base proof with the live base ref head", () => {
+  const source = fs.readFileSync(path.join(repoRoot, "scripts", "post-flight.mjs"), "utf8");
+
+  assert.match(source, /const liveBaseSha = baseRef === "main" \? fetchBranchHeadSha\(result\.repo, baseRef\) : "";/);
+  assert.match(source, /baseSha: liveBaseSha,/);
+  assert.doesNotMatch(source, /baseSha: pull\.base\?\.sha/);
 });


### PR DESCRIPTION
## Summary

- bind autonomous merge preflight evidence to the exact reviewed PR head and base SHAs
- rerun validation and Codex review when `main` advances after an initial review
- reject post-flight merges when either reviewed SHA no longer matches live GitHub state

## Validation

- `npm run validate`
- `node --test test/post-flight-checks.test.mjs test/execute-fix-artifact.test.mjs`
- `node --check scripts/execute-fix-artifact.mjs`
- `node --check scripts/post-flight.mjs`
- `node --check scripts/post-flight-checks.mjs`