### PR TITLE
fix(automation): reuse validation across irrelevant base drift

### DIFF
--- a/scripts/base-drift-validation.mjs
+++ b/scripts/base-drift-validation.mjs
@@ -17,6 +17,7 @@ const PACKAGE_MANAGER_FILES = new Set([
   "pnpm-workspace.yaml",
   "yarn.lock",
 ]);
+const VALIDATION_SCRIPT_EXTENSIONS = new Set(["cjs", "cts", "js", "mjs", "mts", "sh", "ts"]);
 
 export function evaluateValidationBaseDrift({
   validationCommands,
@@ -117,7 +118,14 @@ export function isValidationDriftControlFile(file) {
   const basename = normalized.split("/").at(-1);
   if (PACKAGE_MANAGER_FILES.has(basename)) return true;
   if (/^tsconfig(?:\.[A-Za-z0-9_-]+)*\.jsonc?$/i.test(basename)) return true;
-  return /(^|\/)(?:check-changed|changed-gate)(?:[.-][A-Za-z0-9_-]+)*\.(?:[cm]?[jt]s|sh)$/i.test(normalized);
+  const extensionSeparator = basename.lastIndexOf(".");
+  if (extensionSeparator <= 0) return false;
+  const extension = basename.slice(extensionSeparator + 1).toLowerCase();
+  if (!VALIDATION_SCRIPT_EXTENSIONS.has(extension)) return false;
+  const stem = basename.slice(0, extensionSeparator).toLowerCase();
+  return ["check-changed", "changed-gate"].some(
+    (prefix) => stem === prefix || stem.startsWith(`${prefix}.`) || stem.startsWith(`${prefix}-`),
+  );
 }
 
 function normalizePathEvidence(values) {

--- a/scripts/base-drift-validation.mjs
+++ b/scripts/base-drift-validation.mjs
@@ -1,0 +1,152 @@
+export const MAX_VALIDATION_BASE_DRIFT_COMMITS = 64;
+export const MAX_VALIDATION_BASE_DRIFT_FILES = 128;
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const PACKAGE_MANAGER_FILES = new Set([
+  ".npmrc",
+  ".pnpmfile.cjs",
+  ".pnpmfile.js",
+  ".yarnrc",
+  ".yarnrc.yml",
+  "bun.lock",
+  "bun.lockb",
+  "npm-shrinkwrap.json",
+  "package-lock.json",
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "yarn.lock",
+]);
+
+export function evaluateValidationBaseDrift({
+  validationCommands,
+  validatedHeadSha,
+  currentHeadSha,
+  validatedBaseSha,
+  currentBaseSha,
+  validatedBaseIsAncestorOfHead,
+  validatedBaseIsAncestorOfCurrentBase,
+  driftCommitCount,
+  branchFiles,
+  baseDriftFiles,
+  branchAreas,
+  baseDriftAreas,
+  evidenceComplete,
+  maxCommits = MAX_VALIDATION_BASE_DRIFT_COMMITS,
+  maxFiles = MAX_VALIDATION_BASE_DRIFT_FILES,
+}) {
+  const reject = (reason, details = {}) => ({ status: "rejected", reason, details });
+  if (evidenceComplete !== true) return reject("incomplete_evidence");
+  if (![validatedHeadSha, currentHeadSha, validatedBaseSha, currentBaseSha].every((sha) => SHA_PATTERN.test(sha))) {
+    return reject("invalid_sha");
+  }
+  if (validatedHeadSha !== currentHeadSha) {
+    return reject("validated_head_changed", { validated_head_sha: validatedHeadSha, current_head_sha: currentHeadSha });
+  }
+  if (validatedBaseSha === currentBaseSha) return reject("base_did_not_advance");
+  if (validatedBaseIsAncestorOfHead !== true) return reject("validated_base_not_ancestor_of_head");
+  if (validatedBaseIsAncestorOfCurrentBase !== true) return reject("base_advance_not_fast_forward");
+  if (!Array.isArray(validationCommands) || validationCommands.length !== 1 || validationCommands[0] !== "pnpm check:changed") {
+    return reject("unsupported_validation_command", { validation_commands: validationCommands });
+  }
+  if (!Number.isInteger(driftCommitCount) || driftCommitCount < 1 || driftCommitCount > maxCommits) {
+    return reject("unbounded_commit_drift", { drift_commit_count: driftCommitCount, max_commits: maxCommits });
+  }
+
+  const normalizedBranchFiles = normalizePathEvidence(branchFiles);
+  const normalizedBaseDriftFiles = normalizePathEvidence(baseDriftFiles);
+  const normalizedBranchAreas = normalizeStringEvidence(branchAreas);
+  const normalizedBaseDriftAreas = normalizeStringEvidence(baseDriftAreas);
+  if (
+    !normalizedBranchFiles ||
+    !normalizedBaseDriftFiles ||
+    !normalizedBranchAreas ||
+    !normalizedBaseDriftAreas
+  ) {
+    return reject("incomplete_evidence");
+  }
+  if (
+    normalizedBranchFiles.length === 0 ||
+    normalizedBranchFiles.length > maxFiles ||
+    normalizedBaseDriftFiles.length > maxFiles
+  ) {
+    return reject("unbounded_file_drift", {
+      branch_file_count: normalizedBranchFiles.length,
+      base_drift_file_count: normalizedBaseDriftFiles.length,
+      max_files: maxFiles,
+    });
+  }
+
+  const controlFiles = normalizedBaseDriftFiles.filter(isValidationDriftControlFile);
+  if (controlFiles.length > 0) return reject("validation_control_file_drift", { control_files: controlFiles });
+
+  const overlappingPaths = intersection(normalizedBranchFiles, normalizedBaseDriftFiles);
+  if (overlappingPaths.length > 0) return reject("overlapping_changed_paths", { paths: overlappingPaths });
+
+  const overlappingAreas = intersection(normalizedBranchAreas, normalizedBaseDriftAreas);
+  if (overlappingAreas.length > 0) return reject("overlapping_affected_areas", { areas: overlappingAreas });
+
+  return {
+    status: "reused",
+    proof: {
+      status: "reused",
+      validation_command: "pnpm check:changed",
+      validated_head_sha: validatedHeadSha,
+      validated_base_sha: validatedBaseSha,
+      reviewed_base_sha: currentBaseSha,
+      head_unchanged: true,
+      base_fast_forward: true,
+      drift_commit_count: driftCommitCount,
+      branch_changed_files: normalizedBranchFiles,
+      base_drift_files: normalizedBaseDriftFiles,
+      branch_areas: normalizedBranchAreas,
+      base_drift_areas: normalizedBaseDriftAreas,
+      validation_control_files_changed: [],
+      evidence_complete: true,
+      bounds: {
+        max_commits: maxCommits,
+        max_files_per_side: maxFiles,
+      },
+    },
+  };
+}
+
+export function isValidationDriftControlFile(file) {
+  const normalized = normalizePath(file);
+  if (!normalized) return true;
+  const basename = normalized.split("/").at(-1);
+  if (PACKAGE_MANAGER_FILES.has(basename)) return true;
+  if (/^tsconfig(?:\.[A-Za-z0-9_-]+)*\.jsonc?$/i.test(basename)) return true;
+  return /(^|\/)(?:check-changed|changed-gate)(?:[.-][A-Za-z0-9_-]+)*\.(?:[cm]?[jt]s|sh)$/i.test(normalized);
+}
+
+function normalizePathEvidence(values) {
+  if (!Array.isArray(values)) return null;
+  const normalized = values.map(normalizePath);
+  if (normalized.some((value) => !value)) return null;
+  const unique = [...new Set(normalized)].sort();
+  return unique.length === normalized.length ? unique : null;
+}
+
+function normalizeStringEvidence(values) {
+  if (!Array.isArray(values)) return null;
+  const normalized = values.map((value) => String(value ?? "").trim());
+  if (normalized.some((value) => !value)) return null;
+  const unique = [...new Set(normalized)].sort();
+  return unique.length === normalized.length ? unique : null;
+}
+
+function normalizePath(value) {
+  const raw = String(value ?? "");
+  if (raw !== raw.trim() || raw.includes("\\")) return "";
+  const normalized = raw.replace(/^\.\/+/, "");
+  if (!normalized || normalized.startsWith("/") || normalized.split("/").some((part) => !part || part === "." || part === "..")) {
+    return "";
+  }
+  return normalized;
+}
+
+function intersection(left, right) {
+  const rightValues = new Set(right);
+  return left.filter((value) => rightValues.has(value));
+}

--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -19,6 +19,7 @@ import {
   replacementSourceCloseComment,
   replacementSourceLinkComment,
 } from "./external-messages.mjs";
+import { evaluateValidationBaseDrift } from "./base-drift-validation.mjs";
 
 const FIX_ACTIONS = new Set(["fix_needed", "build_fix_artifact", "open_fix_pr"]);
 const REPAIR_STRATEGIES = new Set(["repair_contributor_branch", "replace_uneditable_branch", "new_fix_pr"]);
@@ -826,7 +827,13 @@ function executeRepairBranch({ fixArtifact, job, targetDir, scopeBlock = null, r
     allowedFixFiles,
     pushCheckpoint: dryRun ? null : pushRepairCheckpoint,
   });
-  if (refreshValidatedBranchBase({ targetDir, branch, baseBranch })) {
+  let finalBaseRefresh = refreshValidatedBranchBase({
+    targetDir,
+    branch,
+    baseBranch,
+    acceptedValidation: acceptedValidationForPrep(prep),
+  });
+  if (finalBaseRefresh.status === "rebased") {
     rebased = true;
     const priorCheckpointCommits = prep.checkpoint_commits;
     prep = editValidatePrepareMerge({
@@ -842,7 +849,13 @@ function executeRepairBranch({ fixArtifact, job, targetDir, scopeBlock = null, r
       pushCheckpoint: dryRun ? null : pushRepairCheckpoint,
     });
     prep.checkpoint_commits = uniqueStrings([...priorCheckpointCommits, ...prep.checkpoint_commits]);
-    if (refreshValidatedBranchBase({ targetDir, branch, baseBranch })) {
+    finalBaseRefresh = refreshValidatedBranchBase({
+      targetDir,
+      branch,
+      baseBranch,
+      acceptedValidation: acceptedValidationForPrep(prep),
+    });
+    if (finalBaseRefresh.status === "rebased") {
       throw new Error("base branch advanced again after validation; requeue before pushing");
     }
   }
@@ -996,7 +1009,13 @@ function executeReplacementBranch({ fixArtifact, targetDir, supersedeSources, fa
     refreshBaseBeforeReview: true,
     pushCheckpoint: pushReplacementCheckpoint,
   });
-  if (refreshValidatedBranchBase({ targetDir, branch, baseBranch })) {
+  let finalBaseRefresh = refreshValidatedBranchBase({
+    targetDir,
+    branch,
+    baseBranch,
+    acceptedValidation: acceptedValidationForPrep(prep),
+  });
+  if (finalBaseRefresh.status === "rebased") {
     const priorCheckpointCommits = prep.checkpoint_commits;
     prep = editValidatePrepareMerge({
       fixArtifact,
@@ -1011,7 +1030,13 @@ function executeReplacementBranch({ fixArtifact, targetDir, supersedeSources, fa
       pushCheckpoint: pushReplacementCheckpoint,
     });
     prep.checkpoint_commits = uniqueStrings([...priorCheckpointCommits, ...prep.checkpoint_commits]);
-    if (refreshValidatedBranchBase({ targetDir, branch, baseBranch })) {
+    finalBaseRefresh = refreshValidatedBranchBase({
+      targetDir,
+      branch,
+      baseBranch,
+      acceptedValidation: acceptedValidationForPrep(prep),
+    });
+    if (finalBaseRefresh.status === "rebased") {
       throw new Error("base branch advanced again after validation; requeue before pushing");
     }
   }
@@ -1410,6 +1435,18 @@ function editValidatePrepareMerge({
   };
 }
 
+function acceptedValidationForPrep(prep) {
+  const validationBaseDrift = prep.merge_preflight?.validation_base_drift;
+  if (validationBaseDrift?.status !== "reused") return null;
+  if (validationBaseDrift.validated_head_sha !== prep.commit) return null;
+  if (validationBaseDrift.reviewed_base_sha !== prep.merge_preflight.base_sha) return null;
+  return {
+    headSha: prep.commit,
+    baseSha: prep.merge_preflight.base_sha,
+    validationBaseDrift,
+  };
+}
+
 function buildFixPrompt({
   fixArtifact,
   branch,
@@ -1779,6 +1816,7 @@ function validateAndReviewLoop({
   let validationCommands = [];
   let reviewAttempts = 0;
   let baseRefreshes = 0;
+  let validationBaseDrift = null;
   while (reviewAttempts < maxReviewAttempts) {
     const attempt = reviewAttempts + 1;
     noteFixStage("validation_start", { mode, attempt, base_refreshes: baseRefreshes });
@@ -1797,25 +1835,63 @@ function validateAndReviewLoop({
       });
       onChangedGateBaseline?.(changedGateBaseline);
     }
-    runDiffCheck({ targetDir, baseBranch });
+    const validatedHeadSha = currentHead(targetDir);
+    const validatedBaseSha = run("git", ["rev-parse", `origin/${baseBranch}`], { cwd: targetDir }).trim();
+    runDiffCheck({ targetDir, baseBranch, baseRef: validatedBaseSha });
     noteFixStage("validation_complete", { mode, attempt, command_count: validationCommands.length, base_refreshes: baseRefreshes });
-    if (refreshBaseBeforeReview && branch && refreshValidatedBranchBase({ targetDir, branch, baseBranch })) {
-      baseRefreshes += 1;
-      noteFixStage("base_refresh_before_review", { mode, attempt, base_refreshes: baseRefreshes });
-      if (baseRefreshes > 1) {
-        throw new Error("base branch advanced again during validation; requeue before review");
+    if (refreshBaseBeforeReview && branch) {
+      const refresh = refreshValidatedBranchBase({
+        targetDir,
+        branch,
+        baseBranch,
+        allowValidationReuse: baseRefreshes > 0,
+        validationState: {
+          validationCommands,
+          validatedHeadSha,
+          validatedBaseSha,
+        },
+      });
+      if (refresh.status === "rebased") {
+        baseRefreshes += 1;
+        validationBaseDrift = null;
+        noteFixStage("base_refresh_before_review", { mode, attempt, base_refreshes: baseRefreshes });
+        continue;
       }
-      continue;
+      if (refresh.status === "rejected") {
+        throw new Error(`base branch advanced again during validation; reuse blocked: ${refresh.reason}`);
+      }
+      if (refresh.status === "reused") {
+        validationBaseDrift = refresh.validation_base_drift;
+        noteFixStage("validation_base_drift_reused", {
+          mode,
+          attempt,
+          base_refreshes: baseRefreshes,
+          validated_base_sha: validationBaseDrift.validated_base_sha,
+          reviewed_base_sha: validationBaseDrift.reviewed_base_sha,
+          drift_commit_count: validationBaseDrift.drift_commit_count,
+        });
+      } else {
+        validationBaseDrift = null;
+      }
     }
     reviewAttempts += 1;
     noteFixStage("codex_review_start", { mode, attempt });
     lastReview = runCodexReview({ fixArtifact, targetDir, mode, attempt, baseBranch, validationCommands });
     noteFixStage("codex_review_complete", { mode, attempt, status: lastReview.status ?? "unknown" });
     lastReview.validation_commands_run = validationCommands;
+    if (validationBaseDrift) lastReview.validation_base_drift = validationBaseDrift;
     if (isCleanCodexReview(lastReview)) return lastReview;
     if (!allowReviewFixes || reviewAttempts === maxReviewAttempts) break;
     const reviewFix = runCodexReviewFix({ fixArtifact, targetDir, mode, review: lastReview, attempt });
     onReviewFix?.(attempt, reviewFix);
+    if (validationBaseDrift) {
+      const refresh = refreshValidatedBranchBase({ targetDir, branch, baseBranch });
+      if (refresh.status === "rebased") {
+        noteFixStage("base_refresh_after_reused_review_fix", { mode, attempt });
+      }
+      validationBaseDrift = null;
+      baseRefreshes = 0;
+    }
   }
   const summary =
     lastReview?.summary ??
@@ -1823,9 +1899,10 @@ function validateAndReviewLoop({
   throw new Error(`Codex /review did not pass after ${reviewAttempts} attempt(s): ${summary}`);
 }
 
-function runDiffCheck({ targetDir, baseBranch }) {
-  ensureMergeBaseAvailable({ targetDir, baseBranch });
-  run("git", ["diff", "--check", `origin/${baseBranch}...HEAD`], { cwd: targetDir });
+function runDiffCheck({ targetDir, baseBranch, baseRef = null }) {
+  const resolvedBaseRef = baseRef ?? `origin/${baseBranch}`;
+  if (!baseRef) ensureMergeBaseAvailable({ targetDir, baseBranch });
+  run("git", ["diff", "--check", `${resolvedBaseRef}...HEAD`], { cwd: targetDir });
   run("git", ["diff", "--check"], { cwd: targetDir });
 }
 
@@ -2189,6 +2266,9 @@ function buildMergePreflight({ fixArtifact, codexReview, headSha, baseSha }) {
         : [`Codex /review passed after agentic fix loop: ${codexReview.summary ?? "clean"}`],
     },
     validation_commands: validationCommands,
+    ...(codexReview.validation_base_drift
+      ? { validation_base_drift: codexReview.validation_base_drift }
+      : {}),
   };
 }
 
@@ -3754,19 +3834,122 @@ function rebaseRecoverableReplacementBranch({ targetDir, branch, baseBranch, fix
   }
 }
 
-function refreshValidatedBranchBase({ targetDir, branch, baseBranch }) {
+function refreshValidatedBranchBase({
+  targetDir,
+  branch,
+  baseBranch,
+  allowValidationReuse = false,
+  validationState = null,
+  acceptedValidation = null,
+}) {
   run("git", ["fetch", "origin", `${baseBranch}:refs/remotes/origin/${baseBranch}`], { cwd: targetDir });
   const baseRef = `origin/${baseBranch}`;
-  if (isAncestor({ targetDir, ancestor: baseRef, descendant: "HEAD" })) return false;
+  const currentBaseSha = run("git", ["rev-parse", baseRef], { cwd: targetDir }).trim();
+  const headSha = currentHead(targetDir);
+  if (isAncestor({ targetDir, ancestor: baseRef, descendant: "HEAD" })) {
+    return { status: "unchanged", base_sha: currentBaseSha, head_sha: headSha };
+  }
+  if (
+    acceptedValidation?.validationBaseDrift?.status === "reused" &&
+    acceptedValidation.headSha === headSha &&
+    acceptedValidation.baseSha === currentBaseSha
+  ) {
+    return {
+      status: "validated",
+      base_sha: currentBaseSha,
+      head_sha: headSha,
+      validation_base_drift: acceptedValidation.validationBaseDrift,
+    };
+  }
+  if (allowValidationReuse && validationState) {
+    const decision = reusableValidationBaseDrift({
+      targetDir,
+      currentBaseSha,
+      currentHeadSha: headSha,
+      ...validationState,
+    });
+    if (decision.status === "reused") {
+      runDiffCheck({ targetDir, baseBranch, baseRef: currentBaseSha });
+      return {
+        status: "reused",
+        base_sha: currentBaseSha,
+        head_sha: headSha,
+        validation_base_drift: {
+          ...decision.proof,
+          git_diff_check: {
+            status: "passed",
+            base_sha: currentBaseSha,
+            commands: [`git diff --check ${currentBaseSha}...HEAD`, "git diff --check"],
+          },
+        },
+      };
+    }
+    noteFixStage("validation_base_drift_rejected", {
+      branch,
+      reason: decision.reason,
+      details: decision.details ?? {},
+    });
+    return { status: "rejected", reason: decision.reason, details: decision.details ?? {} };
+  }
   try {
     run("git", ["rebase", baseRef], { cwd: targetDir });
-    return true;
+    return { status: "rebased", base_sha: currentBaseSha, head_sha: currentHead(targetDir) };
   } catch (error) {
     abortRebase(targetDir);
     throw new Error(
       `base branch advanced after validation and ${branch} needs a fresh rebase pass: ${compactText(error.message, 1200)}`,
     );
   }
+}
+
+function reusableValidationBaseDrift({
+  targetDir,
+  validationCommands,
+  validatedHeadSha,
+  currentHeadSha,
+  validatedBaseSha,
+  currentBaseSha,
+}) {
+  const branchFiles = gitDiffPathEvidence(targetDir, `${validatedBaseSha}...${validatedHeadSha}`);
+  const baseDriftFiles = gitDiffPathEvidence(targetDir, `${validatedBaseSha}..${currentBaseSha}`);
+  const driftCommitCount = Number(
+    run("git", ["rev-list", "--count", `${validatedBaseSha}..${currentBaseSha}`], {
+      cwd: targetDir,
+      maxBuffer: 1024 * 1024,
+    }).trim(),
+  );
+  return evaluateValidationBaseDrift({
+    validationCommands,
+    validatedHeadSha,
+    currentHeadSha,
+    validatedBaseSha,
+    currentBaseSha,
+    validatedBaseIsAncestorOfHead: isAncestor({
+      targetDir,
+      ancestor: validatedBaseSha,
+      descendant: validatedHeadSha,
+    }),
+    validatedBaseIsAncestorOfCurrentBase: isAncestor({
+      targetDir,
+      ancestor: validatedBaseSha,
+      descendant: currentBaseSha,
+    }),
+    driftCommitCount,
+    branchFiles,
+    baseDriftFiles,
+    branchAreas: affectedAreasForFiles(branchFiles),
+    baseDriftAreas: affectedAreasForFiles(baseDriftFiles),
+    evidenceComplete: true,
+  });
+}
+
+function gitDiffPathEvidence(targetDir, range) {
+  return run("git", ["diff", "--name-only", "--no-renames", "-z", range, "--"], {
+    cwd: targetDir,
+    maxBuffer: 1024 * 1024,
+  })
+    .split("\0")
+    .filter(Boolean);
 }
 
 function resolveRecoverableRebaseConflicts({ targetDir, branch, baseRef, fixArtifact, initialError }) {

--- a/test/base-drift-validation.test.mjs
+++ b/test/base-drift-validation.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  evaluateValidationBaseDrift,
+  isValidationDriftControlFile,
+  MAX_VALIDATION_BASE_DRIFT_COMMITS,
+} from "../scripts/base-drift-validation.mjs";
+
+const OLD_BASE = "1".repeat(40);
+const NEW_BASE = "2".repeat(40);
+const HEAD = "3".repeat(40);
+
+function reusableDrift(overrides = {}) {
+  return evaluateValidationBaseDrift({
+    validationCommands: ["pnpm check:changed"],
+    validatedHeadSha: HEAD,
+    currentHeadSha: HEAD,
+    validatedBaseSha: OLD_BASE,
+    currentBaseSha: NEW_BASE,
+    validatedBaseIsAncestorOfHead: true,
+    validatedBaseIsAncestorOfCurrentBase: true,
+    driftCommitCount: 2,
+    branchFiles: ["src/reply/dedupe.ts", "src/reply/dedupe.test.ts"],
+    baseDriftFiles: ["docs/gateway.md"],
+    branchAreas: ["src/reply"],
+    baseDriftAreas: ["docs"],
+    evidenceComplete: true,
+    ...overrides,
+  });
+}
+
+test("accepts bounded irrelevant fast-forward base drift", () => {
+  const decision = reusableDrift();
+
+  assert.equal(decision.status, "reused");
+  assert.deepEqual(decision.proof, {
+    status: "reused",
+    validation_command: "pnpm check:changed",
+    validated_head_sha: HEAD,
+    validated_base_sha: OLD_BASE,
+    reviewed_base_sha: NEW_BASE,
+    head_unchanged: true,
+    base_fast_forward: true,
+    drift_commit_count: 2,
+    branch_changed_files: ["src/reply/dedupe.test.ts", "src/reply/dedupe.ts"],
+    base_drift_files: ["docs/gateway.md"],
+    branch_areas: ["src/reply"],
+    base_drift_areas: ["docs"],
+    validation_control_files_changed: [],
+    evidence_complete: true,
+    bounds: {
+      max_commits: 64,
+      max_files_per_side: 128,
+    },
+  });
+});
+
+test("rejects overlapping changed paths", () => {
+  const decision = reusableDrift({ baseDriftFiles: ["src/reply/dedupe.ts"], baseDriftAreas: ["src/reply"] });
+
+  assert.equal(decision.status, "rejected");
+  assert.equal(decision.reason, "overlapping_changed_paths");
+});
+
+test("rejects disjoint paths in an overlapping affected area", () => {
+  const decision = reusableDrift({
+    baseDriftFiles: ["src/reply/format.ts"],
+    baseDriftAreas: ["src/reply"],
+  });
+
+  assert.equal(decision.status, "rejected");
+  assert.equal(decision.reason, "overlapping_affected_areas");
+});
+
+test("rejects non-fast-forward base movement", () => {
+  const decision = reusableDrift({ validatedBaseIsAncestorOfCurrentBase: false });
+
+  assert.equal(decision.status, "rejected");
+  assert.equal(decision.reason, "base_advance_not_fast_forward");
+});
+
+test("rejects a changed validated head", () => {
+  const decision = reusableDrift({ currentHeadSha: "4".repeat(40) });
+
+  assert.equal(decision.status, "rejected");
+  assert.equal(decision.reason, "validated_head_changed");
+});
+
+test("rejects validation commands other than one normalized changed gate", () => {
+  for (const validationCommands of [
+    ["corepack pnpm check:changed"],
+    ["pnpm check:changed", "git diff --check"],
+    ["pnpm test:serial src/reply/dedupe.test.ts"],
+  ]) {
+    const decision = reusableDrift({ validationCommands });
+    assert.equal(decision.status, "rejected");
+    assert.equal(decision.reason, "unsupported_validation_command");
+  }
+});
+
+test("rejects package-manager, TypeScript config, and changed-gate control drift", () => {
+  for (const file of ["package.json", "pnpm-lock.yaml", "configs/tsconfig.build.json", "scripts/check-changed.mjs"]) {
+    assert.equal(isValidationDriftControlFile(file), true);
+    const decision = reusableDrift({ baseDriftFiles: [file] });
+    assert.equal(decision.status, "rejected");
+    assert.equal(decision.reason, "validation_control_file_drift");
+  }
+});
+
+test("rejects incomplete or unbounded evidence", () => {
+  assert.equal(reusableDrift({ evidenceComplete: false }).reason, "incomplete_evidence");
+  assert.equal(reusableDrift({ baseDriftFiles: [" docs/drift.md"] }).reason, "incomplete_evidence");
+  assert.equal(
+    reusableDrift({ driftCommitCount: MAX_VALIDATION_BASE_DRIFT_COMMITS + 1 }).reason,
+    "unbounded_commit_drift",
+  );
+  assert.equal(
+    reusableDrift({ baseDriftFiles: Array.from({ length: 129 }, (_, index) => `docs/drift-${index}.md`) }).reason,
+    "unbounded_file_drift",
+  );
+});

--- a/test/base-drift-validation.test.mjs
+++ b/test/base-drift-validation.test.mjs
@@ -100,7 +100,13 @@ test("rejects validation commands other than one normalized changed gate", () =>
 });
 
 test("rejects package-manager, TypeScript config, and changed-gate control drift", () => {
-  for (const file of ["package.json", "pnpm-lock.yaml", "configs/tsconfig.build.json", "scripts/check-changed.mjs"]) {
+  for (const file of [
+    "package.json",
+    "pnpm-lock.yaml",
+    "configs/tsconfig.build.json",
+    "scripts/check-changed.mjs",
+    `scripts/changed-gate${"-".repeat(10_000)}.mjs`,
+  ]) {
     assert.equal(isValidationDriftControlFile(file), true);
     const decision = reusableDrift({ baseDriftFiles: [file] });
     assert.equal(decision.status, "rejected");

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -658,13 +658,15 @@ test("execute-fix-artifact makes rebase-only repair a no-generated-edit path", (
   assert.match(source, /recovery_note: "recoverable branch was pushed before fix execution blocked; requeue can resume it"/);
 });
 
-test("execute-fix-artifact preserves review budget across one rebase-only base refresh", () => {
+test("execute-fix-artifact requires one full refresh before bounded validation reuse", () => {
   const source = fs.readFileSync(path.join(repoRoot, "scripts", "execute-fix-artifact.mjs"), "utf8");
 
   assert.match(source, /let reviewAttempts = 0;/);
   assert.match(source, /let baseRefreshes = 0;/);
+  assert.match(source, /allowValidationReuse: baseRefreshes > 0,/);
   assert.match(source, /baseRefreshes \+= 1;/);
-  assert.match(source, /if \(baseRefreshes > 1\) \{\s*throw new Error\("base branch advanced again during validation; requeue before review"\)/);
+  assert.match(source, /if \(refresh\.status === "reused"\) \{/);
+  assert.match(source, /base branch advanced again during validation; reuse blocked:/);
   assert.match(source, /reviewAttempts \+= 1;\s*noteFixStage\("codex_review_start"/);
   assert.match(source, /Codex \/review did not pass after \$\{reviewAttempts\} attempt\(s\):/);
 });
@@ -677,6 +679,43 @@ test("execute-fix-artifact revalidates late base refreshes and binds merge proof
   assert.match(source, /merge_preflight: buildMergePreflight\(\{[\s\S]*?headSha: commit,[\s\S]*?baseSha:/);
   assert.match(source, /function buildMergePreflight\(\{ fixArtifact, codexReview, headSha, baseSha \}\)/);
   assert.match(source, /head_sha: headSha,\s*base_sha: baseSha,/);
+  assert.match(source, /validation_base_drift: codexReview\.validation_base_drift/);
+  assert.match(source, /acceptedValidation: acceptedValidationForPrep\(prep\)/);
+});
+
+test("execute-fix-artifact rebases the first base advance then reuses disjoint changed-gate validation", () => {
+  const run = runValidationBaseDriftReuseFixture();
+
+  assert.equal(run.child.status, 0, run.child.stderr || run.child.stdout);
+  assert.equal(fs.readFileSync(run.validationMarker, "utf8"), "2");
+  assert.equal(run.report.status, "planned");
+
+  const action = run.report.actions[0];
+  const drift = action.merge_preflight.validation_base_drift;
+  assert.equal(drift.status, "reused");
+  assert.equal(drift.validation_command, "pnpm check:changed");
+  assert.equal(drift.validated_head_sha, action.commit);
+  assert.equal(drift.validated_base_sha, run.firstDriftSha);
+  assert.equal(drift.reviewed_base_sha, run.secondDriftSha);
+  assert.deepEqual(drift.branch_changed_files, ["src/app.js"]);
+  assert.deepEqual(drift.base_drift_files, ["docs/drift-2.md"]);
+  assert.deepEqual(drift.branch_areas, ["src/app.js"]);
+  assert.deepEqual(drift.base_drift_areas, ["docs"]);
+  assert.equal(drift.git_diff_check.status, "passed");
+  assert.equal(action.merge_preflight.base_sha, run.secondDriftSha);
+
+  assert.equal(
+    spawnSync("git", ["merge-base", "--is-ancestor", run.firstDriftSha, "HEAD"], {
+      cwd: run.fixture.targetDir,
+    }).status,
+    0,
+  );
+  assert.equal(
+    spawnSync("git", ["merge-base", "--is-ancestor", run.secondDriftSha, "HEAD"], {
+      cwd: run.fixture.targetDir,
+    }).status,
+    1,
+  );
 });
 
 test("execute-fix-artifact bounds and traces rebase-only repair execution", () => {
@@ -695,7 +734,7 @@ test("execute-fix-artifact bounds and traces rebase-only repair execution", () =
   assert.match(source, /codex_review_start/);
   assert.match(source, /refreshBaseBeforeReview: true/);
   assert.match(source, /noteFixStage\("base_refresh_before_review"/);
-  assert.match(source, /refreshBaseBeforeReview && branch && refreshValidatedBranchBase/);
+  assert.match(source, /if \(refreshBaseBeforeReview && branch\) \{/);
   assert.match(source, /do not rerun pnpm, npm, corepack, test, lint, build, or other validation commands/);
   assert.match(source, /may run the minimum read-only `gh pr view` or `gh api` query needed to satisfy them/);
   assert.match(source, /do not mutate GitHub: do not push, comment, review, label, close, merge, assign, or change any remote state/);
@@ -1399,6 +1438,123 @@ test("execute-fix-artifact keeps changed-gate failures strict when strict valida
     .map((file) => JSON.parse(fs.readFileSync(path.join(run.fixture.runDir, "fix-executor-debug", file), "utf8")).phase);
   assert.equal(phases.includes("baseline"), false);
 });
+
+function runValidationBaseDriftReuseFixture() {
+  const fixture = makeFixture();
+  const clusterId = "validation-base-drift-reuse";
+  const resultPath = path.join(fixture.runDir, "result.json");
+  const reportPath = path.join(fixture.runDir, "fix-execution-report.json");
+  const validationMarker = path.join(fixture.root, "check-changed-calls");
+  const writerDir = path.join(fixture.root, "main-writer");
+
+  git(["clone", fixture.originDir, writerDir], { cwd: fixture.root });
+  git(["config", "user.name", "Main Writer"], { cwd: writerDir });
+  git(["config", "user.email", "main-writer@example.com"], { cwd: writerDir });
+
+  fs.writeFileSync(fixture.jobPath, jobFile(clusterId));
+  const result = resultFile(clusterId);
+  result.fix_artifact.validation_commands = ["pnpm check:changed"];
+  fs.writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`);
+
+  writeExecutable(
+    path.join(fixture.binDir, "codex"),
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+const output = args.includes("--output-last-message") ? args[args.indexOf("--output-last-message") + 1] : "";
+if (args.includes("--output-schema")) {
+  fs.writeFileSync(output, JSON.stringify({
+    status: "passed",
+    summary: "clean",
+    findings: [],
+    findings_addressed: true,
+    evidence: ["fixture review passed against refreshed main"],
+  }));
+  process.exit(0);
+}
+const cd = args[args.indexOf("--cd") + 1];
+fs.appendFileSync(path.join(cd, "src", "app.js"), "\\n// bounded drift reuse fixture\\n");
+if (output) fs.writeFileSync(output, "edited\\n");
+`,
+  );
+  writeExecutable(
+    path.join(fixture.binDir, "pnpm"),
+    `#!/usr/bin/env node
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+if (args[0] !== "check:changed") process.exit(0);
+const marker = ${JSON.stringify(validationMarker)};
+const count = fs.existsSync(marker) ? Number(fs.readFileSync(marker, "utf8")) : 0;
+if (count < 2) {
+  const next = count + 1;
+  const cwd = ${JSON.stringify(writerDir)};
+  fs.mkdirSync(path.join(cwd, "docs"), { recursive: true });
+  fs.writeFileSync(path.join(cwd, "docs", "drift-" + next + ".md"), "main drift " + next + "\\n");
+  for (const gitArgs of [
+    ["add", "."],
+    ["commit", "-m", "docs: main drift " + next],
+    ["push", "origin", "HEAD:main"],
+  ]) {
+    const child = spawnSync("git", gitArgs, { cwd, encoding: "utf8" });
+    if (child.status !== 0) {
+      console.error(child.stderr || child.stdout);
+      process.exit(child.status || 1);
+    }
+  }
+}
+fs.writeFileSync(marker, String(count + 1));
+process.exit(0);
+`,
+  );
+
+  const child = spawnSync(
+    process.execPath,
+    [
+      "scripts/execute-fix-artifact.mjs",
+      fixture.jobPath,
+      resultPath,
+      "--target-dir",
+      fixture.targetDir,
+      "--work-dir",
+      fixture.workDir,
+      "--report",
+      reportPath,
+      "--dry-run",
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+        CLOWNFISH_ALLOW_EXECUTE: "1",
+        CLOWNFISH_ALLOW_FIX_PR: "1",
+        CLOWNFISH_FIX_STEP_TIMEOUT_MS: "120000",
+        CLOWNFISH_FIX_TIMEOUT_RESERVE_MS: "0",
+        CLOWNFISH_FIX_REPORT_RESERVE_MS: "0",
+        CLOWNFISH_INSTALL_TARGET_DEPS: "0",
+        CLOWNFISH_SKIP_CODEX_WRITE_PREFLIGHT: "1",
+        CLOWNFISH_CODEX_REVIEW_ATTEMPTS: "1",
+        CLOWNFISH_STREAM_VALIDATION_OUTPUT: "0",
+      },
+    },
+  );
+
+  const secondDriftSha = git(["rev-parse", "HEAD"], { cwd: writerDir });
+  const firstDriftSha = git(["rev-parse", "HEAD^"], { cwd: writerDir });
+  return {
+    fixture,
+    child,
+    report: JSON.parse(fs.readFileSync(reportPath, "utf8")),
+    validationMarker,
+    firstDriftSha,
+    secondDriftSha,
+  };
+}
 
 function runBaselineChangedGateFixture({
   clusterId,

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -1448,6 +1448,7 @@ function runValidationBaseDriftReuseFixture() {
   const writerDir = path.join(fixture.root, "main-writer");
 
   git(["clone", fixture.originDir, writerDir], { cwd: fixture.root });
+  git(["checkout", "main"], { cwd: writerDir });
   git(["config", "user.name", "Main Writer"], { cwd: writerDir });
   git(["config", "user.email", "main-writer@example.com"], { cwd: writerDir });
 


### PR DESCRIPTION
## Summary

- keep the first base refresh strict: rebase and rerun `pnpm check:changed`
- reuse that validation only for later bounded, fast-forward, disjoint base drift with an unchanged head
- record the exact drift proof and run fresh `git diff --check` against the reviewed base

## Why

Fast-moving OpenClaw `main` can advance more than once during one autonomous repair. Clownfish currently requeues after the second advance even when the new commits are unrelated to the branch, starving otherwise valid jobs.

The reuse path fails closed for overlapping files or affected areas, package-manager/lock/TypeScript/changed-gate control changes, non-fast-forward movement, incomplete evidence, or drift beyond 64 commits / 128 files per side. Post-flight exact-head and exact-base merge guards are unchanged.

## Validation

- `node --test test/base-drift-validation.test.mjs test/execute-fix-artifact.test.mjs` (`68/68`)
- `npm run validate` (`6629/6629` jobs)
- `git diff --check origin/main...HEAD`
