### PR TITLE
chore(queue): add six autonomous PR remediation jobs

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T132334-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T132334-001.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T132334-001
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#100801"
+cluster_refs:
+  - "#100801"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:23:34.872Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #100801 fix(cron): accept null fallbacks in update patch payload (#100707)
+
+- bucket: ready_for_maintainer
+- author: SunnyShu0925
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-06T13:14:31Z
+- live url: https://github.com/openclaw/openclaw/pull/100801

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T132334-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T132334-002.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T132334-002
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#100832"
+cluster_refs:
+  - "#100832"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:23:34.873Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 2
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #100832 fix(agents): preserve blank lines in multi-question user input fallback parsing
+
+- bucket: ready_for_maintainer
+- author: machine3at
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: agents, size: XS, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-06T12:25:48Z
+- live url: https://github.com/openclaw/openclaw/pull/100832

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T132334-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T132334-003.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T132334-003
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#99607"
+cluster_refs:
+  - "#99607"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:23:34.873Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 3
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #99607 fix: keep Bedrock live smoke on Bedrock runtime
+
+- bucket: ready_for_maintainer
+- author: brian-bell
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: L, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-07-03T18:57:30Z
+- live url: https://github.com/openclaw/openclaw/pull/99607

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T132334-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T132334-004.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T132334-004
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#99485"
+cluster_refs:
+  - "#99485"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:23:34.873Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 4
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #99485 fix(approvals): identify the originating session in approval prompts
+
+- bucket: ready_for_maintainer
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: channel: matrix, channel: telegram, size: S, channel: qqbot, proof: sufficient, mantis: telegram-visible-proof, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-07-03T10:40:20Z
+- live url: https://github.com/openclaw/openclaw/pull/99485

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T132334-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T132334-005.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T132334-005
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#99362"
+cluster_refs:
+  - "#99362"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:23:34.873Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 5
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #99362 feat(status): surface last compaction outcome in /status
+
+- bucket: ready_for_maintainer
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, agents, size: L, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-07-03T05:40:36Z
+- live url: https://github.com/openclaw/openclaw/pull/99362

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T132334-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T132334-006.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T132334-006
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#98184"
+cluster_refs:
+  - "#98184"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:23:34.873Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 6
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #98184 feat(doctor): warn when cron delivery targets inactive channel
+
+- bucket: ready_for_maintainer
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: M, proof: sufficient, P3, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-02T06:21:45Z
+- live url: https://github.com/openclaw/openclaw/pull/98184


### PR DESCRIPTION
## Summary

- add one autonomous remediation job for each selected pull request:
  - https://github.com/openclaw/openclaw/pull/100801
  - https://github.com/openclaw/openclaw/pull/100832
  - https://github.com/openclaw/openclaw/pull/99607
  - https://github.com/openclaw/openclaw/pull/99485
  - https://github.com/openclaw/openclaw/pull/99362
  - https://github.com/openclaw/openclaw/pull/98184
- generate from live GitHub search with a single PR per autonomous job
- stage queue inputs only; no jobs were dispatched and no pull requests were merged

## Validation

- `npm run validate:job -- <generated-job>` for all six jobs
- `npm run validate` (6,635 jobs validated)