### PR TITLE
fix(queue): normalize published result lookup

### DIFF
--- a/scripts/prune-inbox-jobs.mjs
+++ b/scripts/prune-inbox-jobs.mjs
@@ -13,6 +13,8 @@ const live = args.live !== false && args.live !== "false";
 const limit = numberArg("limit", 0);
 const files = args._.length > 0 ? args._.map((file) => path.resolve(file)) : listJobFiles(inboxDir);
 const selectedFiles = limit > 0 ? files.slice(0, limit) : files;
+const resultDir = path.join(repoRoot(), "results", owner);
+const resultNames = new Set(fs.existsSync(resultDir) ? fs.readdirSync(resultDir) : []);
 const parsedJobs = selectedFiles.map((file) => {
   const job = parseJob(file);
   const fm = job.frontmatter;
@@ -30,12 +32,12 @@ const rows = [];
 
 for (const entry of parsedJobs) {
   const { job, fm, candidates, canonical, resultPath } = entry;
-  const exactResultExists = fs.existsSync(resultPath);
-  const statuses = exactResultExists ? {} : (statusesByRepo.get(fm.repo) ?? {});
+  const resultExists = Boolean(resultPath);
+  const statuses = resultExists ? {} : (statusesByRepo.get(fm.repo) ?? {});
   const openCandidates = candidates.filter((ref) => isOpenRef(statuses[ref]));
   const closedCandidates = candidates.filter((ref) => statuses[ref] && !isOpenRef(statuses[ref]));
   const closedCanonical = canonical.filter((ref) => statuses[ref] && !isOpenRef(statuses[ref]));
-  const action = classify({ fm, exactResultExists, candidates, openCandidates, closedCanonical, live });
+  const action = classify({ fm, resultExists, candidates, openCandidates, closedCanonical, live });
   const destination = destinationFor(job, action);
   rows.push({
     job: job.relativePath,
@@ -44,7 +46,7 @@ for (const entry of parsedJobs) {
     mode: fm.mode,
     action,
     destination,
-    result: exactResultExists ? path.relative(repoRoot(), resultPath) : null,
+    result: resultExists ? path.relative(repoRoot(), resultPath) : null,
     candidates,
     open_candidates: openCandidates,
     closed_candidates: closedCandidates,
@@ -81,9 +83,9 @@ if (json) {
   }
 }
 
-function classify({ fm, exactResultExists, candidates, openCandidates, closedCanonical, live }) {
+function classify({ fm, resultExists, candidates, openCandidates, closedCanonical, live }) {
   if (isExampleJobId(fm.cluster_id)) return "example";
-  if (exactResultExists) return "already_resulted";
+  if (resultExists) return "already_resulted";
   if (live && candidates.length > 0 && openCandidates.length === 0) return "all_candidates_closed";
   if (fm.mode === "plan" && openCandidates.length === 1) return "single_open_candidate";
   if (closedCanonical.length > 0 && openCandidates.length > 1) return "needs_recanonicalize";
@@ -117,13 +119,24 @@ function listJobFiles(directory) {
 }
 
 function resultFilePath(clusterId) {
-  return path.join(repoRoot(), "results", owner, `${clusterId}.md`);
+  const exactName = `${clusterId}.md`;
+  if (resultNames.has(exactName)) return path.join(resultDir, exactName);
+  const publishedName = `${publishedResultSlug(clusterId)}.md`;
+  return resultNames.has(publishedName) ? path.join(resultDir, publishedName) : null;
+}
+
+function publishedResultSlug(value) {
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 120) || "unknown";
 }
 
 function fetchAllStatuses(entries) {
   const refsByRepo = new Map();
   for (const entry of entries) {
-    if (fs.existsSync(entry.resultPath)) continue;
+    if (entry.resultPath) continue;
     const refs = refsByRepo.get(entry.fm.repo) ?? new Set();
     for (const ref of [...entry.candidates, ...entry.clusterRefs]) refs.add(ref);
     refsByRepo.set(entry.fm.repo, refs);

--- a/test/queue-prune-examples.test.mjs
+++ b/test/queue-prune-examples.test.mjs
@@ -250,6 +250,67 @@ test("prune-inbox offline mode preserves unresolved jobs", () => {
   assert.equal(fs.existsSync(unresolvedPath), true);
 });
 
+test("prune-inbox finds publisher-normalized results without breaking exact-case results", (t) => {
+  const fixtureOwner = `queue-prune-case-${process.pid}-${Date.now()}`;
+  const fixtureRoot = path.join(repoRoot, "jobs", fixtureOwner);
+  const inbox = path.join(fixtureRoot, "inbox");
+  const finalized = path.join(fixtureRoot, "outbox", "finalized");
+  const resultDir = path.join(repoRoot, "results", fixtureOwner);
+  const mixedClusterId = "live-pr-inventory-20260706T132334-004";
+  const exactClusterId = "existing-Exact-Case-result";
+  const mixedJob = path.join(inbox, "mixed-case.md");
+  const exactJob = path.join(inbox, "exact-case.md");
+  fs.mkdirSync(inbox, { recursive: true });
+  fs.mkdirSync(resultDir, { recursive: true });
+  t.after(() => {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    fs.rmSync(resultDir, { recursive: true, force: true });
+  });
+  writeJob(mixedJob, {
+    clusterId: mixedClusterId,
+    mode: "autonomous",
+    refs: ["#1", "#2"],
+  });
+  writeJob(exactJob, {
+    clusterId: exactClusterId,
+    mode: "autonomous",
+    refs: ["#3", "#4"],
+  });
+  fs.writeFileSync(path.join(resultDir, "live-pr-inventory-20260706t132334-004.md"), "# mixed-case result\n");
+  fs.writeFileSync(path.join(resultDir, `${exactClusterId}.md`), "# exact-case result\n");
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "scripts/prune-inbox-jobs.mjs",
+      "--inbox",
+      inbox,
+      "--owner",
+      fixtureOwner,
+      "--live",
+      "false",
+      "--write",
+      "--json",
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.summary.already_resulted, 2);
+  assert.equal(payload.summary.movable, 2);
+  const rowsByCluster = new Map(payload.rows.map((row) => [row.cluster_id, row]));
+  assert.equal(
+    rowsByCluster.get(mixedClusterId).result,
+    `results/${fixtureOwner}/live-pr-inventory-20260706t132334-004.md`,
+  );
+  assert.equal(rowsByCluster.get(exactClusterId).result, `results/${fixtureOwner}/${exactClusterId}.md`);
+  assert.equal(fs.existsSync(mixedJob), false);
+  assert.equal(fs.existsSync(exactJob), false);
+  assert.equal(fs.existsSync(path.join(finalized, "mixed-case.md")), true);
+  assert.equal(fs.existsSync(path.join(finalized, "exact-case.md")), true);
+});
+
 test("prune-inbox keeps a positional job path after --write", () => {
   const fixture = makeFixture();
   const targetPath = path.join(fixture.inbox, "target-example.md");


### PR DESCRIPTION
## Summary

- match result filenames using exact directory entries before falling back to the publisher-normalized cluster slug
- preserve existing exact-case result filenames
- cover mixed-case job IDs with lowercase published reports and verify completed jobs move to the finalized outbox

## Tests

- `node --check scripts/prune-inbox-jobs.mjs`
- `node --test test/queue-prune-examples.test.mjs`
- `npm run validate`