### PR TITLE
chore(queue): add eight autonomous PR remediation jobs

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-001.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T135633-001
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#100904"
+cluster_refs:
+  - "#100904"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:56:33.125Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #100904 Fix memory_get all supplement fallback
+
+- bucket: ready_for_maintainer
+- author: mushuiyu886
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: sufficient, P2, rating: platinum hermit, status: ready for maintainer look
+- live updated: 2026-07-06T13:52:02Z
+- live url: https://github.com/openclaw/openclaw/pull/100904

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-002.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T135633-002
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#98821"
+cluster_refs:
+  - "#98821"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:56:33.125Z; bucket=recent_active; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 2
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #98821 fix(gateway): dedupe MCP schema conflict warnings
+
+- bucket: recent_active
+- author: harjothkhara
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, P2
+- live updated: 2026-07-05T19:58:25Z
+- live url: https://github.com/openclaw/openclaw/pull/98821

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-003.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-003.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T135633-003
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#100900"
+cluster_refs:
+  - "#100900"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:56:33.125Z; bucket=needs_proof; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 3
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #100900 fix(memory-wiki): bridge status crashes on malformed memory-plugin artifacts and ignores readMemoryArtifacts=false
+
+- bucket: needs_proof
+- author: huveewomg
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: memory-wiki, P1, rating: silver shellfish, status: needs proof
+- live updated: 2026-07-06T13:45:46Z
+- live url: https://github.com/openclaw/openclaw/pull/100900

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-004.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-004.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T135633-004
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#100902"
+cluster_refs:
+  - "#100902"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:56:33.125Z; bucket=needs_proof; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 4
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #100902 fix(memory-wiki): shared search crashes with "search is not a function" when the memory plugin lacks a full search manager
+
+- bucket: needs_proof
+- author: huveewomg
+- author association: FIRST_TIME_CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: S, extensions: memory-wiki, P2, rating: silver shellfish, status: needs proof
+- live updated: 2026-07-06T13:51:04Z
+- live url: https://github.com/openclaw/openclaw/pull/100902

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-005.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-005.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T135633-005
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#100910"
+cluster_refs:
+  - "#100910"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:56:33.125Z; bucket=recent_active; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 5
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #100910 fix(agents): retry transient filesystem races when reading workspace bootstrap files
+
+- bucket: recent_active
+- author: masatohoshino
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: none
+- live updated: 2026-07-06T13:38:20Z
+- live url: https://github.com/openclaw/openclaw/pull/100910

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-006.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-006.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T135633-006
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#97285"
+cluster_refs:
+  - "#97285"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:56:33.125Z; bucket=needs_human; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 6
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #97285 fix(daemon): refuse duplicate launchd gateway managers
+
+- bucket: needs_human
+- author: harjothkhara
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: gateway, size: S, proof: sufficient, P2, rating: platinum hermit, merge-risk: compatibility, status: ready for maintainer look
+- live updated: 2026-07-04T20:20:32Z
+- live url: https://github.com/openclaw/openclaw/pull/97285

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-007.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-007.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T135633-007
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#85358"
+cluster_refs:
+  - "#85358"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:56:33.125Z; bucket=recent_active; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 7
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #85358 fix(#85334): prevent bundled plugin load paths from being injected into config
+
+- bucket: recent_active
+- author: samson1357924
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: commands, size: M, proof: supplied, P2
+- live updated: 2026-07-05T12:28:56Z
+- live url: https://github.com/openclaw/openclaw/pull/85358

--- a/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-008.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260706T135633-008.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260706T135633-008
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#98052"
+cluster_refs:
+  - "#98052"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-06T13:56:33.125Z; bucket=recent_active; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 8
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #98052 fix(runtime): throw ExitError from non-exiting runtime
+
+- bucket: recent_active
+- author: ly-wang19
+- author association: CONTRIBUTOR
+- draft: no
+- assignees: none
+- labels: size: XS, P3
+- live updated: 2026-07-04T18:44:43Z
+- live url: https://github.com/openclaw/openclaw/pull/98052


### PR DESCRIPTION
## Summary

- add one autonomous remediation job for each selected pull request:
  - https://github.com/openclaw/openclaw/pull/100904
  - https://github.com/openclaw/openclaw/pull/98821
  - https://github.com/openclaw/openclaw/pull/100900
  - https://github.com/openclaw/openclaw/pull/100902
  - https://github.com/openclaw/openclaw/pull/100910
  - https://github.com/openclaw/openclaw/pull/97285
  - https://github.com/openclaw/openclaw/pull/85358
  - https://github.com/openclaw/openclaw/pull/98052
- hydrate current GitHub metadata with a single PR per autonomous job
- stage queue inputs only; no jobs were dispatched and no pull requests were merged

## Validation

- `npm run render -- <generated-job> --mode autonomous` for all eight jobs
- `npm run worker -- <generated-job> --mode autonomous --dry-run` for all eight jobs
- focused frontmatter contract audit for all eight jobs
- `npm run validate` (6,643 jobs validated)
- `git diff --check`