### PR TITLE
fix(dispatch): reserve accepted worker capacity

### DIFF
--- a/scripts/dispatch-jobs.mjs
+++ b/scripts/dispatch-jobs.mjs
@@ -189,6 +189,7 @@ if (writeMode && maxLiveWorkers > writeLiveWorkerCap && !allowHighVolumeWrite) {
 }
 
 let failed = false;
+let capacityReservations = null;
 const jobs = [];
 const targetRepos = new Set();
 for (const file of files) {
@@ -240,6 +241,9 @@ if (!failed) {
       : jobsToDispatch.length;
   const capacityOptions = { repo, workflow: dispatchWorkflow, requested, maxLiveWorkers, ghCommand };
   const capacity = throttledDispatch ? waitForLiveWorkerCapacity(capacityOptions) : assertLiveWorkerCapacity(capacityOptions);
+  if (throttledDispatch && !repositoryBatchDispatch) {
+    capacityReservations = createCapacityReservations(capacity.active_runs);
+  }
   if (repositoryBatchDispatch && capacity.active > 0) {
     throw new Error(
       `refusing repository-batch dispatch: ${capacity.active} active ${batchWorkflow} run(s) already occupy unknown matrix capacity; retry after they finish`,
@@ -376,29 +380,24 @@ while (!failed && index < jobsToDispatch.length) {
     if (!skipPublishBacklogCheck) assertPublishBacklog();
     if (failed) break;
 
-    const capacity = waitForLiveWorkerCapacity({
-      repo,
-      workflow,
-      requested: 1,
-      maxLiveWorkers,
-      ghCommand,
-    });
-    const refreshed = liveWorkerCapacity({ repo, workflow, requested: 1, maxLiveWorkers, ghCommand });
+    const capacity = waitForReservedLiveWorkerCapacity(capacityReservations);
     batchSize = Math.min(
       batchSize,
-      Math.max(1, refreshed.available || capacity.available || 1),
+      capacity.available,
       dispatchBatchSize > 0 ? dispatchBatchSize : Number.POSITIVE_INFINITY,
     );
     console.log(
-      `live worker capacity: ${refreshed.active}/${refreshed.max_live_workers} active; dispatching next ${batchSize} run(s)`,
+      `live worker capacity: ${capacity.active}/${capacity.max_live_workers} active + ${capacity.reserved} reserved; dispatching next ${batchSize} run(s)`,
     );
   }
 
   const batch = jobsToDispatch.slice(index, index + batchSize);
   const results = await dispatchBatch(batch, dispatchConcurrency);
+  const acceptedResults = [];
   for (const result of results) {
     dispatched += 1;
     if (result.status === 0) {
+      acceptedResults.push(result);
       dispatchAttempts.push(dispatchAttempt(result, "accepted"));
       console.log(
         `dispatched ${result.position}/${jobsToDispatch.length} ${result.relative} (${mode}) on ${runner}; execution on ${executionRunner}`,
@@ -409,6 +408,7 @@ while (!failed && index < jobsToDispatch.length) {
       console.error(result.stderr || result.stdout || `failed to dispatch ${result.relative}`);
     }
   }
+  capacityReservations?.reserve(acceptedResults);
   if (writeDispatchLedger && dispatchAttempts.length > 0) appendDispatchLedger(dispatchAttempts);
   index += batchSize;
   if (throttledDispatch && !failed && index < jobsToDispatch.length) {
@@ -546,20 +546,23 @@ function dispatchBatch(batch, concurrency) {
 
 function dispatchJob(relative, position) {
   if (repositoryWorkerDispatch) return dispatchRepositoryWorker(relative, position);
+  const dispatchId = workflow === "cluster-worker.yml" ? workerDispatchId(position) : null;
   return runCommand(
     ghCommand,
-    workflowDispatchArgs(relative),
+    workflowDispatchArgs(relative, dispatchId),
     relative,
     position,
+    null,
+    dispatchId,
   );
 }
 
 function dispatchRepositoryWorker(relative, position) {
-  const workerDispatchId = `${dispatchBatchId}-${String(position).padStart(4, "0")}`;
+  const dispatchId = workerDispatchId(position);
   const payload = {
     event_type: workerEventType,
     client_payload: {
-      dispatch_id: workerDispatchId,
+      dispatch_id: dispatchId,
       job: relative,
       mode,
       runner,
@@ -582,7 +585,7 @@ function dispatchRepositoryWorker(relative, position) {
     relative,
     position,
     `${JSON.stringify(payload)}\n`,
-    workerDispatchId,
+    dispatchId,
   ).then((result) => {
     if (!isRepositoryDispatchSchemaBug(result)) return result;
 
@@ -591,17 +594,21 @@ function dispatchRepositoryWorker(relative, position) {
     );
     return runCommand(
       ghCommand,
-      workflowDispatchArgs(relative, workerDispatchId),
+      workflowDispatchArgs(relative, dispatchId),
       relative,
       position,
       null,
-      workerDispatchId,
+      dispatchId,
     ).then((fallback) => ({
       ...fallback,
       dispatch_event: "workflow",
       dispatch_fallback_reason: "repository_dispatch_422_links_schema",
     }));
   });
+}
+
+function workerDispatchId(position) {
+  return `${dispatchBatchId}-${String(position).padStart(4, "0")}`;
 }
 
 function workflowDispatchArgs(relative, dispatchId = null) {
@@ -817,6 +824,91 @@ function stripAnsi(text) {
 
 function sleepMs(milliseconds) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function createCapacityReservations(activeRuns = []) {
+  const observedRunIds = new Set(activeRuns.map(activeRunId).filter(Boolean));
+  const pendingDispatchIds = new Set();
+  let anonymousReservations = 0;
+
+  return {
+    reserve(results) {
+      for (const result of results) {
+        if (result.batch_dispatch_id) pendingDispatchIds.add(result.batch_dispatch_id);
+        else anonymousReservations += 1;
+      }
+    },
+    reconcile(activeRuns) {
+      const matchedRunIds = new Set();
+      for (const run of activeRuns) {
+        for (const dispatchId of pendingDispatchIds) {
+          if (String(run.displayTitle ?? "") !== `cluster worker ${dispatchId}`) continue;
+          pendingDispatchIds.delete(dispatchId);
+          const runId = activeRunId(run);
+          if (runId) matchedRunIds.add(runId);
+          break;
+        }
+      }
+
+      let newlyVisibleAnonymous = 0;
+      for (const run of activeRuns) {
+        const runId = activeRunId(run);
+        if (!runId || observedRunIds.has(runId)) continue;
+        observedRunIds.add(runId);
+        if (!matchedRunIds.has(runId)) newlyVisibleAnonymous += 1;
+      }
+      anonymousReservations = Math.max(0, anonymousReservations - newlyVisibleAnonymous);
+    },
+    get pending() {
+      return pendingDispatchIds.size + anonymousReservations;
+    },
+  };
+}
+
+function activeRunId(run) {
+  const value = run?.databaseId ?? run?.id ?? run?.url;
+  return value === undefined || value === null ? "" : String(value);
+}
+
+function waitForReservedLiveWorkerCapacity(reservations) {
+  if (!reservations) throw new Error("dispatch capacity reservations were not initialized");
+  const pollMs = positiveCapacitySetting(
+    process.env.CLOWNFISH_LIVE_WORKER_CAPACITY_POLL_MS ?? 30_000,
+    "capacity poll ms",
+  );
+  const timeoutMs = positiveCapacitySetting(
+    process.env.CLOWNFISH_LIVE_WORKER_CAPACITY_TIMEOUT_MS ?? 30 * 60 * 1000,
+    "capacity timeout ms",
+  );
+  const deadline = Date.now() + timeoutMs;
+  let latest = null;
+
+  while (Date.now() <= deadline) {
+    latest = liveWorkerCapacity({ repo, workflow, requested: 1, maxLiveWorkers, ghCommand });
+    reservations.reconcile(latest.active_runs);
+    const reserved = reservations.pending;
+    const available = Math.max(0, latest.max_live_workers - latest.active - reserved);
+    if (available > 0) {
+      return {
+        ...latest,
+        available,
+        reserved,
+      };
+    }
+    sleepMs(Math.min(pollMs, Math.max(1, deadline - Date.now())));
+  }
+
+  throw new Error(
+    `timed out waiting for ${workflow} capacity: ${latest?.active ?? "unknown"} active + ${reservations.pending} reserved + 1 requested exceeds max-live-workers=${maxLiveWorkers}`,
+  );
+}
+
+function positiveCapacitySetting(value, name) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return number;
 }
 
 if (failed) process.exit(1);

--- a/test/dispatch-jobs-capacity.test.mjs
+++ b/test/dispatch-jobs-capacity.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const job = "jobs/openclaw/inbox/cluster-example.md";
+
+test("throttled dispatch reserves accepted jobs while GitHub visibility lags", (t) => {
+  const fixture = runDispatch("lag");
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+
+  assert.equal(fixture.result.status, 0, fixture.result.stderr || fixture.result.stdout);
+  assertCapacitySequence(fixture.events, { laggedPolls: 2 });
+});
+
+test("throttled dispatch releases reservations when accepted jobs become visible", (t) => {
+  const fixture = runDispatch("normal");
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+
+  assert.equal(fixture.result.status, 0, fixture.result.stderr || fixture.result.stdout);
+  assertCapacitySequence(fixture.events, { laggedPolls: 0 });
+});
+
+test("throttled dispatch keeps a fitting batch in one wave", (t) => {
+  const fixture = runDispatch("normal", 5);
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+
+  assert.equal(fixture.result.status, 0, fixture.result.stderr || fixture.result.stdout);
+  const firstDispatchIndex = fixture.events.findIndex((event) => event.startsWith("dispatch:"));
+  assert.ok(firstDispatchIndex >= 0, fixture.events.join("\n"));
+  assert.equal(
+    fixture.events.slice(firstDispatchIndex).filter((event) => event.startsWith("poll:")).length,
+    0,
+    fixture.events.join("\n"),
+  );
+  assert.equal(fixture.events.filter((event) => event.startsWith("dispatch:")).length, 5);
+});
+
+function runDispatch(visibility, jobCount = 8) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-dispatch-capacity-"));
+  const fakeGh = path.join(root, "fake-ghx.mjs");
+  const eventsPath = path.join(root, "events.log");
+  const pollStatePath = path.join(root, "poll-state");
+  writeFakeGhx(fakeGh);
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "scripts/dispatch-jobs.mjs",
+      ...Array.from({ length: jobCount }, () => job),
+      "--mode",
+      "autonomous",
+      "--ref",
+      "HEAD",
+      "--gh-bin",
+      fakeGh,
+      "--skip-token-secret-check",
+      "--skip-publish-backlog-check",
+      "--no-dispatch-ledger",
+      "--wait-for-capacity",
+      "--max-live-workers",
+      "5",
+      "--write-live-worker-cap",
+      "5",
+      "--dispatch-concurrency",
+      "5",
+      "--batch-delay-ms",
+      "1",
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CLOWNFISH_LIVE_WORKER_CAPACITY_POLL_MS: "1",
+        CLOWNFISH_LIVE_WORKER_CAPACITY_TIMEOUT_MS: "5000",
+        FAKE_GHX_EVENTS: eventsPath,
+        FAKE_GHX_POLL_STATE: pollStatePath,
+        FAKE_GHX_VISIBILITY: visibility,
+      },
+    },
+  );
+
+  const events = fs.existsSync(eventsPath)
+    ? fs.readFileSync(eventsPath, "utf8").trim().split("\n").filter(Boolean)
+    : [];
+  return { root, result, events };
+}
+
+function assertCapacitySequence(events, { laggedPolls }) {
+  const dispatchIndexes = events
+    .map((event, index) => (event.startsWith("dispatch:") ? index : -1))
+    .filter((index) => index >= 0);
+  assert.equal(dispatchIndexes.length, 8, events.join("\n"));
+
+  const firstVisibleIndex = events.findIndex((event) => event.endsWith(":101,102,103,104,105"));
+  const freedCapacityIndex = events.findIndex((event) => event.endsWith(":104,105"));
+  assert.ok(firstVisibleIndex > dispatchIndexes[4], events.join("\n"));
+  assert.ok(freedCapacityIndex > firstVisibleIndex, events.join("\n"));
+  assert.ok(dispatchIndexes[5] > freedCapacityIndex, events.join("\n"));
+
+  const lagged = events
+    .slice(dispatchIndexes[4] + 1, firstVisibleIndex)
+    .filter((event) => /^poll:5:\d+:$/.test(event));
+  assert.equal(lagged.length, laggedPolls, events.join("\n"));
+}
+
+function writeFakeGhx(filePath) {
+  fs.writeFileSync(
+    filePath,
+    `#!/usr/bin/env node
+import fs from "node:fs";
+
+const args = process.argv.slice(2);
+const eventsPath = process.env.FAKE_GHX_EVENTS;
+const pollStatePath = process.env.FAKE_GHX_POLL_STATE;
+
+if (args.includes("--version")) {
+  console.log("fake-ghx 1.0");
+  process.exit(0);
+}
+
+if (args[0] === "workflow" && args[1] === "run") {
+  const dispatchId = args.find((arg) => arg.startsWith("dispatch_id="))?.slice(12) ?? "unknown";
+  fs.appendFileSync(eventsPath, \`dispatch:\${dispatchId}\\n\`);
+  process.exit(0);
+}
+
+if (args[0] === "api" && args.some((arg) => arg.endsWith("/runs"))) {
+  const status = args.find((arg) => arg.startsWith("status="))?.slice(7);
+  if (status !== "queued") {
+    console.log(JSON.stringify([{ workflow_runs: [] }]));
+    process.exit(0);
+  }
+
+  const events = fs.existsSync(eventsPath)
+    ? fs.readFileSync(eventsPath, "utf8").split("\\n").filter(Boolean)
+    : [];
+  const dispatchIds = events
+    .filter((event) => event.startsWith("dispatch:"))
+    .map((event) => event.slice(9));
+  const dispatchCount = dispatchIds.length;
+  let activeIds = [];
+  let phasePoll = -1;
+
+  if (dispatchCount === 5) {
+    phasePoll = fs.existsSync(pollStatePath) ? Number(fs.readFileSync(pollStatePath, "utf8")) : 0;
+    fs.writeFileSync(pollStatePath, String(phasePoll + 1));
+    if (process.env.FAKE_GHX_VISIBILITY === "lag") {
+      if (phasePoll >= 2) activeIds = phasePoll === 2 ? [101, 102, 103, 104, 105] : [104, 105];
+    } else {
+      activeIds = phasePoll === 0 ? [101, 102, 103, 104, 105] : [104, 105];
+    }
+  }
+
+  fs.appendFileSync(eventsPath, \`poll:\${dispatchCount}:\${phasePoll}:\${activeIds.join(",")}\\n\`);
+  console.log(JSON.stringify([{
+    workflow_runs: activeIds.map((id) => ({
+      id,
+      status: "queued",
+      created_at: "2026-07-06T00:00:00Z",
+      html_url: \`https://example.invalid/actions/runs/\${id}\`,
+      display_title: \`cluster worker \${dispatchIds[id - 101]}\`,
+    })),
+  }]));
+  process.exit(0);
+}
+
+console.error("unexpected fake ghx args: " + args.join(" "));
+process.exit(1);
+`,
+    { mode: 0o755 },
+  );
+}


### PR DESCRIPTION
## Summary

- reserve accepted dispatches from the current invocation until their exact `dispatch_id` appears in GitHub Actions
- calculate throttled capacity from visible active runs plus pending reservations, then release reservations as runs become visible and continue after real slots free
- preserve one-wave dispatch when the requested jobs already fit available capacity
- add deterministic fake-API coverage for propagation lag, normal visibility, and the single-wave path
- no real jobs were dispatched and no pull requests were merged

## Validation

- `node --test test/dispatch-jobs-capacity.test.mjs test/dispatch-jobs-publish-backlog.test.mjs test/app-token-auth.test.mjs` (20 tests passed)
- `npm run validate` (6,643 jobs validated)
- `node --check scripts/dispatch-jobs.mjs`
- `git diff --check`