### PR TITLE
fix(merge): refine external preflight guards

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -46,6 +46,7 @@ if (!sourceRefs.has(targetRef)) {
 fs.mkdirSync(runDir, { recursive: true });
 
 let pull = null;
+let issue = null;
 let view = null;
 let plan = null;
 let preflightJobPath = null;
@@ -63,7 +64,7 @@ let report = {
 
 try {
   pull = stage("hydrate GitHub state", () => ghJson(["api", `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}`]));
-  const issue = stage("hydrate issue state", () => ghJson(["api", `repos/${sourceJob.frontmatter.repo}/issues/${pullRequest}`]));
+  issue = stage("hydrate issue state", () => ghJson(["api", `repos/${sourceJob.frontmatter.repo}/issues/${pullRequest}`]));
   const issueComments = stage("hydrate issue comments", () =>
     fetchIssueComments({ repo: sourceJob.frontmatter.repo, pullRequest }),
   );
@@ -113,6 +114,50 @@ try {
     process.exit(0);
   }
 
+  const reviewedHeadSha = pull.head.sha;
+  const reviewedState = String(pull.state ?? "").toLowerCase();
+  const refreshedPull = stage("rehydrate GitHub state after review", () =>
+    ghJson(["api", `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}`]),
+  );
+  const refreshedIssue = stage("rehydrate issue state after review", () =>
+    ghJson(["api", `repos/${sourceJob.frontmatter.repo}/issues/${pullRequest}`]),
+  );
+  const refreshedIssueComments = stage("rehydrate issue comments after review", () =>
+    fetchIssueComments({ repo: sourceJob.frontmatter.repo, pullRequest }),
+  );
+  const refreshedView = stage("poll mergeability after review", () =>
+    fetchSettledPullRequestView({ repo: sourceJob.frontmatter.repo, pullRequest }),
+  );
+  const finalBlockers = stage("final read-only blockers", () => [
+    ...(refreshedPull.head?.sha !== reviewedHeadSha
+      ? [`PR head changed after validation: reviewed ${reviewedHeadSha}, current ${refreshedPull.head?.sha ?? "unknown"}`]
+      : []),
+    ...(String(refreshedPull.state ?? "").toLowerCase() !== reviewedState
+      ? [`PR state changed after validation: reviewed ${reviewedState || "unknown"}, current ${refreshedPull.state ?? "unknown"}`]
+      : []),
+    ...readOnlyBlockers({
+      sourceJob,
+      pull: refreshedPull,
+      view: refreshedView,
+      issueComments: refreshedIssueComments,
+      pullRequest,
+    }),
+  ]);
+  if (finalBlockers.length > 0) {
+    writeBlockedArtifacts({
+      reason: finalBlockers.join("; "),
+      validationCommands,
+      codexReview,
+      currentMainSha,
+    });
+    process.exit(0);
+  }
+
+  pull = refreshedPull;
+  issue = refreshedIssue;
+  view = refreshedView;
+  const finalBaseDriftAllowed = currentMainSha !== pull.base.sha && canTolerateBaseDrift(view);
+  const rehydratedAt = new Date().toISOString();
   const result = buildMergeResult({
     sourceJob,
     virtualJob,
@@ -123,15 +168,17 @@ try {
     validationCommands,
     codexReview,
     currentMainSha,
-    baseDriftAllowed,
+    baseDriftAllowed: finalBaseDriftAllowed,
   });
   report = {
     ...report,
     status: "passed",
+    reviewed_at: rehydratedAt,
+    rehydrated_at: rehydratedAt,
     reviewed_head_sha: pull.head.sha,
     reviewed_base_sha: pull.base.sha,
     current_main_sha: currentMainSha,
-    base_drift_allowed: baseDriftAllowed,
+    base_drift_allowed: finalBaseDriftAllowed,
     validation_commands: validationCommands,
     codex_review: {
       status: codexReview.status,
@@ -575,6 +622,7 @@ function buildMergeResult({ sourceJob, virtualJob, pull, issue, view, pullReques
       ? `PR base ${pull.base.sha} drifted from origin/main ${currentMainSha}; exact head remained mergeable with clean latest checks and validation ran against origin/main.`
       : `PR base ${pull.base.sha} matched current origin/main ${currentMainSha} before validation.`,
     `GitHub merge state ${view.mergeStateStatus} and review decision ${view.reviewDecision ?? "none"} were clean.`,
+    `Final GitHub recheck after validation and Codex review kept PR #${pullRequest} open at exact head ${pull.head.sha}.`,
   ];
   return {
     status: "planned",
@@ -609,14 +657,16 @@ function buildMergeResult({ sourceJob, virtualJob, pull, issue, view, pullReques
         target: `#${pullRequest}`,
         security_status: "cleared",
         security_evidence: [
-          "Fresh deterministic security scan found no matching signal in the PR title, body, labels, issue comments, reviews, or inline review comments.",
+          "Final deterministic security scan after validation and Codex review found no matching signal in the PR title, body, labels, issue comments, reviews, or inline review comments.",
         ],
         comments_status: "resolved",
         comments_evidence: [
-          "Fresh GitHub hydration found no actionable top-level or inline comments and no unresolved review threads.",
+          "Final GitHub hydration after validation and Codex review found no actionable top-level or inline comments and no unresolved review threads.",
         ],
         bot_comments_status: "resolved",
-        bot_comments_evidence: ["Fresh GitHub hydration found zero review-bot comments or review bodies requiring follow-up."],
+        bot_comments_evidence: [
+          "Final GitHub hydration after validation and Codex review found zero review-bot comments or review bodies requiring follow-up.",
+        ],
         codex_review: {
           command: "/review",
           status: codexReview.status === "clean" ? "clean" : "passed",
@@ -746,6 +796,11 @@ function isActionableCommentEvidence(
   const body = String(comment.body ?? "").trim();
   const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
 
+  if (isClawSweeperAuthor(author)) {
+    const currentReview = body.toLowerCase().split(/<details>/, 1)[0];
+    if (hasActionableClawSweeperReviewSignal(currentReview)) return true;
+    if (hasClawSweeperReadyReviewSignal(currentReview)) return true;
+  }
   if (isReviewBot({ author: { login: author }, body })) {
     return /found issues|requested changes|changes requested|needs changes?|needs human|do not merge|duplicate|superseded|security/i.test(
       body,
@@ -790,6 +845,9 @@ function isNonBlockingCommentEvidence(
   }
 
   const pullAuthor = String(pull?.user?.login ?? "").toLowerCase();
+  if (author && pullAuthor && author === pullAuthor && isAuthorProofOrStatusComment(body)) {
+    return true;
+  }
   if (
     author &&
     pullAuthor &&
@@ -820,6 +878,10 @@ function hasActionableApprovedReviewBody(body) {
 }
 
 function isBenignAutomationComment({ author, body, pull }) {
+  const currentReview = String(body).split(/<details>/, 1)[0];
+  if (isClawSweeperAuthor(author) && hasClawSweeperReadyReviewSignal(currentReview)) {
+    return isClawSweeperReadyReviewComment({ author, body, pull });
+  }
   if (isStaleAutomationReviewComment({ author, body, pull })) return true;
   if (!isAutomationAuthor(author)) return false;
   if (isDependencyGuardAutomationComment({ body, pull })) return true;
@@ -882,22 +944,43 @@ function isMaintainerApprovalComment({ association, body }) {
 }
 
 function isClawSweeperReadyReviewComment({ author, body, pull }) {
-  if (!["clawsweeper", "clawsweeper[bot]"].includes(author)) return false;
-  if (!hasAutonomousMergeReadySignal(pull)) return false;
-  if (!/^codex review:\s*needs maintainer review before merge\./.test(body)) return false;
-  if (!/(review metrics:\*\*\s*none identified|review metrics:\s*none identified|result:\s*ready for maintainer review|no repair job is needed)/.test(body)) {
-    return false;
-  }
-  return !/found issues before merge|requested changes|changes requested/.test(body);
+  if (!isClawSweeperAuthor(author)) return false;
+  const normalized = String(body ?? "").trim().toLowerCase();
+  const hasExactMarker = hasExactHeadClawSweeperReadyMarker({ body: normalized, pull });
+  if (!hasExactMarker) return false;
+
+  const currentReview = normalized.split(/<details>/, 1)[0];
+  return !hasActionableClawSweeperReviewSignal(currentReview) && hasClawSweeperReadyReviewSignal(currentReview);
 }
 
-function hasAutonomousMergeReadySignal(pull) {
-  const labels = (pull?.labels ?? []).map((label) => String(label?.name ?? "").toLowerCase());
-  if (labels.includes("clownfish:automerge")) return true;
-  const readyForMaintainer = labels.some((label) => label.includes("ready for maintainer look"));
-  if (!readyForMaintainer) return false;
-  if (labels.includes("proof: sufficient")) return true;
-  return labels.includes("docs") && labels.some((label) => label.includes("low-signal-docs"));
+function hasClawSweeperReadyReviewSignal(body) {
+  return (
+    /^codex review:\s*needs maintainer review before merge\./.test(body) &&
+    /result:\s*ready for maintainer review\./.test(body) &&
+    /(review metrics:\*\*\s*none identified|review metrics:\s*none identified|no (?:clawsweeper |automated )?repair(?: job)? is needed|no concrete contributor-facing blocker left|remaining action is normal maintainer review)/.test(
+      body,
+    )
+  );
+}
+
+function isClawSweeperAuthor(author) {
+  return ["clawsweeper", "clawsweeper[bot]"].includes(author);
+}
+
+function hasActionableClawSweeperReviewSignal(body) {
+  const firstLine = String(body).split(/\r?\n/, 1)[0].trim();
+  if (
+    firstLine !== "codex review: needs maintainer review before merge." &&
+    /\b(?:needs?|requires?|blocked|changes?)\b.*\bbefore merge\./.test(firstLine)
+  ) {
+    return true;
+  }
+  return [
+    /\*\*merge readiness\*\*[\s\S]{0,1200}\bresult:\s*blocked until\b/,
+    /\*\*proof guidance\*\*[\s\S]{0,1600}\b(?:needs?|requires?) (?:stronger )?real behavior proof before merge\b/,
+    /\*\*risk before merge\*\*[\s\S]{0,1600}\b(?:blocker|must|needs?|required|missing)\b/,
+    /\*\*next step before merge\*\*[\s\S]{0,1200}\bremaining (?:merge )?blocker\b/,
+  ].some((pattern) => pattern.test(body));
 }
 
 function findHighRiskMergeLabel(labels) {
@@ -940,7 +1023,10 @@ function isCommentCoveredByTrustedApproval(comment, trustedAuthorEvidenceApprova
 function isTrustedExactHeadReadyReviewComment(comment, { pull }) {
   const body = String(comment.body ?? "").trim();
   const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
-  if (!isClawSweeperReadyReviewComment({ author, body: body.toLowerCase(), pull })) return false;
+  return isClawSweeperReadyReviewComment({ author, body, pull });
+}
+
+function hasExactHeadClawSweeperReadyMarker({ body, pull }) {
   if (/<!--\s*clawsweeper-action:/i.test(body)) return false;
 
   const verdictOpeners = body.match(/<!--\s*clawsweeper-verdict:/gi) ?? [];
@@ -950,13 +1036,21 @@ function isTrustedExactHeadReadyReviewComment(comment, { pull }) {
 
   const attributes = parseMarkerAttributes(verdicts[0][2]);
   if (!attributes) return false;
+  const reviewOpeners = body.match(/<!--\s*clawsweeper-review(?=\s)/gi) ?? [];
+  if (reviewOpeners.length !== 1) return false;
+  const reviews = [...body.matchAll(/<!--\s*clawsweeper-review\s+([^>]*)-->/gi)];
+  if (reviews.length !== 1) return false;
+  const reviewAttributes = parseMarkerAttributes(reviews[0][1]);
+  if (!reviewAttributes) return false;
+
   const headSha = String(pull?.head?.sha ?? "").toLowerCase();
   const pullNumber = String(pull?.number ?? "");
   return (
     /^[0-9a-f]{40}$/.test(headSha) &&
     attributes.sha?.toLowerCase() === headSha &&
     attributes.item === pullNumber &&
-    attributes.confidence === "high"
+    attributes.confidence === "high" &&
+    reviewAttributes.item === pullNumber
   );
 }
 
@@ -982,6 +1076,40 @@ function isAuthorProgressEvidenceComment(body) {
     .map((line) => line.trim())
     .filter(Boolean);
   return lines.length > 0 && lines.every(isSafeAuthorProgressLine);
+}
+
+function isAuthorProofOrStatusComment(body) {
+  const normalized = String(body ?? "").trim().toLowerCase();
+  if (!normalized || isAuthorObjectionComment(normalized)) return false;
+
+  const lines = normalized
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return false;
+  if (lines.every(isSafeAuthorProgressLine)) return true;
+
+  const contentLines = lines.map((line) => line.replace(/^[-*]\s+/, "").replace(/^#{1,6}\s*/, ""));
+  const hasStatusLead = contentLines.some((line) =>
+    [
+      /^(?:rebas(?:ed|ing)|re-ran|reran|ran|verified|validated|updated|added|addressed|resolved|fixed|tested)\b/,
+      /^(?:this|the (?:change|patch|pr))\s+(?:fixes|adds|updates|preserves|addresses)\b/,
+    ].some((pattern) => pattern.test(line)),
+  );
+  const hasProofHeading = contentLines.some((line) =>
+    /^(?:proof|validation|verification|test results|current status|status):?$/.test(line),
+  );
+  const hasEvidenceDetail = lines.some(
+    (line) =>
+      /^[-*]\s+/.test(line) &&
+      /`[^`]+`|\b(?:passed|passing|green|clean|no failures|confirms?|shows?|proof)\b/.test(line),
+  );
+  const hasProofSignal =
+    /\b(?:proof|validation|verification|tests?|checks?|ci\/status|repro(?:duction|ducible)?|autoreview)\b/.test(
+      normalized,
+    );
+
+  return (hasProofHeading && hasEvidenceDetail) || (hasStatusLead && (hasEvidenceDetail || hasProofSignal));
 }
 
 function isSafeAuthorProgressLine(line) {
@@ -1024,6 +1152,7 @@ function isAuthorObjectionComment(body) {
     /\b(?:not|isn't|aren't)\s+(?:ready|complete|fixed|resolved)\b/,
     /\b(?:incomplete|unfinished|still investigating|need more time|one more thought|worried|concerns?|unclear)\b/,
     /\b(?:haven't|hasn't|nothing was)\s+fixed\b/,
+    /\b(?:tests?|checks?|ci)\b.{0,40}\b(?:are |is )?(?:still )?(?:failing|failed|red|broken)\b/,
     /\b(?:rather|prefer)\b.{0,40}\bnot (?:merge|land|ship)\b/,
     /\b(?:withdraw|withdrawn|abandon|abandoned|cancel|cancelled|superseded|obsolete)\b/,
     /\b(?:close|stop)\s+(?:this|the)\s+(?:pr|pull request)\b/,

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -136,6 +136,86 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
   assert.equal(reviewed.status, 0, reviewed.stderr || reviewed.stdout);
 });
 
+test("external merge preflight accepts #100910 assignee and harmless label drift after final recheck", () => {
+  const fixture = makeFixture({
+    issueUpdatedAt: "2026-07-06T13:38:20Z",
+    pullUpdatedAt: "2026-07-06T13:38:20Z",
+    rehydratedIssueUpdatedAt: "2026-07-06T14:11:07Z",
+    rehydratedPullUpdatedAt: "2026-07-06T14:11:07Z",
+    rehydratedPullAssignees: [{ login: "maintainer" }],
+    rehydratedPullLabels: [{ name: "P2" }],
+  });
+  const { report, result } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "passed", report.reason);
+  assert.equal(result.actions[0].expected_head_sha, fixture.headSha);
+  assert.equal(result.actions[0].target_updated_at, "2026-07-06T14:11:07Z");
+  assert.match(result.actions[0].evidence.join("\n"), /Final GitHub recheck after validation and Codex review/);
+});
+
+for (const drift of [
+  {
+    name: "head",
+    options: { rehydratedHeadSha: "c".repeat(40) },
+    reason: /PR head changed after validation/,
+  },
+  {
+    name: "state",
+    options: { rehydratedState: "closed" },
+    reason: /PR state changed after validation/,
+  },
+]) {
+  test(`external merge preflight blocks real ${drift.name} drift during final recheck`, () => {
+    const { report } = runPreflightFixture(makeFixture(drift.options));
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, drift.reason);
+  });
+}
+
+for (const guardedDrift of [
+  {
+    name: "security",
+    options: { rehydratedPullLabels: [{ name: "merge-risk: security-boundary" }] },
+    reason: /security-sensitive signal|blocked live label/,
+  },
+  {
+    name: "review",
+    options: { mergeViews: [{}, { reviewDecision: "CHANGES_REQUESTED" }] },
+    reason: /review decision is CHANGES_REQUESTED/,
+  },
+  {
+    name: "checks",
+    options: {
+      mergeViews: [
+        {},
+        {
+          statusCheckRollup: [
+            {
+              name: "CI",
+              workflowName: "CI",
+              status: "COMPLETED",
+              conclusion: "FAILURE",
+              completedAt: "2026-07-06T14:11:07Z",
+            },
+          ],
+        },
+      ],
+    },
+    reason: /non-passing checks: CI/,
+  },
+  {
+    name: "mergeability",
+    options: { mergeViews: [{}, { mergeable: "CONFLICTING", mergeStateStatus: "DIRTY" }] },
+    reason: /mergeability is CONFLICTING|merge state is DIRTY/,
+  },
+]) {
+  test(`external merge preflight blocks ${guardedDrift.name} drift during final recheck`, () => {
+    const { report } = runPreflightFixture(makeFixture(guardedDrift.options));
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, guardedDrift.reason);
+  });
+}
+
 test("external merge preflight tolerates base drift when exact head remains clean", () => {
   const fixture = makeFixture({ currentMainSha: "c".repeat(40) });
   const child = spawnSync(
@@ -359,6 +439,140 @@ test("external merge preflight tolerates ready ClawSweeper docs reviews without 
   const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
   assert.equal(report.status, "passed");
 });
+
+test("external merge preflight ignores #98052 pull-author proof updates", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "ly-wang19" },
+    issueComments: [
+      {
+        author: { login: "ly-wang19" },
+        authorAssociation: "CONTRIBUTOR",
+        body: [
+          "Rebased this PR onto current `origin/main` and re-ran focused proof on the pushed head `aaaaaaaa`.",
+          "",
+          "Proof:",
+          "- `node scripts/run-vitest.mjs src/runtime.test.ts` - passed",
+          "- `rg -n 'createNonExitingRuntime|ExitError|RuntimeExit' src/runtime.ts src/plugin-sdk src/runtime.test.ts` - confirms the typed exit is limited to the non-exiting runtime helper/test surface",
+          "- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean, no accepted/actionable findings",
+          "- GitHub checks on `aaaaaaaa` - no failures; CI/status rollup is green aside from skipped/neutral jobs",
+          "",
+          "The change preserves the existing `Error` message text while adding `ExitError` so callers can distinguish simulated exits without string matching.",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/98052#issuecomment-4881919898",
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+  assert.equal(report.status, "passed", report.reason);
+});
+
+test("external merge preflight ignores #98821 exact-head ClawSweeper ready verdict without synchronized labels", () => {
+  const fixture = makeFixture({
+    pullLabels: [{ name: "gateway" }, { name: "size: S" }, { name: "P2" }],
+    issueComments: [
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: [
+          "Codex review: needs maintainer review before merge.",
+          "",
+          "**Summary**",
+          "The PR adds process-local, tool-qualified warning deduplication plus focused regression tests.",
+          "",
+          "**Review metrics:** 1 noteworthy metric.",
+          "- **Warning branches deduped:** 3 warning branches routed through 1 helper.",
+          "",
+          "**Stored data model**",
+          "Persistent data-model change detected. Confirm migration or upgrade compatibility proof before merge.",
+          "",
+          "**Merge readiness**",
+          "Result: ready for maintainer review.",
+          "",
+          "**Next step before merge**",
+          "- No ClawSweeper repair is needed because the patch has no blocking code finding and sufficient contributor proof; the remaining action is normal maintainer review.",
+          "",
+          "<details>",
+          "<summary>Review history (2 earlier review cycles)</summary>",
+          "",
+          "<!-- clawsweeper-review-history v=1 total=2 -->",
+          "- reviewed 2026-07-04T02:20:55Z :: needs real behavior proof before merge.",
+          "</details>",
+          "",
+          `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high updated_at=2026-07-04T20:18:20Z -->`,
+          "",
+          "<!-- clawsweeper-review item=123 -->",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/98821#issuecomment-4861354589",
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+  assert.equal(report.status, "passed", report.reason);
+});
+
+for (const liveShape of [
+  {
+    number: 100900,
+    url: "https://github.com/openclaw/openclaw/pull/100900#issuecomment-4893455348",
+    body: [
+      "Codex review: needs real behavior proof before merge.",
+      "",
+      "**Merge readiness**",
+      "Result: blocked until stronger real behavior proof is added.",
+      "",
+      "**Proof guidance**",
+      "- [P1] Needs stronger real behavior proof before merge: add redacted after-fix Docker or gateway output.",
+      "",
+      "**Risk before merge**",
+      "- [P1] The remaining merge blocker is proof quality.",
+      "",
+      "**Next step before merge**",
+      "- [P1] The remaining action is contributor-supplied after-fix real behavior proof before maintainer merge review.",
+    ],
+  },
+  {
+    number: 100902,
+    url: "https://github.com/openclaw/openclaw/pull/100902#issuecomment-4893494572",
+    body: [
+      "Codex review: needs real behavior proof before merge.",
+      "",
+      "**Merge readiness**",
+      "Result: blocked until real behavior proof from a real setup is added.",
+      "",
+      "**Proof guidance**",
+      "- [P1] Needs real behavior proof before merge: add a redacted patched-branch Docker or CLI transcript.",
+      "",
+      "**Risk before merge**",
+      "- [P1] After-fix real behavior proof is still missing.",
+      "",
+      "**Next step before merge**",
+      "- [P1] The remaining merge blocker is contributor-supplied after-fix real behavior proof.",
+    ],
+  },
+]) {
+  test(`external merge preflight keeps #${liveShape.number} ClawSweeper proof requirements blocking`, () => {
+    const fixture = makeFixture({
+      pullLabels: [{ name: "status: needs proof" }],
+      issueComments: [
+        {
+          author: { login: "clawsweeper[bot]" },
+          authorAssociation: "CONTRIBUTOR",
+          body: [
+            ...liveShape.body,
+            "",
+            `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+            "",
+            "<!-- clawsweeper-review item=123 -->",
+          ].join("\n"),
+          url: liveShape.url,
+        },
+      ],
+    });
+    const { report } = runPreflightFixture(fixture);
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, /actionable top-level issue comment/);
+  });
+}
 
 test("external merge preflight ignores resolved review-refresh noise covered by an exact-head ready review", () => {
   const fixture = makeFixture({
@@ -653,7 +867,7 @@ test("external merge preflight still blocks author-reported current concerns", (
       {
         author: { login: "contributor" },
         authorAssociation: "CONTRIBUTOR",
-        body: "Do not merge yet; the latest head still has a failing regression test.",
+        body: "Tests are still failing after the rebase.",
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
       },
     ],
@@ -804,7 +1018,7 @@ test("external merge preflight blocks author prose without a trusted exact-head 
   }
 });
 
-test("external merge preflight blocks author progress newer than the exact-head ready review", () => {
+test("external merge preflight ignores objection-free author proof updates newer than the exact-head ready review", () => {
   const fixture = makeFixture({
     pullUser: { login: "contributor" },
     pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
@@ -849,8 +1063,7 @@ test("external merge preflight blocks author progress newer than the exact-head 
   assert.equal(child.status, 0, child.stderr || child.stdout);
 
   const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
-  assert.equal(report.status, "blocked");
-  assert.match(report.reason, /actionable top-level issue comment/);
+  assert.equal(report.status, "passed", report.reason);
 });
 
 test("external merge preflight never lets a ready review suppress an author security concern", () => {
@@ -1764,6 +1977,27 @@ test("external merge preflight blocks merge-risk labels", () => {
   assert.match(report.reason, /blocked live label: merge-risk: availability/);
 });
 
+function runPreflightFixture(fixture) {
+  const child = spawnSync(
+    process.execPath,
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  return {
+    report: JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8")),
+    result: JSON.parse(fs.readFileSync(path.join(fixture.runDir, "result.json"), "utf8")),
+  };
+}
+
 function makeFixture({
   issueComments = [],
   reviewComments = [],
@@ -1775,6 +2009,16 @@ function makeFixture({
   mergeViews = null,
   issueUpdatedAt = "2026-06-19T00:00:00Z",
   pullUpdatedAt = "2026-06-19T00:00:00Z",
+  pullAssignees = [],
+  rehydratedIssueComments = null,
+  rehydratedReviewComments = null,
+  rehydratedReviewThreads = null,
+  rehydratedPullLabels = null,
+  rehydratedIssueUpdatedAt = null,
+  rehydratedPullUpdatedAt = null,
+  rehydratedPullAssignees = null,
+  rehydratedHeadSha = null,
+  rehydratedState = null,
   currentMainSha = null,
   codexReview = {
     status: "clean",
@@ -1790,6 +2034,15 @@ function makeFixture({
   const jobPath = path.join(root, "source-job.md");
   const headSha = "a".repeat(40);
   const baseSha = "b".repeat(40);
+  const finalIssueComments = rehydratedIssueComments ?? issueComments;
+  const finalReviewComments = rehydratedReviewComments ?? reviewComments;
+  const finalReviewThreads = rehydratedReviewThreads ?? [];
+  const finalPullLabels = rehydratedPullLabels ?? pullLabels;
+  const finalIssueUpdatedAt = rehydratedIssueUpdatedAt ?? issueUpdatedAt;
+  const finalPullUpdatedAt = rehydratedPullUpdatedAt ?? pullUpdatedAt;
+  const finalPullAssignees = rehydratedPullAssignees ?? pullAssignees;
+  const finalHeadSha = rehydratedHeadSha ?? headSha;
+  const finalState = rehydratedState ?? "open";
   fs.mkdirSync(binDir, { recursive: true });
   fs.writeFileSync(
     jobPath,
@@ -1830,6 +2083,12 @@ const args = process.argv.slice(2);
 const head = ${JSON.stringify(headSha)};
 const base = ${JSON.stringify(baseSha)};
 const mergeViews = ${JSON.stringify(mergeViews)};
+function nextValue(name, initial, refreshed) {
+  const counterPath = path.join(${JSON.stringify(root)}, name);
+  const count = fs.existsSync(counterPath) ? Number(fs.readFileSync(counterPath, "utf8")) : 0;
+  fs.writeFileSync(counterPath, String(count + 1));
+  return count === 0 ? initial : refreshed;
+}
 if (args[0] === "repo" && args[1] === "clone") {
   const target = args[3];
   fs.mkdirSync(path.join(target, ".git"), { recursive: true });
@@ -1841,20 +2100,22 @@ if (args[0] === "pr" && args[1] === "view") {
   const count = fs.existsSync(counterPath) ? Number(fs.readFileSync(counterPath, "utf8")) : 0;
   fs.writeFileSync(counterPath, String(count + 1));
   const mergeView = Array.isArray(mergeViews) ? mergeViews[Math.min(count, mergeViews.length - 1)] : {};
-  console.log(JSON.stringify({ comments: ${JSON.stringify(issueComments)}, headRefOid: head, isDraft: false, mergeStateStatus: mergeView.mergeStateStatus ?? ${JSON.stringify(mergeStateStatus)}, mergeable: mergeView.mergeable ?? "MERGEABLE", reviewDecision: "APPROVED", reviews: ${JSON.stringify(reviews)}, statusCheckRollup: ${JSON.stringify(statusCheckRollup)}, updatedAt: "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" }));
+  console.log(JSON.stringify({ comments: mergeView.comments ?? ${JSON.stringify(issueComments)}, headRefOid: mergeView.headRefOid ?? head, isDraft: false, mergeStateStatus: mergeView.mergeStateStatus ?? ${JSON.stringify(mergeStateStatus)}, mergeable: mergeView.mergeable ?? "MERGEABLE", reviewDecision: mergeView.reviewDecision ?? "APPROVED", reviews: mergeView.reviews ?? ${JSON.stringify(reviews)}, statusCheckRollup: mergeView.statusCheckRollup ?? ${JSON.stringify(statusCheckRollup)}, updatedAt: mergeView.updatedAt ?? "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" }));
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {
   const query = args.find((value) => value.startsWith("query=")) || "";
   if (query.includes("comments(first: 100)")) {
-    console.log(JSON.stringify({ data: { repository: { pullRequest: { comments: { nodes: ${JSON.stringify(issueComments)} } } } } }));
+    const comments = nextValue("issue-comments-count", ${JSON.stringify(issueComments)}, ${JSON.stringify(finalIssueComments)});
+    console.log(JSON.stringify({ data: { repository: { pullRequest: { comments: { nodes: comments } } } } }));
     process.exit(0);
   }
-  console.log(JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { pageInfo: { hasNextPage: false }, nodes: [] } } } } }));
+  const threads = nextValue("review-threads-count", [], ${JSON.stringify(finalReviewThreads)});
+  console.log(JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { pageInfo: { hasNextPage: false }, nodes: threads } } } } }));
   process.exit(0);
 }
 if (args[0] === "api" && args[1].includes("/pulls/123/comments")) {
-  console.log(${JSON.stringify(JSON.stringify(reviewComments))});
+  console.log(JSON.stringify(nextValue("review-comments-count", ${JSON.stringify(reviewComments)}, ${JSON.stringify(finalReviewComments)})));
   process.exit(0);
 }
 if (args[0] === "api" && args[1].includes("/issues/123/comments")) {
@@ -1862,11 +2123,21 @@ if (args[0] === "api" && args[1].includes("/issues/123/comments")) {
   process.exit(0);
 }
 if (args[0] === "api" && args[1].endsWith("/issues/123")) {
-  console.log(JSON.stringify({ state: "open", draft: false, title: "fix: fixture", body: "", html_url: "https://github.com/openclaw/openclaw/pull/123", updated_at: ${JSON.stringify(issueUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/123" } }));
+  const issue = nextValue(
+    "issue-state-count",
+    { state: "open", updated_at: ${JSON.stringify(issueUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, assignees: ${JSON.stringify(pullAssignees)} },
+    { state: ${JSON.stringify(finalState)}, updated_at: ${JSON.stringify(finalIssueUpdatedAt)}, labels: ${JSON.stringify(finalPullLabels)}, assignees: ${JSON.stringify(finalPullAssignees)} },
+  );
+  console.log(JSON.stringify({ ...issue, draft: false, title: "fix: fixture", body: "", html_url: "https://github.com/openclaw/openclaw/pull/123", pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/123" } }));
   process.exit(0);
 }
 if (args[0] === "api" && args[1].endsWith("/pulls/123")) {
-  console.log(JSON.stringify({ number: 123, state: "open", draft: false, title: "fix: fixture", body: "", html_url: "https://github.com/openclaw/openclaw/pull/123", updated_at: ${JSON.stringify(pullUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, user: ${JSON.stringify(pullUser)}, head: { sha: head, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: base, ref: "main" } }));
+  const pull = nextValue(
+    "pull-state-count",
+    { state: "open", updated_at: ${JSON.stringify(pullUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, assignees: ${JSON.stringify(pullAssignees)}, headSha: head },
+    { state: ${JSON.stringify(finalState)}, updated_at: ${JSON.stringify(finalPullUpdatedAt)}, labels: ${JSON.stringify(finalPullLabels)}, assignees: ${JSON.stringify(finalPullAssignees)}, headSha: ${JSON.stringify(finalHeadSha)} },
+  );
+  console.log(JSON.stringify({ number: 123, ...pull, draft: false, title: "fix: fixture", body: "", html_url: "https://github.com/openclaw/openclaw/pull/123", user: ${JSON.stringify(pullUser)}, head: { sha: pull.headSha, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: base, ref: "main" } }));
   process.exit(0);
 }
 process.stderr.write("unexpected gh command: " + args.join(" "));


### PR DESCRIPTION
## Summary

- classify pull-author proof/status updates as non-blocking unless they contain an explicit objection, failing proof, or security concern
- classify exact-head ClawSweeper durable ready/no-blocker verdicts as non-blocking while preserving needs-proof and actionable-risk blockers
- rehydrate pull state, issue metadata, comments, reviews, checks, threads, and mergeability after validation and Codex review before emitting the guarded merge artifact
- bind the artifact to the refreshed `updated_at`, allowing assignee or harmless label drift observed during preflight while still blocking head, state, security, review, check, and mergeability drift

## Root Cause

The preflight treated essentially every unmatched top-level comment as actionable, including contributor proof updates and ClawSweeper ready verdicts. It also emitted the initial hydration timestamp after long validation/review work, so metadata-only changes during that window caused the applicator to reject an otherwise unchanged exact head.

Live regressions cover:

- https://github.com/openclaw/openclaw/pull/98052#issuecomment-4881919898
- https://github.com/openclaw/openclaw/pull/98821#issuecomment-4861354589
- https://github.com/openclaw/openclaw/pull/100900#issuecomment-4893455348
- https://github.com/openclaw/openclaw/pull/100902#issuecomment-4893494572
- https://github.com/openclaw/openclaw/pull/100910

## Validation

- `node --test test/preflight-external-pr-merge.test.mjs` (52 passed)
- `npm run validate` (6,643 jobs validated)
- `node --check scripts/preflight-external-pr-merge.mjs`
- `git diff --check`