### PR TITLE
fix(preflight): preserve validation failure tails

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -11,6 +11,8 @@ const IGNORED_CHECKS = new Set(["auto-response", "Labeler", "Stale"]);
 const REVIEW_BOT_PATTERN = /\b(?:greptile|codex|asile|coderabbit|copilot)\b/i;
 const INSTALL_TIMEOUT_MS = positiveInteger(process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_INSTALL_TIMEOUT_MS, 10 * 60 * 1000);
 const VALIDATION_TIMEOUT_MS = positiveInteger(process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_VALIDATION_TIMEOUT_MS, 20 * 60 * 1000);
+const FAILURE_REASON_MAX_CHARS = 4000;
+const FAILURE_STREAM_MAX_CHARS = 1800;
 
 const args = parseArgs(process.argv.slice(2));
 const sourceJobPath = args._[0];
@@ -1339,10 +1341,52 @@ function run(command, commandArgs, options = {}) {
     timeout: options.timeout,
     maxBuffer: options.maxBuffer,
   });
-  if (child.error?.code === "ETIMEDOUT") throw new Error(`${command} ${commandArgs.join(" ")} timed out`);
-  if (child.error) throw child.error;
-  if (child.status !== 0) throw new Error((child.stderr || child.stdout || `${command} exited ${child.status}`).trim());
+  if (child.error?.code === "ETIMEDOUT") {
+    const timeout = options.timeout ? `${options.timeout}ms` : "the configured deadline";
+    throw new Error(
+      formatCommandFailure(command, commandArgs, child, `timed out after ${timeout}`),
+    );
+  }
+  if (child.error) {
+    throw new Error(formatCommandFailure(command, commandArgs, child, `failed to start: ${child.error.message}`));
+  }
+  if (child.signal) {
+    throw new Error(formatCommandFailure(command, commandArgs, child, `terminated by ${child.signal}`));
+  }
+  if (child.status !== 0) {
+    throw new Error(formatCommandFailure(command, commandArgs, child, `failed with exit ${child.status}`));
+  }
   return child.stdout ?? "";
+}
+
+function formatCommandFailure(command, commandArgs, child, outcome) {
+  const sections = [`command ${outcome}: ${renderCommand(command, commandArgs)}`];
+  for (const [label, value] of [
+    ["stderr", child.stderr],
+    ["stdout", child.stdout],
+  ]) {
+    const stream = redactSecrets(stripAnsi(value)).trim();
+    if (stream) sections.push(`${label}:\n${boundDiagnostic(stream, FAILURE_STREAM_MAX_CHARS)}`);
+  }
+  return boundDiagnostic(redactSecrets(sections.join("\n")), FAILURE_REASON_MAX_CHARS);
+}
+
+function renderCommand(command, commandArgs) {
+  return [command, ...commandArgs]
+    .map((part) => {
+      const value = String(part);
+      return /^[A-Za-z0-9_./:@%+=,-]+$/.test(value) ? value : JSON.stringify(value);
+    })
+    .join(" ");
+}
+
+function boundDiagnostic(value, maxChars) {
+  const text = String(value ?? "");
+  if (text.length <= maxChars) return text;
+  const marker = "\n... [truncated; showing head and tail] ...\n";
+  const contentChars = maxChars - marker.length;
+  const headChars = Math.min(400, Math.floor(contentChars / 4));
+  return `${text.slice(0, headChars)}${marker}${text.slice(-(contentChars - headChars))}`;
 }
 
 function stage(name, fn) {
@@ -1366,11 +1410,41 @@ function normalizeState(value) {
 }
 
 function redact(value) {
-  let redacted = value;
-  for (const secret of [process.env.GH_TOKEN, process.env.GITHUB_TOKEN, process.env.CLOWNFISH_READ_GH_TOKEN]) {
+  return boundDiagnostic(redactSecrets(stripAnsi(value)), FAILURE_REASON_MAX_CHARS);
+}
+
+function redactSecrets(value) {
+  let redacted = String(value ?? "")
+    .replace(
+      /\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,})\b/g,
+      "[redacted]",
+    )
+    .replace(
+      /\b(authorization)\b(\s*:\s*)(bearer\s+)?([^\s]+)/gi,
+      "$1$2$3[redacted]",
+    )
+    .replace(
+      /\b(bearer)\b(\s+)([^\s]+)/gi,
+      "$1$2[redacted]",
+    )
+    .replace(
+      /\b(token|api[_-]?key|password|secret)\b(\s*[:=]\s*)([^\s]+)/gi,
+      "$1$2[redacted]",
+    );
+  const secrets = new Set(
+    Object.entries(process.env)
+      .filter(([key, secret]) => secret && /(token|secret|password|api[_-]?key|private[_-]?key)/i.test(key))
+      .map(([, secret]) => secret)
+      .filter((secret) => secret.length >= 4),
+  );
+  for (const secret of [...secrets].sort((left, right) => right.length - left.length)) {
     if (secret) redacted = redacted.replaceAll(secret, "[redacted]");
   }
-  return redacted.slice(0, 1200);
+  return redacted;
+}
+
+function stripAnsi(value) {
+  return String(value ?? "").replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "");
 }
 
 function writeJson(filePath, value) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -136,6 +136,46 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
   assert.equal(reviewed.status, 0, reviewed.stderr || reviewed.stdout);
 });
 
+test("external merge preflight preserves the decisive tail of long validation stdout", () => {
+  const fixture = makeFixture({
+    validationFailure: {
+      stdout: [
+        "$ node scripts/check-changed.mjs",
+        "[check:changed] lanes=core, coreTests, extensions, extensionTests",
+        "x".repeat(5000),
+        "src/plugins/memory-state.ts(42,7): error TS2322: decisive stdout tail",
+      ].join("\n"),
+    },
+  });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /^command failed with exit 1: pnpm check:changed/);
+  assert.match(report.reason, /stdout:\n\$ node scripts\/check-changed\.mjs/);
+  assert.match(report.reason, /\[truncated; showing head and tail\]/);
+  assert.match(report.reason, /error TS2322: decisive stdout tail$/);
+  assert.ok(report.reason.length <= 4000, `reason was ${report.reason.length} chars`);
+});
+
+test("external merge preflight reports both output tails without leaking secrets", () => {
+  const secret = `github_pat_${"s".repeat(32)}`;
+  const fixture = makeFixture({
+    validationFailure: {
+      stdout: `stdout prefix token=${secret}\n${"o".repeat(5000)}\ndecisive stdout tail`,
+      stderr: `stderr prefix Authorization: Bearer ${secret}\n${"e".repeat(5000)}\ndecisive stderr tail`,
+    },
+  });
+  const { report } = runPreflightFixture(fixture, { GH_TOKEN: secret });
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /stderr:\nstderr prefix Authorization: Bearer \[redacted\]/);
+  assert.match(report.reason, /decisive stderr tail/);
+  assert.match(report.reason, /stdout:\nstdout prefix token=\[redacted\]/);
+  assert.match(report.reason, /decisive stdout tail$/);
+  assert.doesNotMatch(report.reason, new RegExp(secret));
+  assert.ok(report.reason.length <= 4000, `reason was ${report.reason.length} chars`);
+});
+
 test("external merge preflight accepts #100910 assignee and harmless label drift after final recheck", () => {
   const fixture = makeFixture({
     issueUpdatedAt: "2026-07-06T13:38:20Z",
@@ -2160,7 +2200,7 @@ test("external merge preflight blocks merge-risk labels", () => {
   assert.match(report.reason, /blocked live label: merge-risk: availability/);
 });
 
-function runPreflightFixture(fixture) {
+function runPreflightFixture(fixture, extraEnv = {}) {
   const child = spawnSync(
     process.execPath,
     ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
@@ -2169,6 +2209,7 @@ function runPreflightFixture(fixture) {
       encoding: "utf8",
       env: {
         ...process.env,
+        ...extraEnv,
         PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
         CLOWNFISH_ALLOWED_OWNER: "openclaw",
       },
@@ -2203,6 +2244,7 @@ function makeFixture({
   rehydratedHeadSha = null,
   rehydratedState = null,
   currentMainSha = null,
+  validationFailure = null,
   codexReview = {
     status: "clean",
     summary: "clean fixture review",
@@ -2339,9 +2381,18 @@ if (args[0] === "merge-base") console.log(base);
 process.exit(0);
 `,
   );
-  for (const command of ["corepack", "pnpm"]) {
-    writeExecutable(path.join(binDir, command), "#!/bin/sh\nexit 0\n");
-  }
+  writeExecutable(path.join(binDir, "corepack"), "#!/bin/sh\nexit 0\n");
+  writeExecutable(
+    path.join(binDir, "pnpm"),
+    `#!/usr/bin/env node
+const failure = ${JSON.stringify(validationFailure)};
+if (failure && process.argv.slice(2).join(" ") === "check:changed") {
+  process.stdout.write(String(failure.stdout ?? ""));
+  process.stderr.write(String(failure.stderr ?? ""));
+  process.exit(Number(failure.status ?? 1));
+}
+`,
+  );
   writeExecutable(
     path.join(binDir, "codex"),
     `#!/usr/bin/env node


### PR DESCRIPTION
## Summary

- retain command context when external validation fails
- preserve bounded stdout and stderr head/tail diagnostics
- redact secret-like values and ANSI sequences before writing artifacts

## Validation

- `node --check scripts/preflight-external-pr-merge.mjs`
- focused `node --test` diagnostics regressions
- `npm run validate`
- `git diff --check`