### PR TITLE
fix(actions): fail blocked external preflights

### DIFF
--- a/.github/workflows/external-merge-preflight.yml
+++ b/.github/workflows/external-merge-preflight.yml
@@ -108,6 +108,12 @@ jobs:
             .projectclownfish/external-merge-preflight/preflight-report.json
           if-no-files-found: warn
 
+      - name: Fail blocked preflight
+        if: ${{ always() && steps.outcome.outputs.preflight_passed != 'true' }}
+        run: |
+          echo "::error title=External merge preflight blocked::Preflight did not pass; inspect the uploaded artifact."
+          exit 1
+
   apply:
     name: Apply reviewed merge
     needs: preflight

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -50,6 +50,10 @@ test("external merge workflow validates before guarded apply", () => {
   assert.match(workflow, /inputs\.apply && vars\.CLOWNFISH_ALLOW_EXECUTE == '1' && vars\.CLOWNFISH_ALLOW_MERGE == '1'/);
   assert.match(workflow, /runs-on: \$\{\{ inputs\.runner \}\}/);
   assert.match(workflow, /external-merge-preflight\/preflight-report\.json/);
+  assert.match(
+    workflow,
+    /- name: Upload preflight artifact[\s\S]*?if: always\(\)[\s\S]*?- name: Fail blocked preflight[\s\S]*?if: \$\{\{ always\(\) && steps\.outcome\.outputs\.preflight_passed != 'true' \}\}[\s\S]*?exit 1[\s\S]*?\n  apply:/,
+  );
   assert.match(workflow, /npm run apply-result/);
   assert.match(workflow, /- name: Verify mutation integrity[\s\S]*?npm run assert-mutation-integrity/);
   assert.match(workflow, /- name: Verify mutation integrity[\s\S]*?- name: Upload apply artifact/);


### PR DESCRIPTION
## Summary

- preserve blocked preflight artifacts
- fail the workflow after upload when preflight did not pass
- keep guarded apply limited to passed preflights

## Validation

- focused workflow regression tests
- YAML parse and syntax checks
- `npm run validate`
- `git diff --check`