### PR TITLE
fix(preflight): ignore positive maintainer status comments

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -837,6 +837,7 @@ function isNonBlockingCommentEvidence(
   }
   if (isMaintainerCommandComment({ association, body: normalized })) return true;
   if (isMaintainerApprovalComment({ association, body: normalized })) return true;
+  if (isMaintainerProofOrStatusComment({ association, body })) return true;
   if (isMaintainerEvidenceApprovalComment(comment)) return true;
   if (isReviewRequestComment(normalized)) return true;
   if (
@@ -951,6 +952,13 @@ function isMaintainerApprovalComment({ association, body }) {
   return (
     ["MEMBER", "OWNER", "COLLABORATOR"].includes(association) &&
     /^(?:lgtm|looks good(?: to me)?|approved|ship it|:\+1:|👍)[.! ]*$/.test(body)
+  );
+}
+
+function isMaintainerProofOrStatusComment({ association, body }) {
+  return (
+    ["MEMBER", "OWNER", "COLLABORATOR"].includes(association) &&
+    isAuthorProofOrStatusComment(body)
   );
 }
 
@@ -1122,12 +1130,23 @@ function isAuthorProofOrStatusComment(body) {
       /^[-*]\s+/.test(line) &&
       /`[^`]+`|\b(?:passed|passing|green|clean|no failures|confirms?|shows?|proof)\b/.test(line),
   );
+  const hasInlineEvidenceDetail = contentLines.some(
+    (line) =>
+      /^(?:proof|validation|verification|test results|current status|status):\s+\S/.test(line) &&
+      /`[^`]+`|\b(?:git|node|pnpm|npm|yarn|bun)\s+\S+|\b(?:passed|passing|green|clean|successful)\b/.test(
+        line,
+      ),
+  );
   const hasProofSignal =
     /\b(?:proof|validation|verification|tests?|checks?|ci\/status|repro(?:duction|ducible)?|autoreview)\b/.test(
       normalized,
     );
 
-  return (hasProofHeading && hasEvidenceDetail) || (hasStatusLead && (hasEvidenceDetail || hasProofSignal));
+  return (
+    hasInlineEvidenceDetail ||
+    (hasProofHeading && hasEvidenceDetail) ||
+    (hasStatusLead && (hasEvidenceDetail || hasProofSignal))
+  );
 }
 
 function isSupersededAuthorUnrelatedCiFailureComment(body) {
@@ -1196,6 +1215,7 @@ function isAuthorObjectionComment(body) {
     /\b(?:incomplete|unfinished|still investigating|need more time|one more thought|worried|concerns?|unclear)\b/,
     /\b(?:haven't|hasn't|nothing was)\s+fixed\b/,
     /\b(?:tests?|checks?|ci)\b.{0,40}\b(?:are |is )?(?:still )?(?:failing|failed|red|broken)\b/,
+    /\b(?:found|noticed|observed|identified|detected)\b(?![^.\n]{0,20}\bno\b)[^.\n]{0,100}\b(?:bug|issue|problem|regression|failure|error|risk|concern)\b/,
     /\b(?:rather|prefer)\b.{0,40}\bnot (?:merge|land|ship)\b/,
     /\b(?:withdraw|withdrawn|abandon|abandoned|cancel|cancelled|superseded|obsolete)\b/,
     /\b(?:close|stop)\s+(?:this|the)\s+(?:pr|pull request)\b/,

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -436,6 +436,100 @@ test("external merge preflight tolerates non-actionable automation comments", ()
   assert.equal(report.status, "passed");
 });
 
+test("external merge preflight ignores #89997 positive review, maintainer status, and review command comments", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "kenners22" },
+    issueComments: [
+      {
+        author: { login: "clawsweeper" },
+        authorAssociation: "CONTRIBUTOR",
+        isMinimized: false,
+        body: [
+          "Codex review: needs maintainer review before merge. _Reviewed July 6, 2026, 11:18 AM ET / 15:18 UTC._",
+          "",
+          "**Review metrics:** 1 noteworthy metric.",
+          "",
+          "**Merge readiness**",
+          "Result: ready for maintainer review.",
+          "",
+          "**Next step before merge**",
+          "- No automated repair is needed; the patch looks correct and the remaining action is maintainer landing review for the clean exact head.",
+          "",
+          `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+          "<!-- clawsweeper-review item=123 -->",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/89997#issuecomment-review",
+      },
+      {
+        author: { login: "vincentkoc" },
+        authorAssociation: "MEMBER",
+        isMinimized: false,
+        body: [
+          "Clownfish reef update",
+          "",
+          "Thanks for the contribution here. Clownfish kept this PR as the main lane.",
+          "",
+          "Source PR: https://github.com/openclaw/openclaw/pull/89997",
+          "Validation: git diff --check; node scripts/run-vitest.mjs src/cli/command-startup-policy.test.ts; pnpm check:changed",
+          "Contributor credit stays on this marker, with the PR history doing the receipts.",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/89997#issuecomment-status",
+      },
+      {
+        author: { login: "vincentkoc" },
+        authorAssociation: "MEMBER",
+        isMinimized: false,
+        body: "@clawsweeper re-review",
+        url: "https://github.com/openclaw/openclaw/pull/89997#issuecomment-command",
+      },
+      {
+        author: { login: "reviewer" },
+        authorAssociation: "CONTRIBUTOR",
+        isMinimized: true,
+        minimizedReason: "OUTDATED",
+        body: "Please fix the startup stdout regression before merge.",
+        url: "https://github.com/openclaw/openclaw/pull/89997#issuecomment-minimized",
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+  assert.equal(report.status, "passed", report.reason);
+});
+
+for (const [kind, body] of [
+  [
+    "ask",
+    [
+      "Validation: git diff --check passed.",
+      "Please add a focused ACP regression test before merge.",
+    ].join("\n"),
+  ],
+  [
+    "finding",
+    [
+      "Validation: git diff --check passed.",
+      "I found a regression: bare ACP startup still writes diagnostics to stdout.",
+    ].join("\n"),
+  ],
+]) {
+  test(`external merge preflight keeps unresolved maintainer ${kind} comments blocking`, () => {
+    const fixture = makeFixture({
+      issueComments: [
+        {
+          author: { login: "maintainer" },
+          authorAssociation: "MEMBER",
+          isMinimized: false,
+          body,
+          url: `https://github.com/openclaw/openclaw/pull/123#issuecomment-${kind}`,
+        },
+      ],
+    });
+    const { report } = runPreflightFixture(fixture);
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, /actionable top-level issue comment/);
+  });
+}
+
 test("external merge preflight tolerates ready ClawSweeper docs reviews without proof labels", () => {
   const fixture = makeFixture({
     pullLabels: [


### PR DESCRIPTION
## Summary

- ignore positive maintainer proof/status updates during external merge preflight
- keep unresolved maintainer asks and findings blocking
- cover the live #89997 comment shapes with regressions

## Testing

- `node --test test/preflight-external-pr-merge.test.mjs` (60/60)
- `npm run validate` (6,645 jobs valid)
- syntax and diff checks