### PR TITLE
fix(preflight): ignore approval transcript security modes

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -410,7 +410,9 @@ function readOnlyBlockers({ sourceJob, pull, view, issueComments, pullRequest })
     ...reviewComments.map((comment) => comment.body),
   ];
 
-  if (hasSecuritySensitiveText(texts)) blockers.push("security-sensitive signal in hydrated PR metadata or comments");
+  if (hasSecuritySensitiveText(texts.map(maskBenignApprovalSecurityTranscriptLines))) {
+    blockers.push("security-sensitive signal in hydrated PR metadata or comments");
+  }
   const blockedLabel = findHighRiskMergeLabel(pull.labels);
   if (blockedLabel) blockers.push(`PR has blocked live label: ${blockedLabel}`);
   if (String(pull.state ?? "").toLowerCase() !== "open") blockers.push(`PR is ${pull.state ?? "unknown"}`);
@@ -775,6 +777,29 @@ function checkTimestamp(check) {
 
 function checkName(check) {
   return String(check.name ?? check.context ?? "unknown check");
+}
+
+function maskBenignApprovalSecurityTranscriptLines(value) {
+  const lines = String(value ?? "").split(/\r?\n/);
+  let fence = null;
+
+  return lines
+    .map((line) => {
+      const marker = line.match(/^\s*(`{3,}|~{3,})/)?.[1];
+      if (marker) {
+        if (!fence) {
+          fence = marker[0];
+        } else if (marker[0] === fence) {
+          fence = null;
+        }
+        return line;
+      }
+      if (fence && /^\s*security:\s*(?:deny|allowlist|full)\s*$/i.test(line)) {
+        return "";
+      }
+      return line;
+    })
+    .join("\n");
 }
 
 function isReviewBot(review) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -1436,6 +1436,33 @@ test("external merge preflight never lets a ready review suppress an author secu
   assert.match(report.reason, /security-sensitive signal/);
 });
 
+test("external merge preflight ignores approval security modes inside fenced runtime proof", () => {
+  const fixture = makeFixture({
+    pullBody: [
+      "Real behavior proof:",
+      "",
+      "```text",
+      "Exec approval required",
+      "Session: agent:main:telegram:direct:424242",
+      "Security: allowlist",
+      "```",
+    ].join("\n"),
+  });
+  const { report } = runPreflightFixture(fixture);
+  assert.equal(report.status, "passed", report.reason);
+});
+
+for (const [name, pullBody] of [
+  ["prose security heading", "Security: authorization boundary needs review."],
+  ["fenced security concern", "```text\nSecurity: possible token exposure\n```"],
+]) {
+  test(`external merge preflight keeps ${name} blocking`, () => {
+    const { report } = runPreflightFixture(makeFixture({ pullBody }));
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, /security-sensitive signal/);
+  });
+}
+
 test("external merge preflight never lets a ready review suppress author withdrawal", () => {
   const fixture = makeFixture({
     pullUser: { login: "contributor" },
@@ -2324,6 +2351,8 @@ function makeFixture({
   issueComments = [],
   reviewComments = [],
   reviews = [],
+  pullTitle = "fix: fixture",
+  pullBody = "",
   pullLabels = [],
   pullUser = { login: "contributor" },
   statusCheckRollup = [],
@@ -2451,7 +2480,7 @@ if (args[0] === "api" && args[1].endsWith("/issues/123")) {
     { state: "open", updated_at: ${JSON.stringify(issueUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, assignees: ${JSON.stringify(pullAssignees)} },
     { state: ${JSON.stringify(finalState)}, updated_at: ${JSON.stringify(finalIssueUpdatedAt)}, labels: ${JSON.stringify(finalPullLabels)}, assignees: ${JSON.stringify(finalPullAssignees)} },
   );
-  console.log(JSON.stringify({ ...issue, draft: false, title: "fix: fixture", body: "", html_url: "https://github.com/openclaw/openclaw/pull/123", pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/123" } }));
+  console.log(JSON.stringify({ ...issue, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/openclaw/openclaw/pull/123", pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/123" } }));
   process.exit(0);
 }
 if (args[0] === "api" && args[1].endsWith("/pulls/123")) {
@@ -2460,7 +2489,7 @@ if (args[0] === "api" && args[1].endsWith("/pulls/123")) {
     { state: "open", updated_at: ${JSON.stringify(pullUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, assignees: ${JSON.stringify(pullAssignees)}, headSha: head },
     { state: ${JSON.stringify(finalState)}, updated_at: ${JSON.stringify(finalPullUpdatedAt)}, labels: ${JSON.stringify(finalPullLabels)}, assignees: ${JSON.stringify(finalPullAssignees)}, headSha: ${JSON.stringify(finalHeadSha)} },
   );
-  console.log(JSON.stringify({ number: 123, ...pull, draft: false, title: "fix: fixture", body: "", html_url: "https://github.com/openclaw/openclaw/pull/123", user: ${JSON.stringify(pullUser)}, head: { sha: pull.headSha, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: base, ref: "main" } }));
+  console.log(JSON.stringify({ number: 123, ...pull, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/openclaw/openclaw/pull/123", user: ${JSON.stringify(pullUser)}, head: { sha: pull.headSha, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: base, ref: "main" } }));
   process.exit(0);
 }
 process.stderr.write("unexpected gh command: " + args.join(" "));


### PR DESCRIPTION
## Summary

- ignore fenced approval runtime fields such as `Security: allowlist` during security-sensitive preflight classification
- keep prose security headings and fenced security concerns blocking
- cover the live #99485 proof shape

## Testing

- focused regressions: 3/3
- `node --test test/preflight-external-pr-merge.test.mjs` (63/63)
- `npm run validate` (6,645 jobs valid)
- syntax and diff checks