### PR TITLE
fix(preflight): review synthetic squash result

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -52,6 +52,7 @@ let issue = null;
 let view = null;
 let plan = null;
 let preflightJobPath = null;
+let reviewContext = null;
 let report = {
   repo: sourceJob.frontmatter.repo,
   source_job: sourceJob.relativePath,
@@ -95,6 +96,14 @@ try {
     process.exit(0);
   }
 
+  reviewContext = stage("prepare synthetic merge review", () =>
+    prepareSyntheticMergeReview({
+      targetDir,
+      baseBranch,
+      currentMainSha,
+      exactHeadSha: pull.head.sha,
+    }),
+  );
   stage("prepare target toolchain", () => prepareTargetToolchain(targetDir));
   const validationCommands = stage("target validation", () => runValidation({ targetDir, baseBranch }));
   const codexReview = stage("Codex review", () =>
@@ -104,6 +113,7 @@ try {
       targetDir,
       validationCommands,
       sourceJob,
+      reviewContext,
     }),
   );
   if (!isCleanCodexReview(codexReview)) {
@@ -171,6 +181,7 @@ try {
     codexReview,
     currentMainSha,
     baseDriftAllowed: finalBaseDriftAllowed,
+    reviewContext,
   });
   report = {
     ...report,
@@ -181,6 +192,10 @@ try {
     reviewed_base_sha: pull.base.sha,
     current_main_sha: currentMainSha,
     base_drift_allowed: finalBaseDriftAllowed,
+    synthetic_merge_sha: reviewContext.syntheticMergeSha,
+    synthetic_merge_tree_sha: reviewContext.mergeTreeSha,
+    raw_diff_files: reviewContext.rawDiffFiles,
+    effective_diff_files: reviewContext.effectiveDiffFiles,
     validation_commands: validationCommands,
     codex_review: {
       status: codexReview.status,
@@ -227,6 +242,10 @@ function writeBlockedArtifacts({ reason, validationCommands = [], codexReview = 
     reviewed_head_sha: pull?.head?.sha ?? null,
     reviewed_base_sha: pull?.base?.sha ?? null,
     current_main_sha: currentMainSha,
+    synthetic_merge_sha: reviewContext?.syntheticMergeSha ?? null,
+    synthetic_merge_tree_sha: reviewContext?.mergeTreeSha ?? null,
+    raw_diff_files: reviewContext?.rawDiffFiles ?? null,
+    effective_diff_files: reviewContext?.effectiveDiffFiles ?? null,
     validation_commands: validationCommands,
     codex_review: codexReview
       ? { status: codexReview.status ?? "unknown", findings: Array.isArray(codexReview.findings) ? codexReview.findings.length : null }
@@ -510,6 +529,59 @@ function ensureMergeBase({ cwd, baseBranch, pullRequest, ref }) {
   run("git", ["merge-base", `origin/${baseBranch}`, "HEAD"], { cwd });
 }
 
+function prepareSyntheticMergeReview({ targetDir, baseBranch, currentMainSha, exactHeadSha }) {
+  const baseRef = `origin/${baseBranch}`;
+  const rawDiffFiles = changedFileCount({ cwd: targetDir, baseRef, targetRef: exactHeadSha });
+  const mergeTreeSha = run("git", ["merge-tree", "--write-tree", currentMainSha, exactHeadSha], {
+    cwd: targetDir,
+    timeout: VALIDATION_TIMEOUT_MS,
+  }).trim();
+  if (!/^[0-9a-f]{40}$/i.test(mergeTreeSha)) {
+    throw new Error(`synthetic merge returned invalid tree SHA: ${mergeTreeSha || "empty"}`);
+  }
+  const syntheticMergeSha = run(
+    "git",
+    [
+      "commit-tree",
+      mergeTreeSha,
+      "-p",
+      currentMainSha,
+    ],
+    {
+      cwd: targetDir,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "ProjectClownfish",
+        GIT_AUTHOR_EMAIL: "projectclownfish@users.noreply.github.com",
+        GIT_AUTHOR_DATE: "2000-01-01T00:00:00Z",
+        GIT_COMMITTER_NAME: "ProjectClownfish",
+        GIT_COMMITTER_EMAIL: "projectclownfish@users.noreply.github.com",
+        GIT_COMMITTER_DATE: "2000-01-01T00:00:00Z",
+      },
+      input: `projectclownfish synthetic squash review for ${exactHeadSha}\n`,
+      timeout: VALIDATION_TIMEOUT_MS,
+    },
+  ).trim();
+  if (!/^[0-9a-f]{40}$/i.test(syntheticMergeSha)) {
+    throw new Error(`synthetic merge returned invalid commit SHA: ${syntheticMergeSha || "empty"}`);
+  }
+  run("git", ["checkout", "--detach", syntheticMergeSha], { cwd: targetDir });
+  const checkedOutTree = run("git", ["rev-parse", "HEAD^{tree}"], { cwd: targetDir }).trim();
+  const syntheticParent = run("git", ["rev-parse", "HEAD^"], { cwd: targetDir }).trim();
+  if (checkedOutTree !== mergeTreeSha || syntheticParent !== currentMainSha) {
+    throw new Error(
+      `synthetic merge binding mismatch: expected tree ${mergeTreeSha} on base ${currentMainSha}, got tree ${checkedOutTree} on base ${syntheticParent}`,
+    );
+  }
+  const effectiveDiffFiles = changedFileCount({ cwd: targetDir, baseRef, targetRef: "HEAD" });
+  return { syntheticMergeSha, mergeTreeSha, rawDiffFiles, effectiveDiffFiles };
+}
+
+function changedFileCount({ cwd, baseRef, targetRef }) {
+  const output = run("git", ["diff", "--name-only", `${baseRef}...${targetRef}`], { cwd }).trim();
+  return output ? output.split(/\r?\n/).length : 0;
+}
+
 function isShallowRepository(cwd) {
   return run("git", ["rev-parse", "--is-shallow-repository"], { cwd }).trim() === "true";
 }
@@ -546,7 +618,7 @@ function runValidation({ targetDir, baseBranch }) {
   return ["pnpm check:changed", `git diff --check origin/${baseBranch}...HEAD`, "git diff --check"];
 }
 
-function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sourceJob }) {
+function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sourceJob, reviewContext }) {
   const schemaPath = path.join(runDir, "codex-review.schema.json");
   const outputPath = path.join(runDir, "codex-review.json");
   const defaultCodexReviewSandbox = process.env.GITHUB_ACTIONS === "true" ? "danger-full-access" : "read-only";
@@ -580,7 +652,9 @@ function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sour
     "/review",
     "",
     `Review openclaw PR #${pullRequest} in ${repo}. This is a read-only external merge preflight.`,
-    `Review the exact checked-out PR head against origin/${baseBranch}.`,
+    `HEAD is an ephemeral one-parent squash-result commit built from the exact PR head and current origin/${baseBranch}.`,
+    `Review only the effective diff origin/${baseBranch}...HEAD; the exact GitHub PR head is bound through merge tree ${reviewContext.mergeTreeSha}.`,
+    `Synthetic commit: ${reviewContext.syntheticMergeSha}; raw PR diff files: ${reviewContext.rawDiffFiles}; effective merge diff files: ${reviewContext.effectiveDiffFiles}.`,
     "",
     "The preflight already verified that the PR has no top-level or inline review comments, no unresolved review threads, no review-bot findings, no security signal, and passing GitHub checks.",
     "Do not mutate GitHub or the checkout. Do not run validation commands.",
@@ -619,9 +693,23 @@ function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sour
   return JSON.parse(fs.readFileSync(outputPath, "utf8"));
 }
 
-function buildMergeResult({ sourceJob, virtualJob, pull, issue, view, pullRequest, validationCommands, codexReview, currentMainSha, baseDriftAllowed }) {
+function buildMergeResult({
+  sourceJob,
+  virtualJob,
+  pull,
+  issue,
+  view,
+  pullRequest,
+  validationCommands,
+  codexReview,
+  currentMainSha,
+  baseDriftAllowed,
+  reviewContext,
+}) {
   const evidence = [
     `Exact PR head ${pull.head.sha} checked out from refs/pull/${pullRequest}/head.`,
+    `Validation and Codex review ran on synthetic squash-result commit ${reviewContext.syntheticMergeSha} with origin/main ${currentMainSha} as its parent and merge tree ${reviewContext.mergeTreeSha} computed from exact PR head ${pull.head.sha}.`,
+    `Review surface narrowed from ${reviewContext.rawDiffFiles} raw PR file(s) to ${reviewContext.effectiveDiffFiles} effective merge file(s).`,
     baseDriftAllowed
       ? `PR base ${pull.base.sha} drifted from origin/main ${currentMainSha}; exact head remained mergeable with clean latest checks and validation ran against origin/main.`
       : `PR base ${pull.base.sha} matched current origin/main ${currentMainSha} before validation.`,
@@ -639,7 +727,7 @@ function buildMergeResult({ sourceJob, virtualJob, pull, issue, view, pullReques
         target: `#${pullRequest}`,
         action: "merge_canonical",
         status: "planned",
-        idempotency_key: `external-merge-preflight:${sourceJob.frontmatter.repo}#${pullRequest}:${pull.head.sha}`,
+        idempotency_key: `external-merge-preflight:${sourceJob.frontmatter.repo}#${pullRequest}:${pull.head.sha}:${currentMainSha}:${reviewContext.mergeTreeSha}`,
         expected_head_sha: pull.head.sha,
         classification: "canonical",
         target_kind: "pull_request",

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -19,6 +19,11 @@ test("external merge preflight is exact-head, read-only, and refuses unresolved 
   assert.match(script, /pull\/\$\{pullRequest\}\/head:\$\{ref\}/);
   assert.match(script, /PR head changed during checkout/);
   assert.match(script, /function ensureMergeBase/);
+  assert.match(script, /function prepareSyntheticMergeReview/);
+  assert.match(script, /"merge-tree", "--write-tree", currentMainSha, exactHeadSha/);
+  assert.match(script, /"commit-tree",\s*mergeTreeSha,\s*"-p",\s*currentMainSha/);
+  assert.match(script, /"rev-parse", "HEAD\^\{tree\}"/);
+  assert.match(script, /"rev-parse", "HEAD\^"/);
   assert.match(script, /--deepen/);
   assert.match(script, /--unshallow/);
   assert.match(script, /if \(secret\) redacted = redacted\.replaceAll/);
@@ -132,6 +137,17 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
   assert.equal(result.actions[0].expected_head_sha, fixture.headSha);
   assert.equal(result.actions[0].target_updated_at, "2026-06-19T00:05:00Z");
   assert.equal(result.merge_preflight[0].codex_review.status, "clean");
+  assert.match(result.actions[0].evidence.join("\n"), /synthetic squash-result commit/);
+
+  const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
+  assert.equal(report.synthetic_merge_sha, fixture.syntheticMergeSha);
+  assert.equal(report.synthetic_merge_tree_sha, fixture.mergeTreeSha);
+  assert.equal(report.raw_diff_files, 2);
+  assert.equal(report.effective_diff_files, 1);
+  const gitCommands = fs.readFileSync(fixture.gitCommandsPath, "utf8");
+  assert.match(gitCommands, new RegExp(`merge-tree --write-tree ${fixture.baseSha} ${fixture.headSha}`));
+  assert.match(gitCommands, new RegExp(`commit-tree ${fixture.mergeTreeSha} -p ${fixture.baseSha}`));
+  assert.match(gitCommands, new RegExp(`checkout --detach ${fixture.syntheticMergeSha}`));
 
   const reviewed = spawnSync(process.execPath, ["scripts/review-results.mjs", fixture.runDir], {
     cwd: repoRoot,
@@ -178,6 +194,15 @@ test("external merge preflight reports both output tails without leaking secrets
   assert.match(report.reason, /decisive stdout tail$/);
   assert.doesNotMatch(report.reason, new RegExp(secret));
   assert.ok(report.reason.length <= 4000, `reason was ${report.reason.length} chars`);
+});
+
+test("external merge preflight blocks synthetic merge conflicts", () => {
+  const fixture = makeFixture({ syntheticMergeFailure: "fixture merge conflict" });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /git merge-tree --write-tree/);
+  assert.match(report.reason, /fixture merge conflict/);
 });
 
 test("external merge preflight accepts #100910 assignee and harmless label drift after final recheck", () => {
@@ -2372,6 +2397,7 @@ function makeFixture({
   rehydratedState = null,
   currentMainSha = null,
   validationFailure = null,
+  syntheticMergeFailure = null,
   codexReview = {
     status: "clean",
     summary: "clean fixture review",
@@ -2386,6 +2412,9 @@ function makeFixture({
   const jobPath = path.join(root, "source-job.md");
   const headSha = "a".repeat(40);
   const baseSha = "b".repeat(40);
+  const mergeTreeSha = "c".repeat(40);
+  const syntheticMergeSha = "d".repeat(40);
+  const gitCommandsPath = path.join(root, "git-commands.log");
   const finalIssueComments = rehydratedIssueComments ?? issueComments;
   const finalReviewComments = rehydratedReviewComments ?? reviewComments;
   const finalReviewThreads = rehydratedReviewThreads ?? [];
@@ -2499,12 +2528,53 @@ process.exit(1);
   writeExecutable(
     path.join(binDir, "git"),
     `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
 const args = process.argv.slice(2);
 const head = ${JSON.stringify(headSha)};
 const base = ${JSON.stringify(baseSha)};
 const currentMain = ${JSON.stringify(currentMainSha)} || base;
-if (args[0] === "rev-parse") console.log(args[1] === "origin/main" ? currentMain : head);
-if (args[0] === "merge-base") console.log(base);
+const mergeTree = ${JSON.stringify(mergeTreeSha)};
+const synthetic = ${JSON.stringify(syntheticMergeSha)};
+const statePath = path.join(${JSON.stringify(root)}, "git-state");
+const commandLog = ${JSON.stringify(gitCommandsPath)};
+fs.appendFileSync(commandLog, args.join(" ") + "\\n");
+const state = fs.existsSync(statePath) ? fs.readFileSync(statePath, "utf8") : "pr";
+if (args[0] === "rev-parse") {
+  if (args[1] === "origin/main" || args[1] === "HEAD^") console.log(currentMain);
+  else if (args[1] === "HEAD^{tree}") console.log(mergeTree);
+  else if (args[1] === "--is-shallow-repository") console.log("false");
+  else console.log(state === "synthetic" ? synthetic : state === "main" ? currentMain : head);
+  process.exit(0);
+}
+if (args[0] === "merge-base") {
+  console.log(base);
+  process.exit(0);
+}
+if (args[0] === "checkout") {
+  fs.writeFileSync(statePath, args.at(-1) === synthetic ? "synthetic" : args.at(-1) === "origin/main" ? "main" : "pr");
+  process.exit(0);
+}
+if (args[0] === "merge-tree" && args[1] === "--write-tree") {
+  const failure = ${JSON.stringify(syntheticMergeFailure)};
+  if (failure) {
+    process.stderr.write(failure);
+    process.exit(1);
+  }
+  console.log(mergeTree);
+  process.exit(0);
+}
+if (args[0] === "commit-tree") {
+  console.log(synthetic);
+  process.exit(0);
+}
+if (args[0] === "diff" && args[1] === "--name-only") {
+  if (args.includes("--diff-filter=U")) process.exit(0);
+  const target = args.at(-1);
+  const files = target.endsWith("...HEAD") ? ["src/effective.ts"] : ["src/raw.ts", "src/already-on-main.ts"];
+  process.stdout.write(files.join("\\n") + "\\n");
+  process.exit(0);
+}
 process.exit(0);
 `,
   );
@@ -2529,7 +2599,7 @@ const index = args.indexOf("--output-last-message");
 fs.writeFileSync(args[index + 1], JSON.stringify(${JSON.stringify(codexReview)}));
 `,
   );
-  return { binDir, headSha, jobPath, runDir };
+  return { baseSha, binDir, gitCommandsPath, headSha, jobPath, mergeTreeSha, runDir, syntheticMergeSha };
 }
 
 function writeExecutable(filePath, content) {


### PR DESCRIPTION
## Summary

- build a deterministic one-parent squash-result commit from the exact PR head and current target main
- run validation and Codex review against the effective merge diff instead of stale fork ancestry
- record raw/effective file counts and bind the merge artifact to the computed tree

## Why

Old contributor branches can contain unrelated ancestry even when GitHub would merge only a narrow patch. Reviewing `origin/main...HEAD` on the raw PR head falsely blocked clean PRs with dozens of already-landed files.

## Validation

- `node --test test/preflight-external-pr-merge.test.mjs` (64/64)
- `node --check scripts/preflight-external-pr-merge.mjs`
- `git diff --check`
- `npm run validate` (6,645 jobs)