### PR TITLE
fix(merge): bind external preflight to exact result

### DIFF
--- a/.github/workflows/cluster-worker.yml
+++ b/.github/workflows/cluster-worker.yml
@@ -459,6 +459,7 @@ jobs:
       CLOWNFISH_CLOSE_SUPERSEDED_SOURCE_PRS: ${{ vars.CLOWNFISH_CLOSE_SUPERSEDED_SOURCE_PRS || '0' }}
       CLOWNFISH_GIT_USER_NAME: ${{ vars.CLOWNFISH_GIT_USER_NAME || 'projectclownfish' }}
       CLOWNFISH_GIT_USER_EMAIL: ${{ vars.CLOWNFISH_GIT_USER_EMAIL || 'projectclownfish@users.noreply.github.com' }}
+      CLOWNFISH_APP_ID: ${{ vars.CLOWNFISH_APP_ID }}
       CODEX_CLI_VERSION: ${{ vars.CLOWNFISH_CODEX_CLI_VERSION || '0.125.0' }}
       OPENCLAW_LOCAL_CHECK: "0"
       CLOWNFISH_READ_GH_TOKEN: ${{ github.token }}
@@ -473,6 +474,7 @@ jobs:
           app-id: ${{ vars.CLOWNFISH_APP_ID }}
           private-key: ${{ secrets.CLOWNFISH_APP_PRIVATE_KEY }}
           owner: ${{ vars.CLOWNFISH_ALLOWED_OWNER || github.repository_owner }}
+          permission-checks: write
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
@@ -485,6 +487,7 @@ jobs:
           app-id: ${{ vars.CLOWNFISH_APP_ID }}
           private-key: ${{ secrets.CLOWNFISH_APP_PRIVATE_KEY }}
           owner: ${{ vars.CLOWNFISH_ALLOWED_OWNER || github.repository_owner }}
+          permission-checks: write
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write

--- a/.github/workflows/external-merge-preflight.yml
+++ b/.github/workflows/external-merge-preflight.yml
@@ -136,6 +136,7 @@ jobs:
           app-id: ${{ vars.CLOWNFISH_APP_ID }}
           private-key: ${{ secrets.CLOWNFISH_APP_PRIVATE_KEY }}
           owner: ${{ vars.CLOWNFISH_ALLOWED_OWNER || github.repository_owner }}
+          permission-checks: write
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
@@ -145,6 +146,7 @@ jobs:
           CLOWNFISH_ALLOWED_OWNER: ${{ vars.CLOWNFISH_ALLOWED_OWNER || 'openclaw' }}
           CLOWNFISH_ALLOW_EXECUTE: "1"
           CLOWNFISH_ALLOW_MERGE: "1"
+          CLOWNFISH_APP_ID: ${{ vars.CLOWNFISH_APP_ID }}
           CLOWNFISH_GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           set -euo pipefail

--- a/schemas/codex-result.schema.json
+++ b/schemas/codex-result.schema.json
@@ -206,6 +206,22 @@
             "type": "string",
             "pattern": "^#?[0-9]+$"
           },
+          "reviewed_base_sha": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{40}$"
+          },
+          "reviewed_head_sha": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{40}$"
+          },
+          "effective_diff_sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{64}$"
+          },
+          "effective_diff_files": {
+            "type": "integer",
+            "minimum": 0
+          },
           "security_status": {
             "type": "string",
             "enum": ["cleared"]

--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -22,6 +22,11 @@ const CLEAN_MERGE_STATES = new Set(["CLEAN"]);
 const CLOWNFISH_LABEL = "clownfish";
 const CLOWNFISH_LABEL_COLOR = "F97316";
 const CLOWNFISH_LABEL_DESCRIPTION = "Tracked by Clownfish automation";
+const EXACT_MERGE_CHECK_NAME = "clownfish/exact-merge";
+let activeExactMergeAuthorization = null;
+let exactMergeCleanupRunning = false;
+
+installExactMergeExitCleanup();
 
 const args = parseArgs(process.argv.slice(2));
 const jobPath = args._[0];
@@ -467,18 +472,6 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
   const pullRequest = fetchPullRequest(result.repo, target);
   const view = fetchSettledPullRequestView(result.repo, target);
   const mergedAt = pullRequest.merged_at ?? view.mergedAt ?? null;
-  if (mergedAt) {
-    return {
-      ...base,
-      status: "executed",
-      reason: "already merged",
-      live_state: "merged",
-      live_updated_at: live.updated_at,
-      merged_at: mergedAt,
-      merge_commit_sha: pullRequest.merge_commit_sha ?? view.mergeCommit?.oid ?? null,
-    };
-  }
-
   const expectedHeadSha = String(action.expected_head_sha ?? "");
   if (!/^[0-9a-f]{40}$/i.test(expectedHeadSha)) {
     return {
@@ -501,6 +494,57 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       live_updated_at: live.updated_at,
     };
   }
+  if (mergedAt) {
+    const mergePreflightBlock = validateMergePreflight({
+      result,
+      action,
+      target,
+      expectedHeadSha,
+    });
+    if (mergePreflightBlock) {
+      return {
+        ...base,
+        status: "blocked",
+        reason: mergePreflightBlock,
+        live_state: "merged",
+        live_updated_at: live.updated_at,
+        merged_at: mergedAt,
+        merge_commit_sha: pullRequest.merge_commit_sha ?? view.mergeCommit?.oid ?? null,
+      };
+    }
+    const mergedProof = verifyActualMergedCommit({
+      result,
+      action,
+      target,
+      expectedHeadSha,
+      pullRequest,
+    });
+    if (mergedProof?.reason) {
+      return {
+        ...base,
+        status: "blocked",
+        reason: mergedProof.reason,
+        live_state: "merged",
+        live_updated_at: live.updated_at,
+        merged_at: mergedAt,
+        merge_commit_sha: pullRequest.merge_commit_sha ?? view.mergeCommit?.oid ?? null,
+        reviewed_effective_diff_sha256: mergedProof.reviewed_effective_diff_sha256 ?? null,
+        merged_effective_diff_sha256: mergedProof.merged_effective_diff_sha256 ?? null,
+      };
+    }
+    return {
+      ...base,
+      status: "executed",
+      reason: "already merged",
+      live_state: "merged",
+      live_updated_at: live.updated_at,
+      merged_at: mergedAt,
+      merge_commit_sha: pullRequest.merge_commit_sha ?? view.mergeCommit?.oid ?? null,
+      effective_diff_sha256: mergedProof?.merged_effective_diff_sha256 ?? null,
+      verified_main_sha: mergedProof?.verified_parent_sha ?? null,
+    };
+  }
+
   if (
     metadataDrifted &&
     !isBenignExactHeadClawSweeperUpdate({
@@ -530,7 +574,12 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       live_updated_at: live.updated_at,
     };
   }
-  const mergePreflightBlock = validateMergePreflight({ result, target });
+  const mergePreflightBlock = validateMergePreflight({
+    result,
+    action,
+    target,
+    expectedHeadSha,
+  });
   if (mergePreflightBlock) {
     return {
       ...base,
@@ -538,6 +587,25 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       reason: mergePreflightBlock,
       live_state: live.state,
       live_updated_at: live.updated_at,
+    };
+  }
+  const effectiveDiffBinding = verifyExternalMergeBinding({
+    result,
+    action,
+    target,
+    expectedHeadSha,
+  });
+  if (effectiveDiffBinding?.reason) {
+    return {
+      ...base,
+      status: "blocked",
+      reason: effectiveDiffBinding.reason,
+      live_state: live.state,
+      live_updated_at: live.updated_at,
+      reviewed_effective_diff_sha256: effectiveDiffBinding.reviewed_effective_diff_sha256 ?? null,
+      live_effective_diff_sha256: effectiveDiffBinding.live_effective_diff_sha256 ?? null,
+      verified_main_sha: effectiveDiffBinding.verified_main_sha ?? null,
+      base_drift_proof: effectiveDiffBinding.base_drift_proof ?? null,
     };
   }
   const currentBaseBlock = validatePullRequestCurrentBase({ repo: result.repo, pullRequest, view });
@@ -552,6 +620,20 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       current_main_sha: currentBaseBlock.current_main_sha,
     };
   }
+  if (effectiveDiffBinding) {
+    const mergeMainSha = fetchBranchHeadSha(result.repo, "main");
+    if (mergeMainSha !== effectiveDiffBinding.verified_main_sha) {
+      return {
+        ...base,
+        status: "blocked",
+        reason: "main changed after effective merge diff verification",
+        live_state: live.state,
+        live_updated_at: live.updated_at,
+        verified_main_sha: effectiveDiffBinding.verified_main_sha,
+        current_main_sha: mergeMainSha,
+      };
+    }
+  }
 
   if (process.env.CLOWNFISH_ALLOW_MERGE !== "1") {
     if (!dryRun) labelForClownfishReview(result.repo, target);
@@ -562,6 +644,9 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       live_state: live.state,
       live_updated_at: live.updated_at,
       merge_method: "squash",
+      effective_diff_sha256: effectiveDiffBinding?.live_effective_diff_sha256 ?? null,
+      verified_main_sha: effectiveDiffBinding?.verified_main_sha ?? null,
+      base_drift_proof: effectiveDiffBinding?.base_drift_proof ?? null,
     };
   }
 
@@ -573,30 +658,259 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       live_state: live.state,
       live_updated_at: live.updated_at,
       merge_method: "squash",
+      effective_diff_sha256: effectiveDiffBinding?.live_effective_diff_sha256 ?? null,
+      verified_main_sha: effectiveDiffBinding?.verified_main_sha ?? null,
+      base_drift_proof: effectiveDiffBinding?.base_drift_proof ?? null,
     };
   }
 
-  ghWithRetry([
-    "pr",
-    "merge",
-    String(target),
-    "--repo",
-    result.repo,
-    "--squash",
-    "--match-head-commit",
+  let exactMergeCheck = null;
+  if (effectiveDiffBinding) {
+    const ruleBlock = validateExactMergeRule(result.repo);
+    if (ruleBlock) {
+      return {
+        ...base,
+        status: "blocked",
+        reason: ruleBlock,
+        live_state: live.state,
+        live_updated_at: live.updated_at,
+        expected_head_sha: expectedHeadSha,
+        effective_diff_sha256: effectiveDiffBinding.live_effective_diff_sha256,
+        verified_main_sha: effectiveDiffBinding.verified_main_sha,
+      };
+    }
+    let checkedIssue;
+    let checkedPull;
+    let checkedView;
+    let checkedMainSha;
+    try {
+      checkedIssue = fetchIssue(result.repo, target);
+      checkedPull = fetchPullRequest(result.repo, target);
+      checkedView = fetchSettledPullRequestView(result.repo, target);
+      checkedMainSha = fetchBranchHeadSha(result.repo, "main");
+    } catch (error) {
+      return {
+        ...base,
+        status: "blocked",
+        reason: `could not complete final exact-merge recheck: ${compactErrorText(commandErrorText(error), 500)}`,
+        retry_recommended: true,
+        live_state: live.state,
+        live_updated_at: live.updated_at,
+        expected_head_sha: expectedHeadSha,
+        effective_diff_sha256: effectiveDiffBinding.live_effective_diff_sha256,
+        verified_main_sha: effectiveDiffBinding.verified_main_sha,
+      };
+    }
+    const checkedMergeBlock = validateMergeablePullRequest({
+      pullRequest: checkedPull,
+      view: checkedView,
+    });
+    const checkedPreflightBlock = validateMergePreflight({
+      result,
+      action,
+      target,
+      expectedHeadSha,
+    });
+    if (
+      String(checkedPull.head?.sha ?? "").toLowerCase() !== expectedHeadSha.toLowerCase() ||
+      String(checkedPull.merge_commit_sha ?? "").toLowerCase() !==
+        effectiveDiffBinding.merge_commit_sha.toLowerCase() ||
+      checkedMainSha !== effectiveDiffBinding.verified_main_sha ||
+      checkedIssue.updated_at !== live.updated_at ||
+      hasSecuritySignal(checkedIssue) ||
+      findHighRiskMergeLabel(checkedIssue.labels) ||
+      checkedMergeBlock ||
+      checkedPreflightBlock
+    ) {
+      return {
+        ...base,
+        status: "blocked",
+        reason:
+          checkedPreflightBlock ||
+          checkedMergeBlock ||
+          "head, test merge, main, metadata, or risk state changed before exact-merge authorization",
+        retry_recommended: true,
+        live_state: live.state,
+        live_updated_at: live.updated_at,
+        expected_head_sha: expectedHeadSha,
+        verified_main_sha: effectiveDiffBinding.verified_main_sha,
+        current_main_sha: checkedMainSha,
+      };
+    }
+    try {
+      exactMergeCheck = publishExactMergeCheck({
+        repo: result.repo,
+        action,
+        target,
+        expectedHeadSha,
+        effectiveDiffBinding,
+      });
+    } catch (error) {
+      return {
+        ...base,
+        status: "blocked",
+        reason: `could not publish exact-merge check: ${compactErrorText(commandErrorText(error), 500)}`,
+        retry_recommended: true,
+        live_state: live.state,
+        live_updated_at: live.updated_at,
+        expected_head_sha: expectedHeadSha,
+        effective_diff_sha256: effectiveDiffBinding.live_effective_diff_sha256,
+        verified_main_sha: effectiveDiffBinding.verified_main_sha,
+      };
+    }
+  }
+
+  try {
+    ghOnce([
+      "pr",
+      "merge",
+      String(target),
+      "--repo",
+      result.repo,
+      "--squash",
+      "--match-head-commit",
+      expectedHeadSha,
+    ]);
+  } catch (error) {
+    const mergedAfterError = fetchPullRequestAfterMergeAttempt(result.repo, target);
+    if (mergedAfterError?.merged_at) {
+      return buildMergedActionResult({
+        base,
+        live,
+        result,
+        action,
+        target,
+        expectedHeadSha,
+        merged: mergedAfterError,
+        effectiveDiffBinding,
+        exactMergeCheck,
+        reason: "merge command failed after GitHub accepted the merge",
+      });
+    }
+    const blockedResult = {
+        ...base,
+        status: "blocked",
+        reason: isMergeRefMovementError(error)
+          ? "pull request base or head changed during merge; rerun preflight"
+          : `merge command failed without retry: ${compactErrorText(commandErrorText(error), 500)}`,
+        retry_recommended: true,
+        live_state: live.state,
+        live_updated_at: live.updated_at,
+        expected_head_sha: expectedHeadSha,
+        effective_diff_sha256: effectiveDiffBinding?.live_effective_diff_sha256 ?? null,
+        verified_main_sha: effectiveDiffBinding?.verified_main_sha ?? null,
+        base_drift_proof: effectiveDiffBinding?.base_drift_proof ?? null,
+        exact_merge_check: exactMergeCheck,
+      };
+    return exactMergeCheck
+      ? withExactMergeRevocation({
+          repo: result.repo,
+          target,
+          exactMergeCheck,
+          result: blockedResult,
+        })
+      : blockedResult;
+  }
+  const merged = fetchPullRequestAfterMergeAttempt(result.repo, target);
+  return buildMergedActionResult({
+    base,
+    live,
+    result,
+    action,
+    target,
     expectedHeadSha,
-  ]);
-  const merged = fetchPullRequest(result.repo, target);
+    merged,
+    effectiveDiffBinding,
+    exactMergeCheck,
+    reason: "merged by projectclownfish",
+  });
+}
+
+function fetchPullRequestAfterMergeAttempt(repo, target) {
+  try {
+    return fetchPullRequest(repo, target);
+  } catch {
+    return null;
+  }
+}
+
+function buildMergedActionResult({
+  base,
+  live,
+  result,
+  action,
+  target,
+  expectedHeadSha,
+  merged,
+  effectiveDiffBinding,
+  exactMergeCheck,
+  reason,
+}) {
+  if (!merged?.merged_at || !/^[0-9a-f]{40}$/i.test(String(merged?.merge_commit_sha ?? ""))) {
+    const blockedResult = {
+      ...base,
+      status: "blocked",
+      reason: "merge command returned without a verified merged pull request",
+      retry_recommended: true,
+      live_state: merged?.state ?? live.state,
+      live_updated_at: merged?.updated_at ?? live.updated_at,
+      expected_head_sha: expectedHeadSha,
+      effective_diff_sha256: effectiveDiffBinding?.live_effective_diff_sha256 ?? null,
+      verified_main_sha: effectiveDiffBinding?.verified_main_sha ?? null,
+      exact_merge_check: exactMergeCheck,
+    };
+    return exactMergeCheck
+      ? withExactMergeRevocation({
+          repo: result.repo,
+          exactMergeCheck,
+          result: blockedResult,
+        })
+      : blockedResult;
+  }
+  clearActiveExactMergeAuthorization(exactMergeCheck);
+  const mergedProof = verifyActualMergedCommit({
+    result,
+    action,
+    target,
+    expectedHeadSha,
+    pullRequest: merged,
+  });
+  if (mergedProof?.reason) {
+    return {
+      ...base,
+      status: "blocked",
+      reason: mergedProof.reason,
+      retry_recommended: true,
+      live_state: "merged",
+      live_updated_at: merged.updated_at ?? live.updated_at,
+      merged_at: merged.merged_at,
+      merge_commit_sha: merged.merge_commit_sha,
+      expected_head_sha: expectedHeadSha,
+      reviewed_effective_diff_sha256: mergedProof.reviewed_effective_diff_sha256 ?? null,
+      merged_effective_diff_sha256: mergedProof.merged_effective_diff_sha256 ?? null,
+      verified_main_sha: mergedProof.verified_parent_sha ?? effectiveDiffBinding?.verified_main_sha ?? null,
+      exact_merge_check: exactMergeCheck,
+    };
+  }
   return {
     ...base,
     status: "executed",
-    reason: "merged by projectclownfish",
+    reason,
     live_state: "merged",
-    live_updated_at: live.updated_at,
-    merged_at: merged.merged_at ?? null,
-    merge_commit_sha: merged.merge_commit_sha ?? null,
+    live_updated_at: merged.updated_at ?? live.updated_at,
+    merged_at: merged.merged_at,
+    merge_commit_sha: merged.merge_commit_sha,
     merge_method: "squash",
     expected_head_sha: expectedHeadSha,
+    effective_diff_sha256:
+      mergedProof?.merged_effective_diff_sha256 ??
+      effectiveDiffBinding?.live_effective_diff_sha256 ??
+      null,
+    verified_main_sha:
+      mergedProof?.verified_parent_sha ??
+      effectiveDiffBinding?.verified_main_sha ??
+      null,
+    exact_merge_check: exactMergeCheck,
   };
 }
 
@@ -701,9 +1015,15 @@ function ensureLabel(repo, name, color, description) {
   }
 }
 
-function validateMergePreflight({ result, target }) {
+function validateMergePreflight({ result, action, target, expectedHeadSha }) {
   const preflight = findMergePreflight(result, target);
   if (!preflight) return "merge requires merge_preflight entry";
+  const externalBindingBlock = validateExternalMergeBindingFields({
+    action,
+    preflight,
+    expectedHeadSha,
+  });
+  if (externalBindingBlock) return externalBindingBlock;
   if (preflight.security_status !== "cleared") return "security preflight is not cleared";
   if (!Array.isArray(preflight.security_evidence) || preflight.security_evidence.length === 0) {
     return "security preflight evidence is missing";
@@ -729,6 +1049,482 @@ function validateMergePreflight({ result, target }) {
   const unresolvedThreadBlock = validateResolvedReviewThreads(result.repo, target);
   if (unresolvedThreadBlock) return unresolvedThreadBlock;
   return "";
+}
+
+function validateExternalMergeBindingFields({ action, preflight, expectedHeadSha }) {
+  if (!isExternalMergeAction(action)) return "";
+  if (!preflight) return "external merge requires merge_preflight entry";
+  if (!/^[0-9a-f]{40}$/i.test(String(preflight.reviewed_base_sha ?? ""))) {
+    return "external merge preflight reviewed_base_sha is missing or invalid";
+  }
+  if (String(preflight.reviewed_head_sha ?? "").toLowerCase() !== expectedHeadSha.toLowerCase()) {
+    return "external merge preflight reviewed_head_sha does not match expected head";
+  }
+  if (!/^[0-9a-f]{64}$/i.test(String(preflight.effective_diff_sha256 ?? ""))) {
+    return "external merge preflight effective_diff_sha256 is missing or invalid";
+  }
+  if (!Number.isInteger(preflight.effective_diff_files) || preflight.effective_diff_files < 0) {
+    return "external merge preflight effective_diff_files is missing or invalid";
+  }
+  return "";
+}
+
+function isExternalMergeAction(action) {
+  return String(action?.idempotency_key ?? "").startsWith("external-merge-preflight:");
+}
+
+function verifyExternalMergeBinding({ result, action, target, expectedHeadSha }) {
+  if (!isExternalMergeAction(action)) return null;
+  const preflight = findMergePreflight(result, target);
+  const reviewedFingerprint = String(preflight.effective_diff_sha256).toLowerCase();
+  const reviewedBaseSha = String(preflight.reviewed_base_sha).toLowerCase();
+  const attempts = positiveInteger(process.env.CLOWNFISH_APPLY_MERGE_BINDING_ATTEMPTS, 6);
+  const delayMs = nonNegativeInteger(process.env.CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS, 2000);
+  let lastReason = "GitHub test merge ref was unavailable";
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const verifiedMainSha = fetchBranchHeadSha(result.repo, "main");
+      if (verifiedMainSha !== reviewedBaseSha) {
+        return {
+          reason: "main changed since external validation and Codex review",
+          reviewed_effective_diff_sha256: reviewedFingerprint,
+          verified_main_sha: verifiedMainSha,
+        };
+      }
+      const pull = fetchPullRequest(result.repo, target);
+      if (String(pull.head?.sha ?? "").toLowerCase() !== expectedHeadSha.toLowerCase()) {
+        return {
+          reason: "pull request head changed during effective merge diff verification",
+          reviewed_effective_diff_sha256: reviewedFingerprint,
+          verified_main_sha: verifiedMainSha,
+        };
+      }
+      const mergeCommitSha = String(pull.merge_commit_sha ?? "");
+      if (!/^[0-9a-f]{40}$/i.test(mergeCommitSha)) {
+        lastReason = "GitHub test merge commit SHA is unavailable";
+      } else {
+        const mergeCommit = ghJson(["api", `repos/${result.repo}/git/commits/${mergeCommitSha}`]);
+        const parents = mergeCommit.parents ?? [];
+        const mergeBaseSha = String(parents[0]?.sha ?? "");
+        const mergeHeadSha = String(parents[1]?.sha ?? "");
+        if (mergeBaseSha.toLowerCase() !== reviewedBaseSha) {
+          lastReason = "GitHub test merge commit is not based on the reviewed main SHA";
+        } else if (mergeHeadSha.toLowerCase() !== expectedHeadSha.toLowerCase()) {
+          lastReason = "GitHub test merge commit does not contain the reviewed PR head";
+        } else {
+          const baseCommit = ghJson(["api", `repos/${result.repo}/git/commits/${mergeBaseSha}`]);
+          const baseEntries = fetchGitTreeEntries(result.repo, baseCommit.tree?.sha);
+          const mergeEntries = fetchGitTreeEntries(result.repo, mergeCommit.tree?.sha);
+          const liveFingerprint = fingerprintTreeEntries(baseEntries, mergeEntries);
+          if (liveFingerprint.files !== preflight.effective_diff_files) {
+            return {
+              reason:
+                `effective merge file count changed since review: reviewed ${preflight.effective_diff_files}, ` +
+                `current ${liveFingerprint.files}`,
+              reviewed_effective_diff_sha256: reviewedFingerprint,
+              live_effective_diff_sha256: liveFingerprint.sha256,
+              verified_main_sha: verifiedMainSha,
+            };
+          }
+          if (liveFingerprint.sha256 !== reviewedFingerprint) {
+            return {
+              reason: "effective merge diff changed since Codex review",
+              reviewed_effective_diff_sha256: reviewedFingerprint,
+              live_effective_diff_sha256: liveFingerprint.sha256,
+              verified_main_sha: verifiedMainSha,
+            };
+          }
+          return {
+            reviewed_effective_diff_sha256: reviewedFingerprint,
+            live_effective_diff_sha256: liveFingerprint.sha256,
+            effective_diff_files: liveFingerprint.files,
+            verified_main_sha: verifiedMainSha,
+            merge_commit_sha: mergeCommitSha,
+          };
+        }
+      }
+    } catch (error) {
+      lastReason = `could not verify GitHub test merge commit: ${String(error?.message ?? error)}`;
+    }
+    if (attempt < attempts && delayMs > 0) sleepMs(delayMs);
+  }
+
+  return {
+    reason: lastReason,
+    reviewed_effective_diff_sha256: reviewedFingerprint,
+  };
+}
+
+function validateExactMergeRule(repo) {
+  const appId = positiveInteger(process.env.CLOWNFISH_APP_ID, 0);
+  if (!appId) return "external merge requires CLOWNFISH_APP_ID for exact-merge rule verification";
+  const rules = ghJson(["api", `repos/${repo}/rules/branches/main`]);
+  const statusRule = (rules ?? []).find((rule) => {
+    if (rule?.type !== "required_status_checks") return false;
+    const parameters = rule.parameters ?? {};
+    if (parameters.strict_required_status_checks_policy !== true) return false;
+    return (parameters.required_status_checks ?? []).some(
+      (check) =>
+        check?.context === EXACT_MERGE_CHECK_NAME &&
+        Number(check?.integration_id) === appId,
+    );
+  });
+  return statusRule
+    ? ""
+    : `main must strictly require ${EXACT_MERGE_CHECK_NAME} from GitHub App ${appId}`;
+}
+
+function publishExactMergeCheck({ repo, action, target, expectedHeadSha, effectiveDiffBinding }) {
+  const appId = positiveInteger(process.env.CLOWNFISH_APP_ID, 0);
+  const mergeCommitSha = effectiveDiffBinding.merge_commit_sha.toLowerCase();
+  const externalId = String(action.idempotency_key);
+  const detailsUrl =
+    process.env.GITHUB_RUN_ID && process.env.GITHUB_REPOSITORY
+      ? `${process.env.GITHUB_SERVER_URL ?? "https://github.com"}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+      : undefined;
+  let pending = findExactMergeCheckCandidate({ repo, mergeCommitSha, externalId, appId });
+  if (pending?.status === "completed" && pending?.conclusion === "success") {
+    const exactMergeCheck = exactMergeCheckRecord(pending, mergeCommitSha, externalId);
+    setActiveExactMergeAuthorization(repo, exactMergeCheck);
+    return exactMergeCheck;
+  }
+  if (!pending) {
+    const pendingPayloadPath = writePayload(`pending-exact-merge-check-${target}`, {
+      name: EXACT_MERGE_CHECK_NAME,
+      head_sha: mergeCommitSha,
+      status: "in_progress",
+      external_id: externalId,
+      ...(detailsUrl ? { details_url: detailsUrl } : {}),
+      output: {
+        title: `Exact merge pending for #${target}`,
+        summary: "Final policy checks passed; merge authorization has not been granted yet.",
+      },
+    });
+    try {
+      pending = ghJson([
+        "api",
+        `repos/${repo}/check-runs`,
+        "--method",
+        "POST",
+        "--input",
+        pendingPayloadPath,
+      ]);
+    } catch (error) {
+      pending = findExactMergeCheckCandidate({ repo, mergeCommitSha, externalId, appId });
+      if (!pending) throw error;
+    }
+  }
+  if (pending?.status === "completed" && pending?.conclusion === "success") {
+    const exactMergeCheck = exactMergeCheckRecord(pending, mergeCommitSha, externalId);
+    setActiveExactMergeAuthorization(repo, exactMergeCheck);
+    return exactMergeCheck;
+  }
+  if (
+    !pending ||
+    pending.name !== EXACT_MERGE_CHECK_NAME ||
+    pending.head_sha?.toLowerCase() !== mergeCommitSha ||
+    pending.external_id !== externalId ||
+    pending.status !== "in_progress" ||
+    pending.conclusion != null ||
+    Number(pending.app?.id) !== appId
+  ) {
+    throw new Error("GitHub returned an invalid pending exact-merge check run");
+  }
+
+  const pendingRecord = exactMergeCheckRecord(pending, mergeCommitSha, externalId);
+  const successPayloadPath = writePayload(`authorize-exact-merge-check-${target}`, {
+    name: EXACT_MERGE_CHECK_NAME,
+    status: "completed",
+    conclusion: "success",
+    ...(detailsUrl ? { details_url: detailsUrl } : {}),
+    output: {
+      title: `Exact merge verified for #${target}`,
+      summary:
+        `Reviewed base ${effectiveDiffBinding.verified_main_sha}, head ${expectedHeadSha}, ` +
+        `test merge ${mergeCommitSha}, effective diff ${effectiveDiffBinding.live_effective_diff_sha256}.`,
+    },
+  });
+  let authorized;
+  try {
+    authorized = ghJson([
+      "api",
+      `repos/${repo}/check-runs/${pending.id}`,
+      "--method",
+      "PATCH",
+      "--input",
+      successPayloadPath,
+    ]);
+  } catch (error) {
+    const recovered = findExactMergeCheck({ repo, mergeCommitSha, externalId, appId });
+    if (recovered) {
+      const exactMergeCheck = exactMergeCheckRecord(recovered, mergeCommitSha, externalId);
+      setActiveExactMergeAuthorization(repo, exactMergeCheck);
+      return exactMergeCheck;
+    }
+    setActiveExactMergeAuthorization(repo, pendingRecord);
+    try {
+      revokeExactMergeCheck({ repo, exactMergeCheck: pendingRecord });
+      clearActiveExactMergeAuthorization(pendingRecord);
+    } catch {
+      // The exit guard retries in case GitHub accepted the authorization update.
+    }
+    throw error;
+  }
+  if (
+    !authorized ||
+    authorized.id !== pending.id ||
+    authorized.name !== EXACT_MERGE_CHECK_NAME ||
+    authorized.head_sha?.toLowerCase() !== mergeCommitSha ||
+    authorized.status !== "completed" ||
+    authorized.conclusion !== "success" ||
+    authorized.external_id !== externalId ||
+    Number(authorized.app?.id) !== appId
+  ) {
+    setActiveExactMergeAuthorization(repo, pendingRecord);
+    try {
+      revokeExactMergeCheck({ repo, exactMergeCheck: pendingRecord });
+      clearActiveExactMergeAuthorization(pendingRecord);
+    } catch {
+      // The exit guard retries cleanup if GitHub accepted the authorization update.
+    }
+    throw new Error("GitHub returned an invalid exact-merge authorization");
+  }
+  const exactMergeCheck = exactMergeCheckRecord(authorized, mergeCommitSha, externalId);
+  setActiveExactMergeAuthorization(repo, exactMergeCheck);
+  return exactMergeCheck;
+}
+
+function findExactMergeCheck({ repo, mergeCommitSha, externalId, appId }) {
+  const candidate = findExactMergeCheckCandidate({ repo, mergeCommitSha, externalId, appId });
+  return candidate?.status === "completed" && candidate?.conclusion === "success"
+    ? candidate
+    : null;
+}
+
+function findExactMergeCheckCandidate({ repo, mergeCommitSha, externalId, appId }) {
+  const response = ghJson([
+    "api",
+    `repos/${repo}/commits/${mergeCommitSha}/check-runs?check_name=${encodeURIComponent(EXACT_MERGE_CHECK_NAME)}&filter=all`,
+  ]);
+  const matching = (response?.check_runs ?? [])
+    .filter(
+      (check) =>
+        check?.name === EXACT_MERGE_CHECK_NAME &&
+        check?.head_sha?.toLowerCase() === mergeCommitSha &&
+        check?.external_id === externalId &&
+        Number(check?.app?.id) === appId,
+    )
+    .sort((left, right) => Number(right?.id ?? 0) - Number(left?.id ?? 0));
+  const latest = matching[0];
+  return latest?.status === "in_progress" ||
+    (latest?.status === "completed" && latest?.conclusion === "success")
+    ? latest
+    : null;
+}
+
+function exactMergeCheckRecord(check, mergeCommitSha, externalId) {
+  return {
+    id: check.id,
+    name: EXACT_MERGE_CHECK_NAME,
+    head_sha: mergeCommitSha,
+    external_id: externalId,
+    app_id: Number(check.app?.id),
+    status: check.status,
+    conclusion: check.conclusion,
+  };
+}
+
+function withExactMergeRevocation({ repo, exactMergeCheck, result }) {
+  try {
+    const revocation = revokeExactMergeCheck({ repo, exactMergeCheck });
+    clearActiveExactMergeAuthorization(exactMergeCheck);
+    return { ...result, exact_merge_revocation: revocation };
+  } catch (error) {
+    const reason = compactErrorText(commandErrorText(error), 500);
+    return {
+      ...result,
+      reason: `${result.reason}; exact-merge revocation failed: ${reason}`,
+      exact_merge_revocation: { status: "failed", reason },
+    };
+  }
+}
+
+function revokeExactMergeCheck({ repo, exactMergeCheck }) {
+  const payloadPath = writePayload(`revoke-exact-merge-check-${exactMergeCheck.id}`, {
+    name: EXACT_MERGE_CHECK_NAME,
+    status: "completed",
+    conclusion: "failure",
+    output: {
+      title: "Exact-merge authorization revoked",
+      summary: "The authorization was not consumed by a verified merge.",
+    },
+  });
+  const revoked = ghJson([
+    "api",
+    `repos/${repo}/check-runs/${exactMergeCheck.id}`,
+    "--method",
+    "PATCH",
+    "--input",
+    payloadPath,
+  ]);
+  if (
+    revoked?.id !== exactMergeCheck.id ||
+    revoked?.name !== EXACT_MERGE_CHECK_NAME ||
+    revoked?.status !== "completed" ||
+    revoked?.conclusion !== "failure" ||
+    Number(revoked?.app?.id) !== exactMergeCheck.app_id
+  ) {
+    throw new Error("GitHub returned an invalid exact-merge revocation");
+  }
+  return {
+    status: "revoked",
+    check_id: revoked.id,
+    head_sha: exactMergeCheck.head_sha,
+    external_id: exactMergeCheck.external_id,
+    app_id: exactMergeCheck.app_id,
+  };
+}
+
+function setActiveExactMergeAuthorization(repo, exactMergeCheck) {
+  activeExactMergeAuthorization = { repo, exactMergeCheck };
+}
+
+function clearActiveExactMergeAuthorization(exactMergeCheck) {
+  if (!activeExactMergeAuthorization) return;
+  if (
+    exactMergeCheck &&
+    Number(activeExactMergeAuthorization.exactMergeCheck?.id) !== Number(exactMergeCheck.id)
+  ) {
+    return;
+  }
+  activeExactMergeAuthorization = null;
+}
+
+function installExactMergeExitCleanup() {
+  const cleanup = () => {
+    if (!activeExactMergeAuthorization || exactMergeCleanupRunning) return;
+    exactMergeCleanupRunning = true;
+    try {
+      revokeExactMergeCheck(activeExactMergeAuthorization);
+      activeExactMergeAuthorization = null;
+    } catch (error) {
+      console.error(
+        `failed to revoke active exact-merge authorization: ${compactErrorText(commandErrorText(error), 500)}`,
+      );
+    } finally {
+      exactMergeCleanupRunning = false;
+    }
+  };
+
+  process.once("exit", cleanup);
+  for (const [signal, exitCode] of [
+    ["SIGINT", 130],
+    ["SIGTERM", 143],
+    ["SIGHUP", 129],
+  ]) {
+    process.once(signal, () => {
+      cleanup();
+      process.exit(exitCode);
+    });
+  }
+}
+
+function verifyActualMergedCommit({ result, action, target, expectedHeadSha, pullRequest }) {
+  if (!isExternalMergeAction(action)) return null;
+  const preflight = findMergePreflight(result, target);
+  const bindingBlock = validateExternalMergeBindingFields({
+    action,
+    preflight,
+    expectedHeadSha,
+  });
+  if (bindingBlock) return { reason: bindingBlock };
+  if (String(pullRequest?.head?.sha ?? "").toLowerCase() !== expectedHeadSha.toLowerCase()) {
+    return { reason: "merged pull request head does not match the reviewed head" };
+  }
+  const reviewedFingerprint = String(preflight.effective_diff_sha256).toLowerCase();
+  const reviewedBaseSha = String(preflight.reviewed_base_sha).toLowerCase();
+  const mergeCommitSha = String(pullRequest?.merge_commit_sha ?? "").toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(mergeCommitSha)) {
+    return {
+      reason: "merged pull request does not expose a valid squash commit SHA",
+      reviewed_effective_diff_sha256: reviewedFingerprint,
+    };
+  }
+  try {
+    const mergeCommit = ghJson(["api", `repos/${result.repo}/git/commits/${mergeCommitSha}`]);
+    const parents = mergeCommit.parents ?? [];
+    if (parents.length !== 1 || String(parents[0]?.sha ?? "").toLowerCase() !== reviewedBaseSha) {
+      return {
+        reason: "actual squash commit is not based on the reviewed main SHA",
+        reviewed_effective_diff_sha256: reviewedFingerprint,
+        verified_parent_sha: String(parents[0]?.sha ?? "").toLowerCase() || null,
+      };
+    }
+    const parentCommit = ghJson(["api", `repos/${result.repo}/git/commits/${reviewedBaseSha}`]);
+    const parentEntries = fetchGitTreeEntries(result.repo, parentCommit.tree?.sha);
+    const mergedEntries = fetchGitTreeEntries(result.repo, mergeCommit.tree?.sha);
+    const mergedFingerprint = fingerprintTreeEntries(parentEntries, mergedEntries);
+    if (
+      mergedFingerprint.files !== preflight.effective_diff_files ||
+      mergedFingerprint.sha256 !== reviewedFingerprint
+    ) {
+      return {
+        reason: "actual squash commit diff does not match the reviewed effective diff",
+        reviewed_effective_diff_sha256: reviewedFingerprint,
+        merged_effective_diff_sha256: mergedFingerprint.sha256,
+        verified_parent_sha: reviewedBaseSha,
+      };
+    }
+    return {
+      reviewed_effective_diff_sha256: reviewedFingerprint,
+      merged_effective_diff_sha256: mergedFingerprint.sha256,
+      verified_parent_sha: reviewedBaseSha,
+    };
+  } catch (error) {
+    return {
+      reason: `could not verify actual squash commit: ${compactErrorText(String(error?.message ?? error), 500)}`,
+      reviewed_effective_diff_sha256: reviewedFingerprint,
+    };
+  }
+}
+
+function fetchGitTreeEntries(repo, treeSha) {
+  if (!/^[0-9a-f]{40}$/i.test(String(treeSha ?? ""))) {
+    throw new Error("GitHub commit tree SHA is missing or invalid");
+  }
+  const response = ghJson(["api", `repos/${repo}/git/trees/${treeSha}?recursive=1`]);
+  if (response.truncated) throw new Error("GitHub recursive tree response was truncated");
+  const entries = new Map();
+  for (const entry of response.tree ?? []) {
+    if (entry.type === "tree") continue;
+    const filePath = String(entry.path ?? "");
+    const mode = String(entry.mode ?? "");
+    const type = String(entry.type ?? "");
+    const sha = String(entry.sha ?? "").toLowerCase();
+    if (!filePath || !mode || !type || !/^[0-9a-f]{40}$/i.test(sha)) {
+      throw new Error("GitHub tree contains an invalid entry");
+    }
+    entries.set(filePath, `${mode}:${type}:${sha}`);
+  }
+  return entries;
+}
+
+function fingerprintTreeEntries(baseEntries, resultEntries) {
+  const changes = [];
+  const paths = [...new Set([...baseEntries.keys(), ...resultEntries.keys()])].sort();
+  for (const filePath of paths) {
+    const before = baseEntries.get(filePath) ?? null;
+    const after = resultEntries.get(filePath) ?? null;
+    if (before === after) continue;
+    changes.push([filePath, before, after]);
+  }
+  const serialized = `${changes.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
+  return {
+    files: changes.length,
+    sha256: sha256(serialized),
+    changes,
+  };
 }
 
 function findMergePreflight(result, target) {
@@ -1158,13 +1954,7 @@ function ghWithRetry(ghArgs, attempts = 6) {
   let lastError;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     try {
-      return execFileSync("gh", ghArgs, {
-        cwd: repoRoot(),
-        encoding: "utf8",
-        env: githubCliEnv(),
-        maxBuffer: 64 * 1024 * 1024,
-        stdio: ["ignore", "pipe", "pipe"],
-      }).trim();
+      return ghOnce(ghArgs);
     } catch (error) {
       lastError = error;
       if (!shouldRetryGh(error) || attempt === attempts - 1) throw error;
@@ -1173,6 +1963,16 @@ function ghWithRetry(ghArgs, attempts = 6) {
     }
   }
   throw lastError;
+}
+
+function ghOnce(ghArgs) {
+  return execFileSync("gh", ghArgs, {
+    cwd: repoRoot(),
+    encoding: "utf8",
+    env: githubCliEnv(),
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
 }
 
 function githubCliEnv() {
@@ -1241,12 +2041,15 @@ function shouldRetryGh(error) {
   return (
     message.includes("was submitted too quickly") ||
     message.includes("secondary rate") ||
-    message.includes("Base branch was modified") ||
-    message.includes("Head branch was modified") ||
     /\bHTTP (?:502|503|504)\b/i.test(message) ||
     /\b(?:bad gateway|service unavailable|gateway timeout)\b/i.test(message) ||
     /error connecting to api\.github\.com/i.test(message)
   );
+}
+
+function isMergeRefMovementError(error) {
+  const text = commandErrorText(error);
+  return text.includes("Base branch was modified") || text.includes("Head branch was modified");
 }
 
 function sleepMs(milliseconds) {

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { assertAllowedOwner, parseArgs, parseJob, repoRoot, validateJob } from "./lib.mjs";
 import { hasSecuritySensitiveText } from "./security-sensitive.mjs";
 
@@ -86,7 +87,10 @@ try {
   }
 
   stage("checkout exact PR head", () => checkoutExactPullHead({ repo: sourceJob.frontmatter.repo, pullRequest, expectedHeadSha: pull.head.sha }));
-  const currentMainSha = run("git", ["rev-parse", `origin/${baseBranch}`], { cwd: targetDir }).trim();
+  const currentMainSha = run("git", ["rev-parse", `origin/${baseBranch}`], {
+    cwd: targetDir,
+    env: gitIntegrityEnv(),
+  }).trim();
   const baseDriftAllowed = currentMainSha !== pull.base.sha && canTolerateBaseDrift(view);
   if (currentMainSha !== pull.base.sha && !baseDriftAllowed) {
     writeBlockedArtifacts({
@@ -105,7 +109,9 @@ try {
     }),
   );
   stage("prepare target toolchain", () => prepareTargetToolchain(targetDir));
-  const validationCommands = stage("target validation", () => runValidation({ targetDir, baseBranch }));
+  const validationCommands = stage("target validation", () =>
+    runValidation({ targetDir, reviewContext }),
+  );
   const codexReview = stage("Codex review", () =>
     runCodexReview({
       repo: sourceJob.frontmatter.repo,
@@ -125,6 +131,9 @@ try {
     });
     process.exit(0);
   }
+  stage("verify synthetic review checkout", () =>
+    verifySyntheticReviewCheckout({ targetDir, reviewContext }),
+  );
 
   const reviewedHeadSha = pull.head.sha;
   const reviewedState = String(pull.state ?? "").toLowerCase();
@@ -165,10 +174,50 @@ try {
     process.exit(0);
   }
 
+  const verifiedMainSha = stage("refresh target main after review", () =>
+    refreshTargetMain({ targetDir, baseBranch }),
+  );
+  if (verifiedMainSha !== reviewContext.reviewedBaseSha) {
+    writeBlockedArtifacts({
+      reason:
+        `origin/${baseBranch} changed while validation or review was running: reviewed ` +
+        `${reviewContext.reviewedBaseSha}, current ${verifiedMainSha}`,
+      validationCommands,
+      codexReview,
+      currentMainSha: verifiedMainSha,
+    });
+    process.exit(0);
+  }
+  const verifiedMergeContext = stage("verify effective diff against latest main", () =>
+    computeEffectiveMergeContext({
+      targetDir,
+      baseSha: verifiedMainSha,
+      exactHeadSha: reviewedHeadSha,
+    }),
+  );
+  if (verifiedMergeContext.effectiveDiffSha256 !== reviewContext.effectiveDiffSha256) {
+    writeBlockedArtifacts({
+      reason:
+        `effective merge diff changed while review was running: reviewed ${reviewContext.effectiveDiffSha256}, ` +
+        `current ${verifiedMergeContext.effectiveDiffSha256}`,
+      validationCommands,
+      codexReview,
+      currentMainSha: verifiedMainSha,
+    });
+    process.exit(0);
+  }
+  reviewContext.verifiedMainSha = verifiedMainSha;
+  reviewContext.verifiedMergeTreeSha = verifiedMergeContext.mergeTreeSha;
+  reviewContext.baseDriftProof = {
+    status: "unchanged",
+    reviewed_base_sha: reviewContext.reviewedBaseSha,
+    current_base_sha: verifiedMainSha,
+  };
+
   pull = refreshedPull;
   issue = refreshedIssue;
   view = refreshedView;
-  const finalBaseDriftAllowed = currentMainSha !== pull.base.sha && canTolerateBaseDrift(view);
+  const finalBaseDriftAllowed = verifiedMainSha !== pull.base.sha && canTolerateBaseDrift(view);
   const rehydratedAt = new Date().toISOString();
   const result = buildMergeResult({
     sourceJob,
@@ -179,7 +228,7 @@ try {
     pullRequest,
     validationCommands,
     codexReview,
-    currentMainSha,
+    currentMainSha: verifiedMainSha,
     baseDriftAllowed: finalBaseDriftAllowed,
     reviewContext,
   });
@@ -189,13 +238,16 @@ try {
     reviewed_at: rehydratedAt,
     rehydrated_at: rehydratedAt,
     reviewed_head_sha: pull.head.sha,
-    reviewed_base_sha: pull.base.sha,
-    current_main_sha: currentMainSha,
+    reviewed_base_sha: reviewContext.reviewedBaseSha,
+    current_main_sha: verifiedMainSha,
+    pull_request_base_sha: pull.base.sha,
     base_drift_allowed: finalBaseDriftAllowed,
     synthetic_merge_sha: reviewContext.syntheticMergeSha,
     synthetic_merge_tree_sha: reviewContext.mergeTreeSha,
     raw_diff_files: reviewContext.rawDiffFiles,
     effective_diff_files: reviewContext.effectiveDiffFiles,
+    effective_diff_sha256: reviewContext.effectiveDiffSha256,
+    base_drift_proof: reviewContext.baseDriftProof,
     validation_commands: validationCommands,
     codex_review: {
       status: codexReview.status,
@@ -246,6 +298,7 @@ function writeBlockedArtifacts({ reason, validationCommands = [], codexReview = 
     synthetic_merge_tree_sha: reviewContext?.mergeTreeSha ?? null,
     raw_diff_files: reviewContext?.rawDiffFiles ?? null,
     effective_diff_files: reviewContext?.effectiveDiffFiles ?? null,
+    effective_diff_sha256: reviewContext?.effectiveDiffSha256 ?? null,
     validation_commands: validationCommands,
     codex_review: codexReview
       ? { status: codexReview.status ?? "unknown", findings: Array.isArray(codexReview.findings) ? codexReview.findings.length : null }
@@ -531,14 +584,20 @@ function ensureMergeBase({ cwd, baseBranch, pullRequest, ref }) {
 
 function prepareSyntheticMergeReview({ targetDir, baseBranch, currentMainSha, exactHeadSha }) {
   const baseRef = `origin/${baseBranch}`;
+  const gitConfigSha256 = localGitConfigFingerprint(targetDir);
   const rawDiffFiles = changedFileCount({ cwd: targetDir, baseRef, targetRef: exactHeadSha });
-  const mergeTreeSha = run("git", ["merge-tree", "--write-tree", currentMainSha, exactHeadSha], {
-    cwd: targetDir,
-    timeout: VALIDATION_TIMEOUT_MS,
-  }).trim();
-  if (!/^[0-9a-f]{40}$/i.test(mergeTreeSha)) {
-    throw new Error(`synthetic merge returned invalid tree SHA: ${mergeTreeSha || "empty"}`);
-  }
+  const mergeContext = computeEffectiveMergeContext({
+    targetDir,
+    baseSha: currentMainSha,
+    exactHeadSha,
+  });
+  const {
+    mergeTreeSha,
+    effectiveDiffFiles,
+    effectiveDiffSha256,
+    resultEntries,
+    changedFiles,
+  } = mergeContext;
   const syntheticMergeSha = run(
     "git",
     [
@@ -573,13 +632,188 @@ function prepareSyntheticMergeReview({ targetDir, baseBranch, currentMainSha, ex
       `synthetic merge binding mismatch: expected tree ${mergeTreeSha} on base ${currentMainSha}, got tree ${checkedOutTree} on base ${syntheticParent}`,
     );
   }
-  const effectiveDiffFiles = changedFileCount({ cwd: targetDir, baseRef, targetRef: "HEAD" });
-  return { syntheticMergeSha, mergeTreeSha, rawDiffFiles, effectiveDiffFiles };
+  return {
+    syntheticMergeSha,
+    mergeTreeSha,
+    rawDiffFiles,
+    effectiveDiffFiles,
+    effectiveDiffSha256,
+    reviewedBaseSha: currentMainSha,
+    expectedTreeEntries: resultEntries,
+    changedFiles,
+    gitConfigSha256,
+  };
 }
 
 function changedFileCount({ cwd, baseRef, targetRef }) {
   const output = run("git", ["diff", "--name-only", `${baseRef}...${targetRef}`], { cwd }).trim();
   return output ? output.split(/\r?\n/).length : 0;
+}
+
+function computeEffectiveMergeContext({ targetDir, baseSha, exactHeadSha }) {
+  const mergeTreeSha = run("git", ["merge-tree", "--write-tree", baseSha, exactHeadSha], {
+    cwd: targetDir,
+    env: gitIntegrityEnv(),
+    timeout: VALIDATION_TIMEOUT_MS,
+  }).trim();
+  if (!/^[0-9a-f]{40}$/i.test(mergeTreeSha)) {
+    throw new Error(`synthetic merge returned invalid tree SHA: ${mergeTreeSha || "empty"}`);
+  }
+  const fingerprint = effectiveTreeFingerprint({
+    cwd: targetDir,
+    baseTreeish: baseSha,
+    resultTreeish: mergeTreeSha,
+  });
+  return {
+    mergeTreeSha,
+    effectiveDiffFiles: fingerprint.files,
+    effectiveDiffSha256: fingerprint.sha256,
+    changedFiles: fingerprint.changes.map(([filePath]) => filePath),
+    resultEntries: fingerprint.resultEntries,
+  };
+}
+
+function effectiveTreeFingerprint({ cwd, baseTreeish, resultTreeish }) {
+  return fingerprintTreeEntries(
+    readGitTreeEntries({ cwd, treeish: baseTreeish }),
+    readGitTreeEntries({ cwd, treeish: resultTreeish }),
+  );
+}
+
+function readGitTreeEntries({ cwd, treeish }) {
+  const output = run("git", ["ls-tree", "-r", "-z", treeish], {
+    cwd,
+    env: gitIntegrityEnv(),
+    timeout: VALIDATION_TIMEOUT_MS,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const entries = new Map();
+  for (const record of output.split("\0").filter(Boolean)) {
+    const match = record.match(/^([0-7]{6}) ([a-z]+) ([0-9a-f]{40})\t([\s\S]+)$/i);
+    if (!match) throw new Error(`could not parse git tree entry for ${treeish}`);
+    entries.set(match[4], `${match[1]}:${match[2]}:${match[3].toLowerCase()}`);
+  }
+  return entries;
+}
+
+function fingerprintTreeEntries(baseEntries, resultEntries) {
+  const changes = [];
+  const paths = [...new Set([...baseEntries.keys(), ...resultEntries.keys()])].sort();
+  for (const filePath of paths) {
+    const before = baseEntries.get(filePath) ?? null;
+    const after = resultEntries.get(filePath) ?? null;
+    if (before === after) continue;
+    changes.push([filePath, before, after]);
+  }
+  const serialized = `${changes.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
+  return {
+    files: changes.length,
+    sha256: createHash("sha256").update(serialized).digest("hex"),
+    changes,
+    resultEntries,
+  };
+}
+
+function verifySyntheticReviewCheckout({ targetDir, reviewContext }) {
+  const env = gitIntegrityEnv();
+  const head = run("git", ["rev-parse", "HEAD"], { cwd: targetDir, env }).trim();
+  const tree = run("git", ["rev-parse", "HEAD^{tree}"], { cwd: targetDir, env }).trim();
+  const parent = run("git", ["rev-parse", "HEAD^"], { cwd: targetDir, env }).trim();
+  if (
+    head !== reviewContext.syntheticMergeSha ||
+    tree !== reviewContext.mergeTreeSha ||
+    parent !== reviewContext.reviewedBaseSha ||
+    localGitConfigFingerprint(targetDir) !== reviewContext.gitConfigSha256
+  ) {
+    throw new Error(
+      `synthetic review checkout changed during validation: expected ${reviewContext.syntheticMergeSha} ` +
+        `on ${reviewContext.reviewedBaseSha} with tree ${reviewContext.mergeTreeSha}`,
+    );
+  }
+  verifyTrackedFilesystem({
+    targetDir,
+    expectedEntries: reviewContext.expectedTreeEntries,
+  });
+}
+
+function refreshTargetMain({ targetDir, baseBranch }) {
+  run("git", ["fetch", "--no-tags", "origin", `${baseBranch}:refs/remotes/origin/${baseBranch}`], {
+    cwd: targetDir,
+    env: gitIntegrityEnv(),
+    timeout: VALIDATION_TIMEOUT_MS,
+  });
+  const sha = run("git", ["rev-parse", `origin/${baseBranch}`], {
+    cwd: targetDir,
+    env: gitIntegrityEnv(),
+  }).trim();
+  if (!/^[0-9a-f]{40}$/i.test(sha)) {
+    throw new Error(`refreshed origin/${baseBranch} returned invalid SHA: ${sha || "empty"}`);
+  }
+  return sha;
+}
+
+function verifyTrackedFilesystem({ targetDir, expectedEntries }) {
+  if (!(expectedEntries instanceof Map) || expectedEntries.size === 0) {
+    throw new Error("synthetic review tree entries are unavailable");
+  }
+  const root = `${path.resolve(targetDir)}${path.sep}`;
+  for (const [filePath, entry] of expectedEntries) {
+    const fullPath = path.resolve(targetDir, filePath);
+    if (!fullPath.startsWith(root)) throw new Error(`synthetic review tree contains unsafe path ${filePath}`);
+    const [mode, type, expectedSha] = String(entry).split(":");
+    if (type !== "blob" || !["100644", "100755", "120000"].includes(mode)) {
+      throw new Error(`synthetic review tree contains unsupported entry ${mode}:${type} at ${filePath}`);
+    }
+    let stats;
+    try {
+      stats = fs.lstatSync(fullPath);
+    } catch {
+      throw new Error(`synthetic review checkout is missing tracked path ${filePath}`);
+    }
+    let bytes;
+    if (mode === "120000") {
+      if (!stats.isSymbolicLink()) throw new Error(`synthetic review checkout changed tracked type at ${filePath}`);
+      bytes = fs.readlinkSync(fullPath, { encoding: "buffer" });
+    } else {
+      if (!stats.isFile() || stats.isSymbolicLink()) {
+        throw new Error(`synthetic review checkout changed tracked type at ${filePath}`);
+      }
+      const executable = (stats.mode & 0o111) !== 0;
+      if ((mode === "100755") !== executable) {
+        throw new Error(`synthetic review checkout changed executable mode at ${filePath}`);
+      }
+      bytes = fs.readFileSync(fullPath);
+    }
+    const actualSha = gitBlobSha(bytes);
+    if (actualSha !== expectedSha) {
+      throw new Error(`synthetic review checkout changed tracked bytes at ${filePath}`);
+    }
+  }
+}
+
+function gitBlobSha(bytes) {
+  return createHash("sha1")
+    .update(`blob ${bytes.length}\0`)
+    .update(bytes)
+    .digest("hex");
+}
+
+function gitIntegrityEnv() {
+  return {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_NO_REPLACE_OBJECTS: "1",
+  };
+}
+
+function localGitConfigFingerprint(cwd) {
+  const config = run("git", ["config", "--local", "--list", "--null"], {
+    cwd,
+    env: gitIntegrityEnv(),
+    maxBuffer: 1024 * 1024,
+  });
+  return createHash("sha256").update(config).digest("hex");
 }
 
 function isShallowRepository(cwd) {
@@ -605,23 +839,37 @@ function prepareTargetToolchain(cwd) {
   run("corepack", ["prepare", packageManager, "--activate"], { cwd, env, timeout: INSTALL_TIMEOUT_MS });
   run(
     "pnpm",
-    ["install", "--frozen-lockfile", "--prefer-offline", "--config.engine-strict=false", "--config.enable-pre-post-scripts=true"],
+    ["install", "--frozen-lockfile", "--prefer-offline", "--config.engine-strict=false", "--config.enable-pre-post-scripts=false"],
     { cwd, env, timeout: INSTALL_TIMEOUT_MS },
   );
 }
 
-function runValidation({ targetDir, baseBranch }) {
+function runValidation({ targetDir, reviewContext }) {
   const env = validationEnv();
-  run("pnpm", ["check:changed"], { cwd: targetDir, env, timeout: VALIDATION_TIMEOUT_MS });
-  run("git", ["diff", "--check", `origin/${baseBranch}...HEAD`], { cwd: targetDir, env, timeout: VALIDATION_TIMEOUT_MS });
+  const baseSha = reviewContext.reviewedBaseSha;
+  const headSha = reviewContext.syntheticMergeSha;
+  run("pnpm", ["check:changed", "--base", baseSha, "--head", headSha], {
+    cwd: targetDir,
+    env,
+    timeout: VALIDATION_TIMEOUT_MS,
+  });
+  run("git", ["diff", "--check", `${baseSha}...${headSha}`], {
+    cwd: targetDir,
+    env,
+    timeout: VALIDATION_TIMEOUT_MS,
+  });
   run("git", ["diff", "--check"], { cwd: targetDir, env, timeout: VALIDATION_TIMEOUT_MS });
-  return ["pnpm check:changed", `git diff --check origin/${baseBranch}...HEAD`, "git diff --check"];
+  return [
+    `pnpm check:changed --base ${baseSha} --head ${headSha}`,
+    `git diff --check ${baseSha}...${headSha}`,
+    "git diff --check",
+  ];
 }
 
 function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sourceJob, reviewContext }) {
   const schemaPath = path.join(runDir, "codex-review.schema.json");
   const outputPath = path.join(runDir, "codex-review.json");
-  const defaultCodexReviewSandbox = process.env.GITHUB_ACTIONS === "true" ? "danger-full-access" : "read-only";
+  const defaultCodexReviewSandbox = "read-only";
   const codexReviewSandbox = process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_CODEX_SANDBOX ?? defaultCodexReviewSandbox;
   writeJson(schemaPath, {
     $schema: "https://json-schema.org/draft/2020-12/schema",
@@ -652,9 +900,10 @@ function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sour
     "/review",
     "",
     `Review openclaw PR #${pullRequest} in ${repo}. This is a read-only external merge preflight.`,
-    `HEAD is an ephemeral one-parent squash-result commit built from the exact PR head and current origin/${baseBranch}.`,
-    `Review only the effective diff origin/${baseBranch}...HEAD; the exact GitHub PR head is bound through merge tree ${reviewContext.mergeTreeSha}.`,
+    `The checkout is an ephemeral one-parent squash-result commit built from the exact PR head and reviewed base ${reviewContext.reviewedBaseSha}.`,
+    `Review only the immutable effective diff ${reviewContext.reviewedBaseSha}...${reviewContext.syntheticMergeSha}; do not use mutable branch refs.`,
     `Synthetic commit: ${reviewContext.syntheticMergeSha}; raw PR diff files: ${reviewContext.rawDiffFiles}; effective merge diff files: ${reviewContext.effectiveDiffFiles}.`,
+    `Effective diff fingerprint: ${reviewContext.effectiveDiffSha256}.`,
     "",
     "The preflight already verified that the PR has no top-level or inline review comments, no unresolved review threads, no review-bot findings, no security signal, and passing GitHub checks.",
     "Do not mutate GitHub or the checkout. Do not run validation commands.",
@@ -708,8 +957,12 @@ function buildMergeResult({
 }) {
   const evidence = [
     `Exact PR head ${pull.head.sha} checked out from refs/pull/${pullRequest}/head.`,
-    `Validation and Codex review ran on synthetic squash-result commit ${reviewContext.syntheticMergeSha} with origin/main ${currentMainSha} as its parent and merge tree ${reviewContext.mergeTreeSha} computed from exact PR head ${pull.head.sha}.`,
+    `Validation and Codex review ran on synthetic squash-result commit ${reviewContext.syntheticMergeSha} with origin/main ${reviewContext.reviewedBaseSha} as its parent and merge tree ${reviewContext.mergeTreeSha} computed from exact PR head ${pull.head.sha}.`,
     `Review surface narrowed from ${reviewContext.rawDiffFiles} raw PR file(s) to ${reviewContext.effectiveDiffFiles} effective merge file(s).`,
+    `Effective blob delta ${reviewContext.effectiveDiffSha256} was unchanged after refreshing origin/main to ${reviewContext.verifiedMainSha}.`,
+    reviewContext.baseDriftProof.drift_commit_count > 0
+      ? `Review-base reuse accepted ${reviewContext.baseDriftProof.drift_commit_count} bounded disjoint main commit(s).`
+      : "Review base still matched current origin/main after review.",
     baseDriftAllowed
       ? `PR base ${pull.base.sha} drifted from origin/main ${currentMainSha}; exact head remained mergeable with clean latest checks and validation ran against origin/main.`
       : `PR base ${pull.base.sha} matched current origin/main ${currentMainSha} before validation.`,
@@ -727,7 +980,7 @@ function buildMergeResult({
         target: `#${pullRequest}`,
         action: "merge_canonical",
         status: "planned",
-        idempotency_key: `external-merge-preflight:${sourceJob.frontmatter.repo}#${pullRequest}:${pull.head.sha}:${currentMainSha}:${reviewContext.mergeTreeSha}`,
+        idempotency_key: `external-merge-preflight:${sourceJob.frontmatter.repo}#${pullRequest}:${pull.head.sha}:${reviewContext.effectiveDiffSha256}`,
         expected_head_sha: pull.head.sha,
         classification: "canonical",
         target_kind: "pull_request",
@@ -747,6 +1000,10 @@ function buildMergeResult({
     merge_preflight: [
       {
         target: `#${pullRequest}`,
+        reviewed_base_sha: reviewContext.reviewedBaseSha,
+        reviewed_head_sha: pull.head.sha,
+        effective_diff_sha256: reviewContext.effectiveDiffSha256,
+        effective_diff_files: reviewContext.effectiveDiffFiles,
         security_status: "cleared",
         security_evidence: [
           "Final deterministic security scan after validation and Codex review found no matching signal in the PR title, body, labels, issue comments, reviews, or inline review comments.",
@@ -1432,7 +1689,13 @@ function ghReadEnv() {
 }
 
 function validationEnv() {
-  const env = { ...process.env, OPENCLAW_LOCAL_CHECK: "0" };
+  const env = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_NO_REPLACE_OBJECTS: "1",
+    OPENCLAW_LOCAL_CHECK: "0",
+  };
   for (const key of [
     "GH_TOKEN",
     "GITHUB_TOKEN",
@@ -1447,7 +1710,12 @@ function validationEnv() {
 }
 
 function codexEnv() {
-  const env = { ...process.env };
+  const env = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_NO_REPLACE_OBJECTS: "1",
+  };
   for (const key of [
     "GH_TOKEN",
     "GITHUB_TOKEN",

--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -633,6 +633,20 @@ function validateMergePreflight(mergePreflight, mergeActions, failures) {
       failures.push(`${target} merge action missing merge_preflight entry`);
       continue;
     }
+    if (String(action.idempotency_key ?? "").startsWith("external-merge-preflight:")) {
+      if (!/^[0-9a-f]{40}$/i.test(String(preflight.reviewed_base_sha ?? ""))) {
+        failures.push(`${target} external merge_preflight.reviewed_base_sha must be a 40-character Git SHA`);
+      }
+      if (String(preflight.reviewed_head_sha ?? "").toLowerCase() !== expectedHeadSha.toLowerCase()) {
+        failures.push(`${target} external merge_preflight.reviewed_head_sha must match expected_head_sha`);
+      }
+      if (!/^[0-9a-f]{64}$/i.test(String(preflight.effective_diff_sha256 ?? ""))) {
+        failures.push(`${target} external merge_preflight.effective_diff_sha256 must be a SHA-256 digest`);
+      }
+      if (!Number.isInteger(preflight.effective_diff_files) || preflight.effective_diff_files < 0) {
+        failures.push(`${target} external merge_preflight.effective_diff_files must be a non-negative integer`);
+      }
+    }
     if (preflight.security_status !== "cleared") {
       failures.push(`${target} merge_preflight.security_status must be cleared`);
     }

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -8,6 +9,26 @@ import test from "node:test";
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const EXPECTED_HEAD_SHA = "a".repeat(40);
 const CHANGED_HEAD_SHA = "b".repeat(40);
+const CURRENT_MAIN_SHA = "c".repeat(40);
+const TEST_MERGE_SHA = "d".repeat(40);
+const SQUASH_COMMIT_SHA = "6".repeat(40);
+const SQUASH_TREE_SHA = "0".repeat(40);
+const BASE_TREE_SHA = "e".repeat(40);
+const MERGE_TREE_SHA = "f".repeat(40);
+const CURRENT_MAIN_TREE_SHA = "8".repeat(40);
+const REVIEWED_BASE_SHA = "4".repeat(40);
+const REVIEWED_BASE_TREE_SHA = "5".repeat(40);
+const BASE_BLOB_SHA = "1".repeat(40);
+const MERGE_BLOB_SHA = "2".repeat(40);
+const EFFECTIVE_DIFF_SHA256 = createHash("sha256")
+  .update(
+    `${JSON.stringify([
+      "src/cli/effective.ts",
+      `100644:blob:${BASE_BLOB_SHA}`,
+      `100644:blob:${MERGE_BLOB_SHA}`,
+    ])}\n`,
+  )
+  .digest("hex");
 
 test("apply-result maps the applicator token into gh CLI auth", () => {
   const source = fs.readFileSync(path.join(repoRoot, "scripts", "apply-result.mjs"), "utf8");
@@ -543,6 +564,524 @@ test("apply-result pins a clean merge to the reviewed PR head", () => {
   assert.deepEqual(mergeArgs.slice(-3), ["--squash", "--match-head-commit", EXPECTED_HEAD_SHA]);
 });
 
+test("apply-result verifies an external preflight effective diff before merge", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "executed");
+  assert.equal(report.actions[0].effective_diff_sha256, EFFECTIVE_DIFF_SHA256);
+  assert.equal(report.actions[0].verified_main_sha, CURRENT_MAIN_SHA);
+  assert.equal(report.actions[0].exact_merge_check.name, "clownfish/exact-merge");
+  assert.equal(report.actions[0].exact_merge_check.head_sha, TEST_MERGE_SHA);
+  assert.equal(report.actions[0].exact_merge_check.app_id, 3535277);
+  const ghCalls = fs
+    .readFileSync(callLogPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  const authorizationIndex = ghCalls.findIndex(
+    (args) =>
+      args[0] === "api" &&
+      args[1] === "repos/openclaw/openclaw/check-runs/4242" &&
+      args.includes("PATCH"),
+  );
+  const mergeIndex = ghCalls.findIndex((args) => args[0] === "pr" && args[1] === "merge");
+  assert.ok(authorizationIndex >= 0);
+  assert.equal(mergeIndex, authorizationIndex + 1);
+});
+
+test("apply-result blocks external merge when the strict exact-merge rule is missing", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    exactMergeRule: false,
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /main must strictly require clownfish\/exact-merge/);
+  assert.equal(fs.existsSync(mergeStatePath), false);
+});
+
+test("apply-result blocks an external preflight when the effective diff changes", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    mergeBlobSha: "3".repeat(40),
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+    env: { CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0" },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(report.actions[0].reason, "effective merge diff changed since Codex review");
+  assert.equal(fs.existsSync(mergeStatePath), false);
+});
+
+test("apply-result blocks a stale GitHub test merge even when changed paths are disjoint", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    mergeBaseSha: "9".repeat(40),
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /test merge commit is not based on the reviewed main SHA/);
+  assert.equal(fs.existsSync(mergeStatePath), false);
+});
+
+test("apply-result blocks any main drift since external review", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    reviewedBaseSha: REVIEWED_BASE_SHA,
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(
+    resultPath,
+    `${JSON.stringify(
+      mergeResultJson({ externalBinding: true, reviewedBaseSha: REVIEWED_BASE_SHA }),
+      null,
+      2,
+    )}\n`,
+  );
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(report.actions[0].reason, "main changed since external validation and Codex review");
+  assert.equal(fs.existsSync(mergeStatePath), false);
+});
+
+test("apply-result blocks overlapping main drift since external review", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    reviewedBaseSha: REVIEWED_BASE_SHA,
+    currentMainExtraPath: "src/cli/help.ts",
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(
+    resultPath,
+    `${JSON.stringify(
+      mergeResultJson({ externalBinding: true, reviewedBaseSha: REVIEWED_BASE_SHA }),
+      null,
+      2,
+    )}\n`,
+  );
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(report.actions[0].reason, "main changed since external validation and Codex review");
+  assert.equal(fs.existsSync(mergeStatePath), false);
+});
+
+test("apply-result does not retry when GitHub reports merge ref movement", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    mergeFailure: "Base branch was modified. Review and try the merge again.",
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    mergeStatePath,
+    env: { CLOWNFISH_GH_RETRY_BASE_MS: "1" },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(report.actions[0].retry_recommended, true);
+  const ghCalls = fs
+    .readFileSync(callLogPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  assert.equal(
+    ghCalls.filter((args) => args[0] === "pr" && args[1] === "merge").length,
+    1,
+  );
+});
+
+test("apply-result revokes the exact-merge check when an external merge is not accepted", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    mergeFailure: "Base branch was modified. Review and try the merge again.",
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(report.actions[0].exact_merge_revocation.status, "revoked");
+  assert.equal(report.actions[0].exact_merge_revocation.check_id, 4242);
+  const ghCalls = fs
+    .readFileSync(callLogPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  assert.equal(
+    ghCalls.filter(
+      (args) =>
+        args[0] === "api" &&
+        args[1] === "repos/openclaw/openclaw/check-runs/4242" &&
+        args.includes("PATCH"),
+    ).length,
+    2,
+  );
+});
+
+test("apply-result does not retry merge-time HTTP 503 responses", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    mergeFailure: "HTTP 503: Service Unavailable",
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    mergeStatePath,
+    env: { CLOWNFISH_GH_RETRY_BASE_MS: "1" },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /merge command failed without retry/);
+  const ghCalls = fs
+    .readFileSync(callLogPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  assert.equal(
+    ghCalls.filter((args) => args[0] === "pr" && args[1] === "merge").length,
+    1,
+  );
+});
+
+test("apply-result requires post-merge GitHub proof", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    mergeSucceedsWithoutState: true,
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(report.actions[0].reason, "merge command returned without a verified merged pull request");
+  assert.equal(report.actions[0].exact_merge_revocation.status, "revoked");
+  const ghCalls = fs
+    .readFileSync(callLogPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  assert.equal(
+    ghCalls.filter(
+      (args) =>
+        args[0] === "api" &&
+        args[1] === "repos/openclaw/openclaw/check-runs/4242" &&
+        args.includes("PATCH"),
+    ).length,
+    2,
+  );
+});
+
+test("apply-result verifies the actual squash commit tree after merge", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    squashBlobSha: "9".repeat(40),
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(report.actions[0].reason, "actual squash commit diff does not match the reviewed effective diff");
+  assert.equal(fs.existsSync(mergeStatePath), true);
+});
+
+test("apply-result verifies an already-merged external preflight result", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(mergeStatePath, "merged");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "executed");
+  assert.equal(report.actions[0].merge_commit_sha, SQUASH_COMMIT_SHA);
+  assert.equal(report.actions[0].effective_diff_sha256, EFFECTIVE_DIFF_SHA256);
+});
+
+test("apply-result rejects an already-merged replay with invalid review policy", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(mergeStatePath, "merged");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  const replay = mergeResultJson({ externalBinding: true });
+  replay.merge_preflight[0].codex_review.status = "failed";
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(replay, null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(report.actions[0].reason, "Codex /review status is failed");
+});
+
+test("apply-result re-reads an ambiguous merge failure and verifies accepted state", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    mergeFailure: "HTTP 503: Service Unavailable",
+    mergeAcceptedBeforeFailure: true,
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "executed");
+  assert.equal(report.actions[0].reason, "merge command failed after GitHub accepted the merge");
+  assert.equal(report.actions[0].merge_commit_sha, SQUASH_COMMIT_SHA);
+});
+
 test("apply-result retries transient GitHub 5xx during merge preflight", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");
@@ -694,6 +1233,7 @@ function apply(jobPath, resultPath, reportPath, binDir, { dryRun = true, callLog
         ...process.env,
         PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
         CLOWNFISH_ALLOW_EXECUTE: "1",
+        CLOWNFISH_APP_ID: "3535277",
         ...(callLogPath ? { GH_CALL_LOG: callLogPath } : {}),
         ...(allowMerge ? { CLOWNFISH_ALLOW_MERGE: "1" } : {}),
         ...(mergeStatePath ? { MERGE_STATE: mergeStatePath } : {}),
@@ -820,6 +1360,18 @@ function writeReadyMergeGhStub(
     labels = [],
     issueUpdatedAt = "2026-06-11T05:07:30Z",
     issueComments = [],
+    externalBinding = false,
+    mergeBlobSha = MERGE_BLOB_SHA,
+    mergeBaseSha = CURRENT_MAIN_SHA,
+    currentMainBlobSha = BASE_BLOB_SHA,
+    reviewedBaseSha = CURRENT_MAIN_SHA,
+    currentMainExtraPath = "src/other/unrelated.ts",
+    mergeFailure = null,
+    mergeSucceedsWithoutState = false,
+    mergeAcceptedBeforeFailure = false,
+    squashParentSha = CURRENT_MAIN_SHA,
+    squashBlobSha = mergeBlobSha,
+    exactMergeRule = true,
   },
 ) {
   const ghPath = path.join(binDir, "gh");
@@ -832,14 +1384,27 @@ const args = process.argv.slice(2);
 const merged = Boolean(process.env.MERGE_STATE && fs.existsSync(process.env.MERGE_STATE));
 const mergeViews = ${JSON.stringify(mergeViews)};
 const viewCountPath = ${JSON.stringify(viewCountPath)};
+const checkStatePath = ${JSON.stringify(path.join(binDir, "exact-merge-check.json"))};
+const externalBinding = ${JSON.stringify(externalBinding)};
+const reviewedBaseSha = ${JSON.stringify(reviewedBaseSha)};
 if (process.env.GH_CALL_LOG) fs.appendFileSync(process.env.GH_CALL_LOG, JSON.stringify(args) + "\\n");
 function write(value) {
   process.stdout.write(JSON.stringify(value));
 }
+function checkRuns() {
+  return fs.existsSync(checkStatePath)
+    ? JSON.parse(fs.readFileSync(checkStatePath, "utf8"))
+    : [];
+}
+function writeCheck(check) {
+  const checks = checkRuns().filter((item) => item.external_id !== check.external_id);
+  checks.push(check);
+  fs.writeFileSync(checkStatePath, JSON.stringify(checks));
+}
 if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
   write({
     number: 60063,
-    state: "open",
+    state: merged ? "closed" : "open",
     title: "streaming fix",
     updated_at: ${JSON.stringify(issueUpdatedAt)},
     labels: ${JSON.stringify(labels)},
@@ -853,15 +1418,126 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
     draft: false,
     updated_at: "2026-06-11T05:07:30Z",
     labels: ${JSON.stringify(labels)},
-    base: { ref: "main", sha: "current-main" },
+    base: { ref: "main", sha: externalBinding ? ${JSON.stringify(CURRENT_MAIN_SHA)} : "current-main" },
     head: { sha: ${JSON.stringify(headSha)} },
     merged_at: merged ? "2026-06-11T05:09:00Z" : null,
-    merge_commit_sha: merged ? "c".repeat(40) : null
+    merge_commit_sha: externalBinding
+      ? (merged ? ${JSON.stringify(SQUASH_COMMIT_SHA)} : ${JSON.stringify(TEST_MERGE_SHA)})
+      : (merged ? "c".repeat(40) : null)
   });
 } else if (args[0] === "api" && args[1].startsWith("repos/openclaw/openclaw/issues/60063/comments")) {
-  write([${JSON.stringify(issueComments)}]);
+  const comments = ${JSON.stringify(issueComments)};
+  write(args.includes("--slurp") ? [comments] : comments);
 } else if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/ref/heads/main") {
-  write({ object: { sha: "current-main" } });
+  write({ object: { sha: externalBinding ? ${JSON.stringify(CURRENT_MAIN_SHA)} : "current-main" } });
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/rules/branches/main") {
+  write(${JSON.stringify(exactMergeRule)} ? [
+    {
+      type: "required_status_checks",
+      parameters: {
+        strict_required_status_checks_policy: true,
+        required_status_checks: [
+          { context: "clownfish/exact-merge", integration_id: 3535277 }
+        ]
+      }
+    }
+  ] : []);
+} else if (externalBinding && args[0] === "api" && args[1].startsWith("repos/openclaw/openclaw/commits/${TEST_MERGE_SHA}/check-runs?")) {
+  const checks = checkRuns();
+  write({ total_count: checks.length, check_runs: checks });
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/check-runs" && args.includes("POST")) {
+  const inputIndex = args.indexOf("--input");
+  const payload = JSON.parse(fs.readFileSync(args[inputIndex + 1], "utf8"));
+  const check = {
+    id: 4242,
+    name: payload.name,
+    head_sha: payload.head_sha,
+    external_id: payload.external_id,
+    status: payload.status,
+    conclusion: payload.conclusion,
+    completed_at: "2026-06-11T05:08:02Z",
+    app: { id: 3535277 }
+  };
+  writeCheck(check);
+  write(check);
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/check-runs/4242" && args.includes("PATCH")) {
+  const inputIndex = args.indexOf("--input");
+  const payload = JSON.parse(fs.readFileSync(args[inputIndex + 1], "utf8"));
+  const existing = checkRuns().find((item) => item.id === 4242);
+  const check = {
+    id: 4242,
+    name: payload.name,
+    head_sha: existing?.head_sha ?? ${JSON.stringify(TEST_MERGE_SHA)},
+    external_id: existing?.external_id,
+    status: payload.status,
+    conclusion: payload.conclusion,
+    completed_at: "2026-06-11T05:08:03Z",
+    app: { id: 3535277 }
+  };
+  writeCheck(check);
+  write(check);
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/commits/${TEST_MERGE_SHA}") {
+  write({
+    sha: ${JSON.stringify(TEST_MERGE_SHA)},
+    tree: { sha: ${JSON.stringify(MERGE_TREE_SHA)} },
+    parents: [{ sha: ${JSON.stringify(mergeBaseSha)} }, { sha: ${JSON.stringify(headSha)} }]
+  });
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/commits/${SQUASH_COMMIT_SHA}") {
+  write({
+    sha: ${JSON.stringify(SQUASH_COMMIT_SHA)},
+    tree: { sha: ${JSON.stringify(SQUASH_TREE_SHA)} },
+    parents: [{ sha: ${JSON.stringify(squashParentSha)} }]
+  });
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/commits/${mergeBaseSha}") {
+  write({ sha: ${JSON.stringify(mergeBaseSha)}, tree: { sha: ${JSON.stringify(BASE_TREE_SHA)} }, parents: [] });
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/commits/${CURRENT_MAIN_SHA}") {
+  write({ sha: ${JSON.stringify(CURRENT_MAIN_SHA)}, tree: { sha: ${JSON.stringify(CURRENT_MAIN_TREE_SHA)} }, parents: [] });
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/commits/${REVIEWED_BASE_SHA}") {
+  write({ sha: ${JSON.stringify(REVIEWED_BASE_SHA)}, tree: { sha: ${JSON.stringify(REVIEWED_BASE_TREE_SHA)} }, parents: [] });
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/compare/${REVIEWED_BASE_SHA}...${CURRENT_MAIN_SHA}") {
+  write({
+    status: "ahead",
+    ahead_by: 1,
+    total_commits: 1,
+    merge_base_commit: { sha: ${JSON.stringify(REVIEWED_BASE_SHA)} }
+  });
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/trees/${BASE_TREE_SHA}?recursive=1") {
+  write({
+    truncated: false,
+    tree: [
+      { path: "src/cli/effective.ts", mode: "100644", type: "blob", sha: ${JSON.stringify(BASE_BLOB_SHA)} },
+      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: "7".repeat(40) }
+    ]
+  });
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/trees/${MERGE_TREE_SHA}?recursive=1") {
+  write({
+    truncated: false,
+    tree: [
+      { path: "src/cli/effective.ts", mode: "100644", type: "blob", sha: ${JSON.stringify(mergeBlobSha)} },
+      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: "7".repeat(40) }
+    ]
+  });
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/trees/${SQUASH_TREE_SHA}?recursive=1") {
+  write({
+    truncated: false,
+    tree: [
+      { path: "src/cli/effective.ts", mode: "100644", type: "blob", sha: ${JSON.stringify(squashBlobSha)} },
+      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: "7".repeat(40) }
+    ]
+  });
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/trees/${CURRENT_MAIN_TREE_SHA}?recursive=1") {
+  write({
+    truncated: false,
+    tree: [
+      { path: "src/cli/effective.ts", mode: "100644", type: "blob", sha: ${JSON.stringify(currentMainBlobSha)} },
+      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: "7".repeat(40) }
+    ]
+  });
+} else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/trees/${REVIEWED_BASE_TREE_SHA}?recursive=1") {
+  write({
+    truncated: false,
+    tree: [{ path: "src/cli/effective.ts", mode: "100644", type: "blob", sha: ${JSON.stringify(BASE_BLOB_SHA)} }]
+  });
 } else if (args[0] === "api" && args[1] === "graphql") {
   write({ data: { repository: { pullRequest: { reviewThreads: { pageInfo: { hasNextPage: false }, nodes: [] } } } } });
 } else if (args[0] === "pr" && args[1] === "view" && args[2] === "60063") {
@@ -881,7 +1557,16 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
     statusCheckRollup: ${JSON.stringify(statusCheckRollup)}
   });
 } else if (args[0] === "pr" && args[1] === "merge" && args[2] === "60063") {
-  fs.writeFileSync(process.env.MERGE_STATE, "merged");
+  if (${JSON.stringify(mergeFailure)}) {
+    if (${JSON.stringify(mergeAcceptedBeforeFailure)}) {
+      fs.writeFileSync(process.env.MERGE_STATE, "merged");
+    }
+    process.stderr.write(${JSON.stringify(mergeFailure)} + "\\n");
+    process.exit(1);
+  }
+  if (!${JSON.stringify(mergeSucceedsWithoutState)}) {
+    fs.writeFileSync(process.env.MERGE_STATE, "merged");
+  }
 } else {
   process.stderr.write("unexpected gh call: " + args.join(" ") + "\\n");
   process.exit(1);
@@ -984,7 +1669,7 @@ function resultJsonWithHydratedCandidate() {
   };
 }
 
-function mergeResultJson() {
+function mergeResultJson({ externalBinding = false, reviewedBaseSha = CURRENT_MAIN_SHA } = {}) {
   return {
     status: "planned",
     repo: "openclaw/openclaw",
@@ -998,13 +1683,23 @@ function mergeResultJson() {
         action: "merge_canonical",
         status: "planned",
         classification: "fix_pr",
-        idempotency_key: "openclaw/openclaw#60063:merge:stale-test",
+        idempotency_key: externalBinding
+          ? `external-merge-preflight:openclaw/openclaw#60063:${EXPECTED_HEAD_SHA}:${EFFECTIVE_DIFF_SHA256}`
+          : "openclaw/openclaw#60063:merge:stale-test",
         expected_head_sha: EXPECTED_HEAD_SHA,
       },
     ],
     merge_preflight: [
       {
         target: "#60063",
+        ...(externalBinding
+          ? {
+              reviewed_base_sha: reviewedBaseSha,
+              reviewed_head_sha: EXPECTED_HEAD_SHA,
+              effective_diff_sha256: EFFECTIVE_DIFF_SHA256,
+              effective_diff_files: 1,
+            }
+          : {}),
         security_status: "cleared",
         security_evidence: ["no security-sensitive labels or comments"],
         comments_status: "resolved",

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -20,7 +21,7 @@ test("external merge preflight is exact-head, read-only, and refuses unresolved 
   assert.match(script, /PR head changed during checkout/);
   assert.match(script, /function ensureMergeBase/);
   assert.match(script, /function prepareSyntheticMergeReview/);
-  assert.match(script, /"merge-tree", "--write-tree", currentMainSha, exactHeadSha/);
+  assert.match(script, /"merge-tree", "--write-tree", baseSha, exactHeadSha/);
   assert.match(script, /"commit-tree",\s*mergeTreeSha,\s*"-p",\s*currentMainSha/);
   assert.match(script, /"rev-parse", "HEAD\^\{tree\}"/);
   assert.match(script, /"rev-parse", "HEAD\^"/);
@@ -33,13 +34,21 @@ test("external merge preflight is exact-head, read-only, and refuses unresolved 
   assert.match(script, /inline review comment/);
   assert.match(
     script,
-    /const defaultCodexReviewSandbox = process\.env\.GITHUB_ACTIONS === "true" \? "danger-full-access" : "read-only";/,
+    /const defaultCodexReviewSandbox = "read-only";/,
   );
   assert.match(script, /CLOWNFISH_EXTERNAL_PREFLIGHT_CODEX_SANDBOX \?\? defaultCodexReviewSandbox/);
   assert.match(script, /--sandbox",\s*codexReviewSandbox/);
+  assert.match(script, /--config\.enable-pre-post-scripts=false/);
+  assert.match(script, /GIT_NO_REPLACE_OBJECTS: "1"/);
+  assert.match(script, /function verifyTrackedFilesystem/);
+  assert.match(script, /function gitBlobSha/);
+  assert.match(script, /"check:changed", "--base", baseSha, "--head", headSha/);
+  assert.match(script, /do not use mutable branch refs/);
   assert.match(script, /delete env\[key\]/);
   assert.match(script, /if \(process\.env\.GITHUB_ACTIONS === "true"\) \{\s*delete env\.OPENAI_API_KEY;\s*delete env\.CODEX_API_KEY;/s);
   assert.match(script, /function validationEnv\(\)[\s\S]*?"CLOWNFISH_READ_GH_TOKEN"/);
+  assert.match(script, /function validationEnv\(\)[\s\S]*?GIT_NO_REPLACE_OBJECTS: "1"/);
+  assert.match(script, /function codexEnv\(\)[\s\S]*?GIT_NO_REPLACE_OBJECTS: "1"/);
   assert.doesNotMatch(script, /pr", "merge"/);
   assert.doesNotMatch(script, /resolveReviewThread/);
 });
@@ -63,6 +72,8 @@ test("external merge workflow validates before guarded apply", () => {
   assert.match(workflow, /- name: Verify mutation integrity[\s\S]*?npm run assert-mutation-integrity/);
   assert.match(workflow, /- name: Verify mutation integrity[\s\S]*?- name: Upload apply artifact/);
   assert.match(workflow, /permission-pull-requests: write/);
+  assert.match(workflow, /permission-checks: write/);
+  assert.match(workflow, /CLOWNFISH_APP_ID: \$\{\{ vars\.CLOWNFISH_APP_ID \}\}/);
 });
 
 test("cluster worker chains blocked merge candidates through external preflight", () => {
@@ -85,6 +96,8 @@ test("cluster worker chains blocked merge candidates through external preflight"
   assert.match(runnerScript, /still running after/);
   assert.match(runnerScript, /clearInterval\(heartbeat\)/);
   assert.match(clusterWorkflow, /- name: Run external merge preflights/);
+  assert.match(clusterWorkflow, /CLOWNFISH_APP_ID: \$\{\{ vars\.CLOWNFISH_APP_ID \}\}/);
+  assert.equal((clusterWorkflow.match(/permission-checks: write/g) ?? []).length >= 2, true);
   assert.match(
     clusterWorkflow,
     /npm run run-external-merge-preflights -- "\$\{\{ needs\.prepare\.outputs\.job \}\}"[\s\S]*?--max-prs "\$\{\{ vars\.CLOWNFISH_EXTERNAL_PREFLIGHT_MAX_PRS \|\| '5' \}\}"[\s\S]*?--concurrency "\$\{\{ vars\.CLOWNFISH_EXTERNAL_PREFLIGHT_CONCURRENCY \|\| '3' \}\}"/,
@@ -137,6 +150,10 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
   assert.equal(result.actions[0].expected_head_sha, fixture.headSha);
   assert.equal(result.actions[0].target_updated_at, "2026-06-19T00:05:00Z");
   assert.equal(result.merge_preflight[0].codex_review.status, "clean");
+  assert.equal(result.merge_preflight[0].reviewed_base_sha, fixture.baseSha);
+  assert.equal(result.merge_preflight[0].reviewed_head_sha, fixture.headSha);
+  assert.equal(result.merge_preflight[0].effective_diff_sha256, fixture.effectiveDiffSha256);
+  assert.equal(result.merge_preflight[0].effective_diff_files, 1);
   assert.match(result.actions[0].evidence.join("\n"), /synthetic squash-result commit/);
 
   const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
@@ -144,10 +161,27 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
   assert.equal(report.synthetic_merge_tree_sha, fixture.mergeTreeSha);
   assert.equal(report.raw_diff_files, 2);
   assert.equal(report.effective_diff_files, 1);
+  assert.equal(report.effective_diff_sha256, fixture.effectiveDiffSha256);
   const gitCommands = fs.readFileSync(fixture.gitCommandsPath, "utf8");
   assert.match(gitCommands, new RegExp(`merge-tree --write-tree ${fixture.baseSha} ${fixture.headSha}`));
   assert.match(gitCommands, new RegExp(`commit-tree ${fixture.mergeTreeSha} -p ${fixture.baseSha}`));
   assert.match(gitCommands, new RegExp(`checkout --detach ${fixture.syntheticMergeSha}`));
+  assert.match(
+    gitCommands,
+    new RegExp(`diff --check ${fixture.baseSha}\\.\\.\\.${fixture.syntheticMergeSha}`),
+  );
+  assert.doesNotMatch(gitCommands, /diff --check origin\/main\.\.\.HEAD/);
+  const pnpmCommands = fs.readFileSync(fixture.pnpmCommandsPath, "utf8");
+  assert.match(
+    pnpmCommands,
+    new RegExp(`check:changed --base ${fixture.baseSha} --head ${fixture.syntheticMergeSha}`),
+  );
+  const codexPrompt = fs.readFileSync(fixture.codexPromptPath, "utf8");
+  assert.match(
+    codexPrompt,
+    new RegExp(`${fixture.baseSha}\\.\\.\\.${fixture.syntheticMergeSha}`),
+  );
+  assert.doesNotMatch(codexPrompt, /origin\/main\.\.\.HEAD/);
 
   const reviewed = spawnSync(process.execPath, ["scripts/review-results.mjs", fixture.runDir], {
     cwd: repoRoot,
@@ -203,6 +237,14 @@ test("external merge preflight blocks synthetic merge conflicts", () => {
   assert.equal(report.status, "blocked");
   assert.match(report.reason, /git merge-tree --write-tree/);
   assert.match(report.reason, /fixture merge conflict/);
+});
+
+test("external merge preflight blocks tracked checkout mutation after review", () => {
+  const fixture = makeFixture({ codexMutatesCheckout: true });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /synthetic review checkout changed tracked bytes/);
 });
 
 test("external merge preflight accepts #100910 assignee and harmless label drift after final recheck", () => {
@@ -286,7 +328,7 @@ for (const guardedDrift of [
 }
 
 test("external merge preflight tolerates base drift when exact head remains clean", () => {
-  const fixture = makeFixture({ currentMainSha: "c".repeat(40) });
+  const fixture = makeFixture({ currentMainSha: "9".repeat(40) });
   const child = spawnSync(
     process.execPath,
     ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
@@ -307,6 +349,15 @@ test("external merge preflight tolerates base drift when exact head remains clea
   assert.match(result.actions[0].evidence.join("\n"), /drifted from origin\/main/);
   const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
   assert.equal(report.base_drift_allowed, true);
+});
+
+test("external merge preflight blocks when main moves during validation or review", () => {
+  const fixture = makeFixture({ refreshedMainSha: "9".repeat(40) });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /changed while validation or review was running/);
+  assert.match(report.reason, new RegExp(`${fixture.baseSha}, current ${"9".repeat(40)}`));
 });
 
 test("external merge preflight treats zero-finding clean reviews as clean", () => {
@@ -2396,8 +2447,10 @@ function makeFixture({
   rehydratedHeadSha = null,
   rehydratedState = null,
   currentMainSha = null,
+  refreshedMainSha = null,
   validationFailure = null,
   syntheticMergeFailure = null,
+  codexMutatesCheckout = false,
   codexReview = {
     status: "clean",
     summary: "clean fixture review",
@@ -2414,7 +2467,24 @@ function makeFixture({
   const baseSha = "b".repeat(40);
   const mergeTreeSha = "c".repeat(40);
   const syntheticMergeSha = "d".repeat(40);
+  const baseBlobSha = "e".repeat(40);
+  const effectiveContent = "fixture effective content\n";
+  const mergeBlobSha = createHash("sha1")
+    .update(`blob ${Buffer.byteLength(effectiveContent)}\0`)
+    .update(effectiveContent)
+    .digest("hex");
+  const effectiveDiffSha256 = createHash("sha256")
+    .update(
+      `${JSON.stringify([
+        "src/effective.ts",
+        `100644:blob:${baseBlobSha}`,
+        `100644:blob:${mergeBlobSha}`,
+      ])}\n`,
+    )
+    .digest("hex");
   const gitCommandsPath = path.join(root, "git-commands.log");
+  const pnpmCommandsPath = path.join(root, "pnpm-commands.log");
+  const codexPromptPath = path.join(root, "codex-prompt.txt");
   const finalIssueComments = rehydratedIssueComments ?? issueComments;
   const finalReviewComments = rehydratedReviewComments ?? reviewComments;
   const finalReviewThreads = rehydratedReviewThreads ?? [];
@@ -2473,7 +2543,9 @@ function nextValue(name, initial, refreshed) {
 if (args[0] === "repo" && args[1] === "clone") {
   const target = args[3];
   fs.mkdirSync(path.join(target, ".git"), { recursive: true });
+  fs.mkdirSync(path.join(target, "src"), { recursive: true });
   fs.writeFileSync(path.join(target, "package.json"), JSON.stringify({ packageManager: "pnpm@10.33.0" }));
+  fs.writeFileSync(path.join(target, "src", "effective.ts"), ${JSON.stringify(effectiveContent)});
   process.exit(0);
 }
 if (args[0] === "pr" && args[1] === "view") {
@@ -2534,17 +2606,31 @@ const args = process.argv.slice(2);
 const head = ${JSON.stringify(headSha)};
 const base = ${JSON.stringify(baseSha)};
 const currentMain = ${JSON.stringify(currentMainSha)} || base;
+const refreshedMain = ${JSON.stringify(refreshedMainSha)} || currentMain;
 const mergeTree = ${JSON.stringify(mergeTreeSha)};
 const synthetic = ${JSON.stringify(syntheticMergeSha)};
+const baseBlob = ${JSON.stringify(baseBlobSha)};
+const mergeBlob = ${JSON.stringify(mergeBlobSha)};
 const statePath = path.join(${JSON.stringify(root)}, "git-state");
+const refreshedMainPath = path.join(${JSON.stringify(root)}, "main-refreshed");
+const mainFetchCountPath = path.join(${JSON.stringify(root)}, "main-fetch-count");
 const commandLog = ${JSON.stringify(gitCommandsPath)};
 fs.appendFileSync(commandLog, args.join(" ") + "\\n");
 const state = fs.existsSync(statePath) ? fs.readFileSync(statePath, "utf8") : "pr";
 if (args[0] === "rev-parse") {
-  if (args[1] === "origin/main" || args[1] === "HEAD^") console.log(currentMain);
+  if (args[1] === "origin/main") {
+    console.log(fs.existsSync(refreshedMainPath) ? refreshedMain : currentMain);
+  }
+  else if (args[1] === "HEAD^") console.log(currentMain);
   else if (args[1] === "HEAD^{tree}") console.log(mergeTree);
   else if (args[1] === "--is-shallow-repository") console.log("false");
   else console.log(state === "synthetic" ? synthetic : state === "main" ? currentMain : head);
+  process.exit(0);
+}
+if (args[0] === "fetch" && args.some((arg) => arg === "main:refs/remotes/origin/main")) {
+  const count = fs.existsSync(mainFetchCountPath) ? Number(fs.readFileSync(mainFetchCountPath, "utf8")) : 0;
+  fs.writeFileSync(mainFetchCountPath, String(count + 1));
+  if (count >= 1) fs.writeFileSync(refreshedMainPath, "refreshed");
   process.exit(0);
 }
 if (args[0] === "merge-base") {
@@ -2568,6 +2654,12 @@ if (args[0] === "commit-tree") {
   console.log(synthetic);
   process.exit(0);
 }
+if (args[0] === "ls-tree") {
+  const treeish = args.at(-1);
+  const blob = treeish === mergeTree ? mergeBlob : baseBlob;
+  process.stdout.write("100644 blob " + blob + "\\tsrc/effective.ts\\0");
+  process.exit(0);
+}
 if (args[0] === "diff" && args[1] === "--name-only") {
   if (args.includes("--diff-filter=U")) process.exit(0);
   const target = args.at(-1);
@@ -2582,8 +2674,11 @@ process.exit(0);
   writeExecutable(
     path.join(binDir, "pnpm"),
     `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(pnpmCommandsPath)}, args.join(" ") + "\\n");
 const failure = ${JSON.stringify(validationFailure)};
-if (failure && process.argv.slice(2).join(" ") === "check:changed") {
+if (failure && args[0] === "check:changed") {
   process.stdout.write(String(failure.stdout ?? ""));
   process.stderr.write(String(failure.stderr ?? ""));
   process.exit(Number(failure.status ?? 1));
@@ -2596,10 +2691,26 @@ if (failure && process.argv.slice(2).join(" ") === "check:changed") {
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 const index = args.indexOf("--output-last-message");
+fs.writeFileSync(${JSON.stringify(codexPromptPath)}, fs.readFileSync(0, "utf8"));
+if (${JSON.stringify(codexMutatesCheckout)}) {
+  fs.writeFileSync("src/effective.ts", "mutated by fixture review\\n");
+}
 fs.writeFileSync(args[index + 1], JSON.stringify(${JSON.stringify(codexReview)}));
 `,
   );
-  return { baseSha, binDir, gitCommandsPath, headSha, jobPath, mergeTreeSha, runDir, syntheticMergeSha };
+  return {
+    baseSha,
+    binDir,
+    effectiveDiffSha256,
+    codexPromptPath,
+    gitCommandsPath,
+    headSha,
+    jobPath,
+    mergeTreeSha,
+    pnpmCommandsPath,
+    runDir,
+    syntheticMergeSha,
+  };
 }
 
 function writeExecutable(filePath, content) {


### PR DESCRIPTION
## Summary

- review the synthetic squash result and bind it to immutable base/head/effective-diff evidence
- require a source-pinned `clownfish/exact-merge` check before external merges
- fail closed on checkout mutation, main drift, stale test merges, ambiguous merge results, and incomplete post-merge proof
- wire Checks permission through both applicator workflows

## Validation

- `npm test` (389 passed)
- `npm run validate` (6,645 jobs)
- independent code review: no remaining high/medium findings