### PR TITLE
fix(merge): allow exact-check preauthorization state

### DIFF
--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -564,7 +564,12 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
     };
   }
 
-  const mergeBlock = validateMergeablePullRequest({ pullRequest, view });
+  const externalMergeAction = isExternalMergeAction(action);
+  const mergeBlock = validateMergeablePullRequest({
+    pullRequest,
+    view,
+    allowBlocked: externalMergeAction,
+  });
   if (mergeBlock) {
     return {
       ...base,
@@ -608,7 +613,12 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       base_drift_proof: effectiveDiffBinding.base_drift_proof ?? null,
     };
   }
-  const currentBaseBlock = validatePullRequestCurrentBase({ repo: result.repo, pullRequest, view });
+  const currentBaseBlock = validatePullRequestCurrentBase({
+    repo: result.repo,
+    pullRequest,
+    view,
+    allowBlocked: externalMergeAction,
+  });
   if (currentBaseBlock) {
     return {
       ...base,
@@ -704,6 +714,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
     const checkedMergeBlock = validateMergeablePullRequest({
       pullRequest: checkedPull,
       view: checkedView,
+      allowBlocked: externalMergeAction,
     });
     const checkedPreflightBlock = validateMergePreflight({
       result,
@@ -1600,7 +1611,7 @@ function validateReplacementCloseout({ result, actionName, target }) {
   return "replacement PR closeout is handled by execute-fix after the replacement branch is pushed";
 }
 
-function validateMergeablePullRequest({ pullRequest, view }) {
+function validateMergeablePullRequest({ pullRequest, view, allowBlocked = false }) {
   if (pullRequest.state !== "open") return `pull request is ${pullRequest.state}`;
   if (pullRequest.draft || view.isDraft) return "pull request is draft";
   if (String(view.baseRefName ?? pullRequest.base?.ref ?? "") !== "main") return "pull request base is not main";
@@ -1610,13 +1621,13 @@ function validateMergeablePullRequest({ pullRequest, view }) {
   }
   const checkBlock = validateStatusChecks(view.statusCheckRollup ?? []);
   if (checkBlock) return checkBlock;
-  if (!isAcceptableMergeState(view)) {
+  if (!isAcceptableMergeState(view, { allowBlocked })) {
     return `merge state status is ${view.mergeStateStatus || "unknown"}`;
   }
   return "";
 }
 
-function validatePullRequestCurrentBase({ repo, pullRequest, view }) {
+function validatePullRequestCurrentBase({ repo, pullRequest, view, allowBlocked = false }) {
   const pullRequestBaseSha = String(pullRequest?.base?.sha ?? "");
   const currentMainSha = fetchBranchHeadSha(repo, "main");
   if (!pullRequestBaseSha || !currentMainSha) {
@@ -1627,7 +1638,11 @@ function validatePullRequestCurrentBase({ repo, pullRequest, view }) {
     };
   }
   if (pullRequestBaseSha !== currentMainSha) {
-    if (view?.mergeable === "MERGEABLE" && isAcceptableMergeState(view) && !validateStatusChecks(view.statusCheckRollup ?? [])) {
+    if (
+      view?.mergeable === "MERGEABLE" &&
+      isAcceptableMergeState(view, { allowBlocked }) &&
+      !validateStatusChecks(view.statusCheckRollup ?? [])
+    ) {
       return null;
     }
     return {
@@ -1654,10 +1669,13 @@ function validateStatusChecks(checks) {
   return "";
 }
 
-function isAcceptableMergeState(view) {
+function isAcceptableMergeState(view, { allowBlocked = false } = {}) {
   const state = String(view.mergeStateStatus ?? "");
   if (CLEAN_MERGE_STATES.has(state)) return true;
-  return state === "UNSTABLE" && view.mergeable === "MERGEABLE" && !validateStatusChecks(view.statusCheckRollup ?? []);
+  if (state !== "UNSTABLE" && !(allowBlocked && state === "BLOCKED")) return false;
+  // A required clownfish/exact-merge check makes GitHub report BLOCKED until
+  // an external applicator publishes the exact-head authorization.
+  return view.mergeable === "MERGEABLE" && !validateStatusChecks(view.statusCheckRollup ?? []);
 }
 
 function latestStatusChecks(checks) {

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -8,6 +8,7 @@ import { hasSecuritySensitiveText } from "./security-sensitive.mjs";
 
 const PASSING_CHECK_CONCLUSIONS = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"]);
 const CLEAN_MERGE_STATES = new Set(["CLEAN"]);
+const PRE_AUTHORIZATION_MERGE_STATES = new Set(["UNSTABLE", "BLOCKED"]);
 const IGNORED_CHECKS = new Set(["auto-response", "Labeler", "Stale"]);
 const REVIEW_BOT_PATTERN = /\b(?:greptile|codex|asile|coderabbit|copilot)\b/i;
 const INSTALL_TIMEOUT_MS = positiveInteger(process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_INSTALL_TIMEOUT_MS, 10 * 60 * 1000);
@@ -1096,7 +1097,13 @@ function isFailingCheck(check) {
 function isAcceptableMergeState(view) {
   const state = String(view.mergeStateStatus ?? "");
   if (CLEAN_MERGE_STATES.has(state)) return true;
-  return state === "UNSTABLE" && view.mergeable === "MERGEABLE" && latestStatusChecks(view.statusCheckRollup ?? []).every((check) => !isFailingCheck(check));
+  // A required clownfish/exact-merge check makes GitHub report BLOCKED until
+  // the applicator publishes the exact-head authorization.
+  return (
+    PRE_AUTHORIZATION_MERGE_STATES.has(state) &&
+    view.mergeable === "MERGEABLE" &&
+    latestStatusChecks(view.statusCheckRollup ?? []).every((check) => !isFailingCheck(check))
+  );
 }
 
 function canTolerateBaseDrift(view) {

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -564,7 +564,7 @@ test("apply-result pins a clean merge to the reviewed PR head", () => {
   assert.deepEqual(mergeArgs.slice(-3), ["--squash", "--match-head-commit", EXPECTED_HEAD_SHA]);
 });
 
-test("apply-result verifies an external preflight effective diff before merge", () => {
+test("apply-result allows blocked state for an exact-bound external merge", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");
   const callLogPath = path.join(tmp, "gh-calls.jsonl");
@@ -574,6 +574,7 @@ test("apply-result verifies an external preflight effective diff before merge", 
   writeReadyMergeGhStub(binDir, {
     headSha: EXPECTED_HEAD_SHA,
     externalBinding: true,
+    mergeStateStatus: "BLOCKED",
   });
 
   const jobPath = path.join(tmp, "job.md");
@@ -1186,6 +1187,44 @@ test("apply-result allows unstable merge state when latest checks are clean", ()
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
   assert.equal(report.actions[0].status, "executed");
+});
+
+test("apply-result blocks generic merges in blocked state", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    mergeStateStatus: "BLOCKED",
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(report.actions[0].reason, "merge state status is BLOCKED");
+  const ghCalls = fs
+    .readFileSync(callLogPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  assert.equal(ghCalls.some((args) => args[0] === "pr" && args[1] === "merge"), false);
 });
 
 test("apply-result blocks merge targets with live merge-risk labels", () => {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -418,6 +418,25 @@ test("external merge preflight polls transient unknown mergeability", () => {
   assert.equal(report.status, "passed");
 });
 
+test("external merge preflight accepts blocked state before exact-check authorization", () => {
+  const fixture = makeFixture({
+    mergeStateStatus: "BLOCKED",
+    statusCheckRollup: [
+      {
+        name: "CI",
+        workflowName: "CI",
+        status: "COMPLETED",
+        conclusion: "SUCCESS",
+        completedAt: "2026-07-06T20:25:00Z",
+      },
+    ],
+  });
+  const { report, result } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "passed", report.reason);
+  assert.equal(result.actions[0].expected_head_sha, fixture.headSha);
+});
+
 test("external merge preflight tolerates non-actionable automation comments", () => {
   const fixture = makeFixture({
     mergeStateStatus: "UNSTABLE",


### PR DESCRIPTION
## Summary

- accept GitHub `BLOCKED` during external exact-head preflight before the App authorization check exists
- keep ordinary merge actions blocked in that state
- cover both the App-pinned exact-check path and the generic rejection path

## Verification

- `npm test` (391 passed)
- `npm run validate` (6,645 jobs)
- focused external preflight tests (67 passed)
- focused applicator tests (40 passed)
- independent review: no medium-or-higher findings