### PR TITLE
fix(merge): support hosted stale-head reviews

### DIFF
--- a/.github/workflows/external-merge-preflight.yml
+++ b/.github/workflows/external-merge-preflight.yml
@@ -46,6 +46,17 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Prepare Codex Linux sandbox
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap apparmor-profiles apparmor-utils
+          profile_source="/usr/share/apparmor/extra-profiles/bwrap-userns-restrict"
+          test -f "$profile_source"
+          sudo install -m 0644 "$profile_source" /etc/apparmor.d/bwrap-userns-restrict
+          sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
+
       - name: Cache Codex CLI and npm downloads
         uses: actions/cache@v5
         with:

--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -568,7 +568,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
   const mergeBlock = validateMergeablePullRequest({
     pullRequest,
     view,
-    allowBlocked: externalMergeAction,
+    allowExactMergeState: externalMergeAction,
   });
   if (mergeBlock) {
     return {
@@ -617,7 +617,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
     repo: result.repo,
     pullRequest,
     view,
-    allowBlocked: externalMergeAction,
+    allowExactMergeState: externalMergeAction,
   });
   if (currentBaseBlock) {
     return {
@@ -714,7 +714,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
     const checkedMergeBlock = validateMergeablePullRequest({
       pullRequest: checkedPull,
       view: checkedView,
-      allowBlocked: externalMergeAction,
+      allowExactMergeState: externalMergeAction,
     });
     const checkedPreflightBlock = validateMergePreflight({
       result,
@@ -1611,7 +1611,7 @@ function validateReplacementCloseout({ result, actionName, target }) {
   return "replacement PR closeout is handled by execute-fix after the replacement branch is pushed";
 }
 
-function validateMergeablePullRequest({ pullRequest, view, allowBlocked = false }) {
+function validateMergeablePullRequest({ pullRequest, view, allowExactMergeState = false }) {
   if (pullRequest.state !== "open") return `pull request is ${pullRequest.state}`;
   if (pullRequest.draft || view.isDraft) return "pull request is draft";
   if (String(view.baseRefName ?? pullRequest.base?.ref ?? "") !== "main") return "pull request base is not main";
@@ -1621,13 +1621,13 @@ function validateMergeablePullRequest({ pullRequest, view, allowBlocked = false 
   }
   const checkBlock = validateStatusChecks(view.statusCheckRollup ?? []);
   if (checkBlock) return checkBlock;
-  if (!isAcceptableMergeState(view, { allowBlocked })) {
+  if (!isAcceptableMergeState(view, { allowExactMergeState })) {
     return `merge state status is ${view.mergeStateStatus || "unknown"}`;
   }
   return "";
 }
 
-function validatePullRequestCurrentBase({ repo, pullRequest, view, allowBlocked = false }) {
+function validatePullRequestCurrentBase({ repo, pullRequest, view, allowExactMergeState = false }) {
   const pullRequestBaseSha = String(pullRequest?.base?.sha ?? "");
   const currentMainSha = fetchBranchHeadSha(repo, "main");
   if (!pullRequestBaseSha || !currentMainSha) {
@@ -1640,7 +1640,7 @@ function validatePullRequestCurrentBase({ repo, pullRequest, view, allowBlocked 
   if (pullRequestBaseSha !== currentMainSha) {
     if (
       view?.mergeable === "MERGEABLE" &&
-      isAcceptableMergeState(view, { allowBlocked }) &&
+      isAcceptableMergeState(view, { allowExactMergeState }) &&
       !validateStatusChecks(view.statusCheckRollup ?? [])
     ) {
       return null;
@@ -1669,12 +1669,17 @@ function validateStatusChecks(checks) {
   return "";
 }
 
-function isAcceptableMergeState(view, { allowBlocked = false } = {}) {
+function isAcceptableMergeState(view, { allowExactMergeState = false } = {}) {
   const state = String(view.mergeStateStatus ?? "");
   if (CLEAN_MERGE_STATES.has(state)) return true;
-  if (state !== "UNSTABLE" && !(allowBlocked && state === "BLOCKED")) return false;
-  // A required clownfish/exact-merge check makes GitHub report BLOCKED until
-  // an external applicator publishes the exact-head authorization.
+  if (
+    state !== "UNSTABLE" &&
+    !(allowExactMergeState && ["BLOCKED", "BEHIND"].includes(state))
+  ) {
+    return false;
+  }
+  // Exact-bound external actions verify the synthetic merge against current
+  // main before publishing authorization or attempting the one-shot merge.
   return view.mergeable === "MERGEABLE" && !validateStatusChecks(view.statusCheckRollup ?? []);
 }
 

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -8,7 +8,7 @@ import { hasSecuritySensitiveText } from "./security-sensitive.mjs";
 
 const PASSING_CHECK_CONCLUSIONS = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"]);
 const CLEAN_MERGE_STATES = new Set(["CLEAN"]);
-const PRE_AUTHORIZATION_MERGE_STATES = new Set(["UNSTABLE", "BLOCKED"]);
+const PRE_AUTHORIZATION_MERGE_STATES = new Set(["UNSTABLE", "BLOCKED", "BEHIND"]);
 const IGNORED_CHECKS = new Set(["auto-response", "Labeler", "Stale"]);
 const REVIEW_BOT_PATTERN = /\b(?:greptile|codex|asile|coderabbit|copilot)\b/i;
 const INSTALL_TIMEOUT_MS = positiveInteger(process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_INSTALL_TIMEOUT_MS, 10 * 60 * 1000);
@@ -1097,8 +1097,8 @@ function isFailingCheck(check) {
 function isAcceptableMergeState(view) {
   const state = String(view.mergeStateStatus ?? "");
   if (CLEAN_MERGE_STATES.has(state)) return true;
-  // A required clownfish/exact-merge check makes GitHub report BLOCKED until
-  // the applicator publishes the exact-head authorization.
+  // External preflight can safely review BLOCKED or BEHIND heads because it
+  // binds a synthetic merge against current main before authorization.
   return (
     PRE_AUTHORIZATION_MERGE_STATES.has(state) &&
     view.mergeable === "MERGEABLE" &&

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -564,56 +564,58 @@ test("apply-result pins a clean merge to the reviewed PR head", () => {
   assert.deepEqual(mergeArgs.slice(-3), ["--squash", "--match-head-commit", EXPECTED_HEAD_SHA]);
 });
 
-test("apply-result allows blocked state for an exact-bound external merge", () => {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
-  const binDir = path.join(tmp, "bin");
-  const callLogPath = path.join(tmp, "gh-calls.jsonl");
-  const mergeStatePath = path.join(tmp, "merge-state");
-  fs.mkdirSync(binDir, { recursive: true });
-  fs.writeFileSync(callLogPath, "");
-  writeReadyMergeGhStub(binDir, {
-    headSha: EXPECTED_HEAD_SHA,
-    externalBinding: true,
-    mergeStateStatus: "BLOCKED",
+for (const mergeStateStatus of ["BLOCKED", "BEHIND"]) {
+  test(`apply-result allows ${mergeStateStatus.toLowerCase()} state for an exact-bound external merge`, () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+    const binDir = path.join(tmp, "bin");
+    const callLogPath = path.join(tmp, "gh-calls.jsonl");
+    const mergeStatePath = path.join(tmp, "merge-state");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(callLogPath, "");
+    writeReadyMergeGhStub(binDir, {
+      headSha: EXPECTED_HEAD_SHA,
+      externalBinding: true,
+      mergeStateStatus,
+    });
+
+    const jobPath = path.join(tmp, "job.md");
+    const resultPath = path.join(tmp, "result.json");
+    const reportPath = path.join(tmp, "apply-report.json");
+    fs.writeFileSync(jobPath, mergeJobMarkdown());
+    fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+    const result = apply(jobPath, resultPath, reportPath, binDir, {
+      dryRun: false,
+      allowMerge: true,
+      callLogPath,
+      mergeStatePath,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "executed");
+    assert.equal(report.actions[0].effective_diff_sha256, EFFECTIVE_DIFF_SHA256);
+    assert.equal(report.actions[0].verified_main_sha, CURRENT_MAIN_SHA);
+    assert.equal(report.actions[0].exact_merge_check.name, "clownfish/exact-merge");
+    assert.equal(report.actions[0].exact_merge_check.head_sha, TEST_MERGE_SHA);
+    assert.equal(report.actions[0].exact_merge_check.app_id, 3535277);
+    const ghCalls = fs
+      .readFileSync(callLogPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    const authorizationIndex = ghCalls.findIndex(
+      (args) =>
+        args[0] === "api" &&
+        args[1] === "repos/openclaw/openclaw/check-runs/4242" &&
+        args.includes("PATCH"),
+    );
+    const mergeIndex = ghCalls.findIndex((args) => args[0] === "pr" && args[1] === "merge");
+    assert.ok(authorizationIndex >= 0);
+    assert.equal(mergeIndex, authorizationIndex + 1);
   });
-
-  const jobPath = path.join(tmp, "job.md");
-  const resultPath = path.join(tmp, "result.json");
-  const reportPath = path.join(tmp, "apply-report.json");
-  fs.writeFileSync(jobPath, mergeJobMarkdown());
-  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
-
-  const result = apply(jobPath, resultPath, reportPath, binDir, {
-    dryRun: false,
-    allowMerge: true,
-    callLogPath,
-    mergeStatePath,
-  });
-
-  assert.equal(result.status, 0, result.stderr || result.stdout);
-  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
-  assert.equal(report.actions[0].status, "executed");
-  assert.equal(report.actions[0].effective_diff_sha256, EFFECTIVE_DIFF_SHA256);
-  assert.equal(report.actions[0].verified_main_sha, CURRENT_MAIN_SHA);
-  assert.equal(report.actions[0].exact_merge_check.name, "clownfish/exact-merge");
-  assert.equal(report.actions[0].exact_merge_check.head_sha, TEST_MERGE_SHA);
-  assert.equal(report.actions[0].exact_merge_check.app_id, 3535277);
-  const ghCalls = fs
-    .readFileSync(callLogPath, "utf8")
-    .trim()
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => JSON.parse(line));
-  const authorizationIndex = ghCalls.findIndex(
-    (args) =>
-      args[0] === "api" &&
-      args[1] === "repos/openclaw/openclaw/check-runs/4242" &&
-      args.includes("PATCH"),
-  );
-  const mergeIndex = ghCalls.findIndex((args) => args[0] === "pr" && args[1] === "merge");
-  assert.ok(authorizationIndex >= 0);
-  assert.equal(mergeIndex, authorizationIndex + 1);
-});
+}
 
 test("apply-result blocks external merge when the strict exact-merge rule is missing", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
@@ -1189,43 +1191,45 @@ test("apply-result allows unstable merge state when latest checks are clean", ()
   assert.equal(report.actions[0].status, "executed");
 });
 
-test("apply-result blocks generic merges in blocked state", () => {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
-  const binDir = path.join(tmp, "bin");
-  const callLogPath = path.join(tmp, "gh-calls.jsonl");
-  const mergeStatePath = path.join(tmp, "merge-state");
-  fs.mkdirSync(binDir, { recursive: true });
-  fs.writeFileSync(callLogPath, "");
-  writeReadyMergeGhStub(binDir, {
-    headSha: EXPECTED_HEAD_SHA,
-    mergeStateStatus: "BLOCKED",
+for (const mergeStateStatus of ["BLOCKED", "BEHIND"]) {
+  test(`apply-result blocks generic merges in ${mergeStateStatus.toLowerCase()} state`, () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+    const binDir = path.join(tmp, "bin");
+    const callLogPath = path.join(tmp, "gh-calls.jsonl");
+    const mergeStatePath = path.join(tmp, "merge-state");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(callLogPath, "");
+    writeReadyMergeGhStub(binDir, {
+      headSha: EXPECTED_HEAD_SHA,
+      mergeStateStatus,
+    });
+
+    const jobPath = path.join(tmp, "job.md");
+    const resultPath = path.join(tmp, "result.json");
+    const reportPath = path.join(tmp, "apply-report.json");
+    fs.writeFileSync(jobPath, mergeJobMarkdown());
+    fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson(), null, 2)}\n`);
+
+    const result = apply(jobPath, resultPath, reportPath, binDir, {
+      dryRun: false,
+      allowMerge: true,
+      callLogPath,
+      mergeStatePath,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "blocked");
+    assert.equal(report.actions[0].reason, `merge state status is ${mergeStateStatus}`);
+    const ghCalls = fs
+      .readFileSync(callLogPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    assert.equal(ghCalls.some((args) => args[0] === "pr" && args[1] === "merge"), false);
   });
-
-  const jobPath = path.join(tmp, "job.md");
-  const resultPath = path.join(tmp, "result.json");
-  const reportPath = path.join(tmp, "apply-report.json");
-  fs.writeFileSync(jobPath, mergeJobMarkdown());
-  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson(), null, 2)}\n`);
-
-  const result = apply(jobPath, resultPath, reportPath, binDir, {
-    dryRun: false,
-    allowMerge: true,
-    callLogPath,
-    mergeStatePath,
-  });
-
-  assert.equal(result.status, 0, result.stderr || result.stdout);
-  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
-  assert.equal(report.actions[0].status, "blocked");
-  assert.equal(report.actions[0].reason, "merge state status is BLOCKED");
-  const ghCalls = fs
-    .readFileSync(callLogPath, "utf8")
-    .trim()
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => JSON.parse(line));
-  assert.equal(ghCalls.some((args) => args[0] === "pr" && args[1] === "merge"), false);
-});
+}
 
 test("apply-result blocks merge targets with live merge-risk labels", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -54,6 +54,9 @@ test("external merge preflight is exact-head, read-only, and refuses unresolved 
 });
 
 test("external merge workflow validates before guarded apply", () => {
+  assert.match(workflow, /- name: Prepare Codex Linux sandbox/);
+  assert.match(workflow, /apt-get install -y bubblewrap apparmor-profiles apparmor-utils/);
+  assert.match(workflow, /apparmor_parser -r \/etc\/apparmor\.d\/bwrap-userns-restrict/);
   assert.match(workflow, /npm run preflight-external-merge/);
   assert.match(workflow, /"\$SOURCE_JOB" --pr "\$PULL_REQUEST"/);
   assert.match(workflow, /npm run review-results/);
@@ -418,24 +421,26 @@ test("external merge preflight polls transient unknown mergeability", () => {
   assert.equal(report.status, "passed");
 });
 
-test("external merge preflight accepts blocked state before exact-check authorization", () => {
-  const fixture = makeFixture({
-    mergeStateStatus: "BLOCKED",
-    statusCheckRollup: [
-      {
-        name: "CI",
-        workflowName: "CI",
-        status: "COMPLETED",
-        conclusion: "SUCCESS",
-        completedAt: "2026-07-06T20:25:00Z",
-      },
-    ],
-  });
-  const { report, result } = runPreflightFixture(fixture);
+for (const mergeStateStatus of ["BLOCKED", "BEHIND"]) {
+  test(`external merge preflight accepts ${mergeStateStatus.toLowerCase()} state for exact review`, () => {
+    const fixture = makeFixture({
+      mergeStateStatus,
+      statusCheckRollup: [
+        {
+          name: "CI",
+          workflowName: "CI",
+          status: "COMPLETED",
+          conclusion: "SUCCESS",
+          completedAt: "2026-07-06T20:25:00Z",
+        },
+      ],
+    });
+    const { report, result } = runPreflightFixture(fixture);
 
-  assert.equal(report.status, "passed", report.reason);
-  assert.equal(result.actions[0].expected_head_sha, fixture.headSha);
-});
+    assert.equal(report.status, "passed", report.reason);
+    assert.equal(result.actions[0].expected_head_sha, fixture.headSha);
+  });
+}
 
 test("external merge preflight tolerates non-actionable automation comments", () => {
   const fixture = makeFixture({


### PR DESCRIPTION
## Summary
- allow exact-bound external reviews to proceed when GitHub reports `BEHIND`
- keep ordinary merge actions fail-closed for `BLOCKED` and `BEHIND`
- prepare the hosted Ubuntu runner for Codex read-only sandboxing with bubblewrap/AppArmor

## Validation
- `npm test` (394 passed)
- `npm run validate` (6,645 jobs)
- `git diff --check`
- independent review: no medium-or-higher findings