### PR TITLE
fix(preflight): rebaseline integrity after toolchain setup

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -568,18 +568,25 @@ function readOnlyBlockers({ sourceJob, pull, view, issueComments, pullRequest })
 }
 
 function checkoutExactPullHead({ repo, pullRequest, expectedHeadSha }) {
+  const env = gitIntegrityEnv();
   if (!fs.existsSync(path.join(targetDir, ".git"))) {
     fs.mkdirSync(path.dirname(targetDir), { recursive: true });
     run("gh", ["repo", "clone", repo, targetDir, "--", "--depth=1", "--filter=blob:none"], { env: ghReadEnv() });
   }
-  if (run("git", ["status", "--porcelain"], { cwd: targetDir }).trim()) {
+  if (run("git", ["status", "--porcelain"], { cwd: targetDir, env }).trim()) {
     throw new Error("target checkout has uncommitted changes");
   }
-  run("git", ["fetch", "--no-tags", "origin", `${baseBranch}:refs/remotes/origin/${baseBranch}`], { cwd: targetDir });
+  run("git", ["fetch", "--no-tags", "origin", `${baseBranch}:refs/remotes/origin/${baseBranch}`], {
+    cwd: targetDir,
+    env,
+  });
   const ref = `refs/remotes/origin/clownfish-preflight-${pullRequest}`;
-  run("git", ["fetch", "--no-tags", "origin", `pull/${pullRequest}/head:${ref}`], { cwd: targetDir });
-  run("git", ["checkout", "--detach", ref], { cwd: targetDir });
-  const actualHeadSha = run("git", ["rev-parse", "HEAD"], { cwd: targetDir }).trim();
+  run("git", ["fetch", "--no-tags", "origin", `pull/${pullRequest}/head:${ref}`], {
+    cwd: targetDir,
+    env,
+  });
+  run("git", ["checkout", "--detach", ref], { cwd: targetDir, env });
+  const actualHeadSha = run("git", ["rev-parse", "HEAD"], { cwd: targetDir, env }).trim();
   if (actualHeadSha !== expectedHeadSha) {
     throw new Error(`PR head changed during checkout: expected ${expectedHeadSha}, got ${actualHeadSha}`);
   }
@@ -587,24 +594,41 @@ function checkoutExactPullHead({ repo, pullRequest, expectedHeadSha }) {
 }
 
 function ensureMergeBase({ cwd, baseBranch, pullRequest, ref }) {
+  const env = gitIntegrityEnv();
   for (const depth of [50, 200, 1000]) {
     const probe = spawnSync("git", ["merge-base", `origin/${baseBranch}`, "HEAD"], {
       cwd,
+      env,
       encoding: "utf8",
       maxBuffer: 1024 * 1024,
     });
     if (probe.status === 0 && String(probe.stdout ?? "").trim()) return;
-    run("git", ["fetch", "--no-tags", "--deepen", String(depth), "origin", `${baseBranch}:refs/remotes/origin/${baseBranch}`], { cwd });
-    run("git", ["fetch", "--no-tags", "--deepen", String(depth), "origin", `pull/${pullRequest}/head:${ref}`], { cwd });
+    run(
+      "git",
+      [
+        "fetch",
+        "--no-tags",
+        "--deepen",
+        String(depth),
+        "origin",
+        `${baseBranch}:refs/remotes/origin/${baseBranch}`,
+      ],
+      { cwd, env },
+    );
+    run(
+      "git",
+      ["fetch", "--no-tags", "--deepen", String(depth), "origin", `pull/${pullRequest}/head:${ref}`],
+      { cwd, env },
+    );
   }
   if (isShallowRepository(cwd)) {
     run(
       "git",
       ["fetch", "--no-tags", "--unshallow", "origin", `${baseBranch}:refs/remotes/origin/${baseBranch}`, `pull/${pullRequest}/head:${ref}`],
-      { cwd },
+      { cwd, env },
     );
   }
-  run("git", ["merge-base", `origin/${baseBranch}`, "HEAD"], { cwd });
+  run("git", ["merge-base", `origin/${baseBranch}`, "HEAD"], { cwd, env });
 }
 
 function prepareSyntheticMergeReview({ targetDir, baseBranch, currentMainSha, exactHeadSha }) {
@@ -633,7 +657,7 @@ function prepareSyntheticMergeReview({ targetDir, baseBranch, currentMainSha, ex
     {
       cwd: targetDir,
       env: {
-        ...process.env,
+        ...gitIntegrityEnv(),
         GIT_AUTHOR_NAME: "ProjectClownfish",
         GIT_AUTHOR_EMAIL: "projectclownfish@users.noreply.github.com",
         GIT_AUTHOR_DATE: "2000-01-01T00:00:00Z",
@@ -648,7 +672,10 @@ function prepareSyntheticMergeReview({ targetDir, baseBranch, currentMainSha, ex
   if (!/^[0-9a-f]{40}$/i.test(syntheticMergeSha)) {
     throw new Error(`synthetic merge returned invalid commit SHA: ${syntheticMergeSha || "empty"}`);
   }
-  run("git", ["checkout", "--detach", syntheticMergeSha], { cwd: targetDir });
+  run("git", ["checkout", "--detach", syntheticMergeSha], {
+    cwd: targetDir,
+    env: gitIntegrityEnv(),
+  });
   const preToolchainSnapshot = syntheticReviewCheckoutSnapshot(targetDir);
   if (
     preToolchainSnapshot.head !== syntheticMergeSha ||
@@ -674,7 +701,10 @@ function prepareSyntheticMergeReview({ targetDir, baseBranch, currentMainSha, ex
 }
 
 function changedFileCount({ cwd, baseRef, targetRef }) {
-  const output = run("git", ["diff", "--name-only", `${baseRef}...${targetRef}`], { cwd }).trim();
+  const output = run("git", ["diff", "--name-only", `${baseRef}...${targetRef}`], {
+    cwd,
+    env: gitIntegrityEnv(),
+  }).trim();
   return output ? output.split(/\r?\n/).length : 0;
 }
 
@@ -851,9 +881,9 @@ function gitBlobSha(bytes) {
     .digest("hex");
 }
 
-function gitIntegrityEnv() {
+function gitIntegrityEnv(baseEnv = process.env) {
   return {
-    ...process.env,
+    ...baseEnv,
     GIT_ALLOW_PROTOCOL: "https:ssh",
     GIT_CONFIG_COUNT: "2",
     GIT_CONFIG_GLOBAL: "/dev/null",
@@ -935,7 +965,12 @@ function formatChangedGitConfigKeys(keys) {
 }
 
 function isShallowRepository(cwd) {
-  return run("git", ["rev-parse", "--is-shallow-repository"], { cwd }).trim() === "true";
+  return (
+    run("git", ["rev-parse", "--is-shallow-repository"], {
+      cwd,
+      env: gitIntegrityEnv(),
+    }).trim() === "true"
+  );
 }
 
 function prepareTargetToolchain(cwd) {
@@ -2027,15 +2062,15 @@ function ghJson(commandArgs) {
 }
 
 function ghReadEnv() {
-  return { ...process.env, GH_TOKEN: process.env.CLOWNFISH_READ_GH_TOKEN || process.env.GH_TOKEN || process.env.GITHUB_TOKEN };
+  return {
+    ...gitIntegrityEnv(),
+    GH_TOKEN: process.env.CLOWNFISH_READ_GH_TOKEN || process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
+  };
 }
 
 function validationEnv() {
   const env = {
-    ...process.env,
-    GIT_CONFIG_GLOBAL: "/dev/null",
-    GIT_CONFIG_NOSYSTEM: "1",
-    GIT_NO_REPLACE_OBJECTS: "1",
+    ...gitIntegrityEnv(),
     OPENCLAW_LOCAL_CHECK: "0",
   };
   for (const key of [
@@ -2052,12 +2087,7 @@ function validationEnv() {
 }
 
 function codexEnv() {
-  const env = {
-    ...process.env,
-    GIT_CONFIG_GLOBAL: "/dev/null",
-    GIT_CONFIG_NOSYSTEM: "1",
-    GIT_NO_REPLACE_OBJECTS: "1",
-  };
+  const env = gitIntegrityEnv();
   for (const key of [
     "GH_TOKEN",
     "GITHUB_TOKEN",

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -569,9 +569,15 @@ function readOnlyBlockers({ sourceJob, pull, view, issueComments, pullRequest })
 
 function checkoutExactPullHead({ repo, pullRequest, expectedHeadSha }) {
   const env = gitIntegrityEnv();
+  if (fs.existsSync(targetDir)) {
+    throw new Error("target checkout path already exists; refusing reused target");
+  }
+  fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+  run("gh", ["repo", "clone", repo, targetDir, "--", "--depth=1", "--filter=blob:none"], {
+    env: ghReadEnv(),
+  });
   if (!fs.existsSync(path.join(targetDir, ".git"))) {
-    fs.mkdirSync(path.dirname(targetDir), { recursive: true });
-    run("gh", ["repo", "clone", repo, targetDir, "--", "--depth=1", "--filter=blob:none"], { env: ghReadEnv() });
+    throw new Error("fresh target clone did not create a Git checkout");
   }
   if (run("git", ["status", "--porcelain"], { cwd: targetDir, env }).trim()) {
     throw new Error("target checkout has uncommitted changes");

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -55,6 +55,8 @@ let view = null;
 let plan = null;
 let preflightJobPath = null;
 let reviewContext = null;
+let validationCommands = [];
+let codexReview = null;
 let report = {
   repo: sourceJob.frontmatter.repo,
   source_job: sourceJob.relativePath,
@@ -110,10 +112,27 @@ try {
     }),
   );
   stage("prepare target toolchain", () => prepareTargetToolchain(targetDir));
-  const validationCommands = stage("target validation", () =>
+  reviewContext.integrityBaseline = stage("verify synthetic review checkout after toolchain", () =>
+    verifySyntheticReviewCheckout({
+      targetDir,
+      expectedSnapshot: reviewContext.preToolchainSnapshot,
+      expectedEntries: reviewContext.expectedTreeEntries,
+      phase: "target toolchain preparation",
+      allowGitConfigChanges: true,
+    }),
+  );
+  validationCommands = stage("target validation", () =>
     runValidation({ targetDir, reviewContext }),
   );
-  const codexReview = stage("Codex review", () =>
+  stage("verify synthetic review checkout after validation", () =>
+    verifySyntheticReviewCheckout({
+      targetDir,
+      expectedSnapshot: reviewContext.integrityBaseline,
+      expectedEntries: reviewContext.expectedTreeEntries,
+      phase: "target validation",
+    }),
+  );
+  codexReview = stage("Codex review", () =>
     runCodexReview({
       repo: sourceJob.frontmatter.repo,
       pullRequest,
@@ -121,6 +140,14 @@ try {
       validationCommands,
       sourceJob,
       reviewContext,
+    }),
+  );
+  stage("verify synthetic review checkout after Codex review", () =>
+    verifySyntheticReviewCheckout({
+      targetDir,
+      expectedSnapshot: reviewContext.integrityBaseline,
+      expectedEntries: reviewContext.expectedTreeEntries,
+      phase: "Codex review",
     }),
   );
   if (!isCleanCodexReview(codexReview)) {
@@ -132,9 +159,6 @@ try {
     });
     process.exit(0);
   }
-  stage("verify synthetic review checkout", () =>
-    verifySyntheticReviewCheckout({ targetDir, reviewContext }),
-  );
 
   const reviewedHeadSha = pull.head.sha;
   const reviewedState = String(pull.state ?? "").toLowerCase();
@@ -268,7 +292,7 @@ try {
     preflightJobPath = writePreflightJob({ sourceJob, pull, pullRequest, runDir }).path;
     plan.source_job = path.relative(repoRoot(), preflightJobPath);
   }
-  writeBlockedArtifacts({ reason });
+  writeBlockedArtifacts({ reason, validationCommands, codexReview });
   process.exitCode = 0;
 }
 
@@ -585,7 +609,6 @@ function ensureMergeBase({ cwd, baseBranch, pullRequest, ref }) {
 
 function prepareSyntheticMergeReview({ targetDir, baseBranch, currentMainSha, exactHeadSha }) {
   const baseRef = `origin/${baseBranch}`;
-  const gitConfigSha256 = localGitConfigFingerprint(targetDir);
   const rawDiffFiles = changedFileCount({ cwd: targetDir, baseRef, targetRef: exactHeadSha });
   const mergeContext = computeEffectiveMergeContext({
     targetDir,
@@ -626,11 +649,15 @@ function prepareSyntheticMergeReview({ targetDir, baseBranch, currentMainSha, ex
     throw new Error(`synthetic merge returned invalid commit SHA: ${syntheticMergeSha || "empty"}`);
   }
   run("git", ["checkout", "--detach", syntheticMergeSha], { cwd: targetDir });
-  const checkedOutTree = run("git", ["rev-parse", "HEAD^{tree}"], { cwd: targetDir }).trim();
-  const syntheticParent = run("git", ["rev-parse", "HEAD^"], { cwd: targetDir }).trim();
-  if (checkedOutTree !== mergeTreeSha || syntheticParent !== currentMainSha) {
+  const preToolchainSnapshot = syntheticReviewCheckoutSnapshot(targetDir);
+  if (
+    preToolchainSnapshot.head !== syntheticMergeSha ||
+    preToolchainSnapshot.tree !== mergeTreeSha ||
+    preToolchainSnapshot.parent !== currentMainSha
+  ) {
     throw new Error(
-      `synthetic merge binding mismatch: expected tree ${mergeTreeSha} on base ${currentMainSha}, got tree ${checkedOutTree} on base ${syntheticParent}`,
+      `synthetic merge binding mismatch: expected head ${syntheticMergeSha}, tree ${mergeTreeSha}, parent ${currentMainSha}; ` +
+        `actual head ${preToolchainSnapshot.head}, tree ${preToolchainSnapshot.tree}, parent ${preToolchainSnapshot.parent}`,
     );
   }
   return {
@@ -642,7 +669,7 @@ function prepareSyntheticMergeReview({ targetDir, baseBranch, currentMainSha, ex
     reviewedBaseSha: currentMainSha,
     expectedTreeEntries: resultEntries,
     changedFiles,
-    gitConfigSha256,
+    preToolchainSnapshot,
   };
 }
 
@@ -715,26 +742,45 @@ function fingerprintTreeEntries(baseEntries, resultEntries) {
   };
 }
 
-function verifySyntheticReviewCheckout({ targetDir, reviewContext }) {
-  const env = gitIntegrityEnv();
-  const head = run("git", ["rev-parse", "HEAD"], { cwd: targetDir, env }).trim();
-  const tree = run("git", ["rev-parse", "HEAD^{tree}"], { cwd: targetDir, env }).trim();
-  const parent = run("git", ["rev-parse", "HEAD^"], { cwd: targetDir, env }).trim();
-  if (
-    head !== reviewContext.syntheticMergeSha ||
-    tree !== reviewContext.mergeTreeSha ||
-    parent !== reviewContext.reviewedBaseSha ||
-    localGitConfigFingerprint(targetDir) !== reviewContext.gitConfigSha256
-  ) {
+function verifySyntheticReviewCheckout({
+  targetDir,
+  expectedSnapshot,
+  expectedEntries,
+  phase,
+  allowGitConfigChanges = false,
+}) {
+  const actualSnapshot = syntheticReviewCheckoutSnapshot(targetDir);
+  const mismatchedFields = [
+    ["head", expectedSnapshot.head, actualSnapshot.head],
+    ["tree", expectedSnapshot.tree, actualSnapshot.tree],
+    ["parent", expectedSnapshot.parent, actualSnapshot.parent],
+    ["config", expectedSnapshot.gitConfig.sha256, actualSnapshot.gitConfig.sha256],
+  ]
+    .filter(([field, expected, actual]) => expected !== actual && !(field === "config" && allowGitConfigChanges))
+    .map(([field]) => field);
+  if (mismatchedFields.length > 0) {
+    const changedKeys = changedGitConfigKeys(expectedSnapshot.gitConfig, actualSnapshot.gitConfig);
     throw new Error(
-      `synthetic review checkout changed during validation: expected ${reviewContext.syntheticMergeSha} ` +
-        `on ${reviewContext.reviewedBaseSha} with tree ${reviewContext.mergeTreeSha}`,
+      `synthetic review checkout integrity mismatch: phase=${phase}; mismatched_fields=${mismatchedFields.join(",")}; ` +
+        `expected_head=${expectedSnapshot.head}; actual_head=${actualSnapshot.head}; ` +
+        `expected_tree=${expectedSnapshot.tree}; actual_tree=${actualSnapshot.tree}; ` +
+        `expected_parent=${expectedSnapshot.parent}; actual_parent=${actualSnapshot.parent}; ` +
+        `expected_config_sha256=${expectedSnapshot.gitConfig.sha256}; actual_config_sha256=${actualSnapshot.gitConfig.sha256}; ` +
+        `changed_git_config_keys=${formatChangedGitConfigKeys(changedKeys)}`,
     );
   }
-  verifyTrackedFilesystem({
-    targetDir,
-    expectedEntries: reviewContext.expectedTreeEntries,
-  });
+  verifyTrackedFilesystem({ targetDir, expectedEntries });
+  return actualSnapshot;
+}
+
+function syntheticReviewCheckoutSnapshot(targetDir) {
+  const env = gitIntegrityEnv();
+  return {
+    head: run("git", ["rev-parse", "HEAD"], { cwd: targetDir, env }).trim(),
+    tree: run("git", ["rev-parse", "HEAD^{tree}"], { cwd: targetDir, env }).trim(),
+    parent: run("git", ["rev-parse", "HEAD^"], { cwd: targetDir, env }).trim(),
+    gitConfig: localGitConfigSnapshot(targetDir),
+  };
 }
 
 function refreshTargetMain({ targetDir, baseBranch }) {
@@ -808,13 +854,54 @@ function gitIntegrityEnv() {
   };
 }
 
-function localGitConfigFingerprint(cwd) {
+function localGitConfigSnapshot(cwd) {
   const config = run("git", ["config", "--local", "--list", "--null"], {
     cwd,
     env: gitIntegrityEnv(),
     maxBuffer: 1024 * 1024,
   });
-  return createHash("sha256").update(config).digest("hex");
+  const keyValues = new Map();
+  for (const entry of config.split("\0").filter(Boolean)) {
+    const separator = entry.indexOf("\n");
+    const key = (separator === -1 ? entry : entry.slice(0, separator)).trim().toLowerCase();
+    if (!key) continue;
+    const value = separator === -1 ? "" : entry.slice(separator + 1);
+    const valueHashes = keyValues.get(key) ?? [];
+    valueHashes.push(createHash("sha256").update(value).digest("hex"));
+    keyValues.set(key, valueHashes);
+  }
+  return {
+    sha256: createHash("sha256").update(config).digest("hex"),
+    keyFingerprints: new Map(
+      [...keyValues].map(([key, valueHashes]) => [
+        key,
+        createHash("sha256").update(valueHashes.join("\0")).digest("hex"),
+      ]),
+    ),
+  };
+}
+
+function changedGitConfigKeys(expected, actual) {
+  const keys = new Set([...expected.keyFingerprints.keys(), ...actual.keyFingerprints.keys()]);
+  return [...keys]
+    .filter((key) => expected.keyFingerprints.get(key) !== actual.keyFingerprints.get(key))
+    .map(safeGitConfigKey)
+    .sort();
+}
+
+function safeGitConfigKey(key) {
+  const parts = key.split(".");
+  const safePart = /^[a-z][a-z0-9-]{0,63}$/;
+  if (parts.length === 2 && parts.every((part) => safePart.test(part))) return key;
+  const section = safePart.test(parts[0] ?? "") ? parts[0] : "config";
+  const name = safePart.test(parts.at(-1) ?? "") ? parts.at(-1) : "key";
+  return `${section}.[redacted].${name}`;
+}
+
+function formatChangedGitConfigKeys(keys) {
+  if (keys.length === 0) return "unavailable";
+  const shown = keys.slice(0, 20);
+  return keys.length === shown.length ? shown.join(",") : `${shown.join(",")},...(+${keys.length - shown.length})`;
 }
 
 function isShallowRepository(cwd) {

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -118,7 +118,7 @@ try {
       expectedSnapshot: reviewContext.preToolchainSnapshot,
       expectedEntries: reviewContext.expectedTreeEntries,
       phase: "target toolchain preparation",
-      allowGitConfigChanges: true,
+      allowToolchainGitConfigChange: true,
     }),
   );
   validationCommands = stage("target validation", () =>
@@ -747,16 +747,22 @@ function verifySyntheticReviewCheckout({
   expectedSnapshot,
   expectedEntries,
   phase,
-  allowGitConfigChanges = false,
+  allowToolchainGitConfigChange = false,
 }) {
   const actualSnapshot = syntheticReviewCheckoutSnapshot(targetDir);
+  const toolchainConfigChangeAllowed =
+    allowToolchainGitConfigChange &&
+    isAllowedToolchainGitConfigChange(expectedSnapshot.gitConfig, actualSnapshot.gitConfig);
   const mismatchedFields = [
     ["head", expectedSnapshot.head, actualSnapshot.head],
     ["tree", expectedSnapshot.tree, actualSnapshot.tree],
     ["parent", expectedSnapshot.parent, actualSnapshot.parent],
     ["config", expectedSnapshot.gitConfig.sha256, actualSnapshot.gitConfig.sha256],
   ]
-    .filter(([field, expected, actual]) => expected !== actual && !(field === "config" && allowGitConfigChanges))
+    .filter(
+      ([field, expected, actual]) =>
+        expected !== actual && !(field === "config" && toolchainConfigChangeAllowed),
+    )
     .map(([field]) => field);
   if (mismatchedFields.length > 0) {
     const changedKeys = changedGitConfigKeys(expectedSnapshot.gitConfig, actualSnapshot.gitConfig);
@@ -848,14 +854,20 @@ function gitBlobSha(bytes) {
 function gitIntegrityEnv() {
   return {
     ...process.env,
+    GIT_ALLOW_PROTOCOL: "https:ssh",
+    GIT_CONFIG_COUNT: "2",
     GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_KEY_0: "core.hooksPath",
+    GIT_CONFIG_KEY_1: "protocol.ext.allow",
     GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_VALUE_0: "/dev/null",
+    GIT_CONFIG_VALUE_1: "never",
     GIT_NO_REPLACE_OBJECTS: "1",
   };
 }
 
 function localGitConfigSnapshot(cwd) {
-  const config = run("git", ["config", "--local", "--list", "--null"], {
+  const config = run("git", ["config", "--local", "--includes", "--list", "--null"], {
     cwd,
     env: gitIntegrityEnv(),
     maxBuffer: 1024 * 1024,
@@ -872,6 +884,7 @@ function localGitConfigSnapshot(cwd) {
   }
   return {
     sha256: createHash("sha256").update(config).digest("hex"),
+    valueFingerprints: keyValues,
     keyFingerprints: new Map(
       [...keyValues].map(([key, valueHashes]) => [
         key,
@@ -881,12 +894,29 @@ function localGitConfigSnapshot(cwd) {
   };
 }
 
-function changedGitConfigKeys(expected, actual) {
+function changedGitConfigRawKeys(expected, actual) {
   const keys = new Set([...expected.keyFingerprints.keys(), ...actual.keyFingerprints.keys()]);
   return [...keys]
     .filter((key) => expected.keyFingerprints.get(key) !== actual.keyFingerprints.get(key))
+    .sort();
+}
+
+function changedGitConfigKeys(expected, actual) {
+  return changedGitConfigRawKeys(expected, actual)
     .map(safeGitConfigKey)
     .sort();
+}
+
+function isAllowedToolchainGitConfigChange(expected, actual) {
+  const changedKeys = changedGitConfigRawKeys(expected, actual);
+  if (changedKeys.length !== 1 || changedKeys[0] !== "core.hookspath") {
+    return false;
+  }
+  const values = actual.valueFingerprints.get("core.hookspath") ?? [];
+  return (
+    values.length === 1 &&
+    values[0] === createHash("sha256").update("git-hooks").digest("hex")
+  );
 }
 
 function safeGitConfigKey(key) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -250,6 +250,45 @@ test("external merge preflight blocks tracked checkout mutation after review", (
   assert.match(report.reason, /synthetic review checkout changed tracked bytes/);
 });
 
+test("external merge preflight allows target setup to update local Git config", () => {
+  const fixture = makeFixture({
+    toolchainGitConfig: { key: "core.hooksPath", value: ".githooks" },
+  });
+  const { report, result } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "passed", report.reason);
+  assert.equal(result.actions[0]?.action, "merge_canonical");
+});
+
+test("external merge preflight blocks later Git config mutation with precise diagnostics", () => {
+  const sensitiveValue = "sensitive-review-helper-value";
+  const fixture = makeFixture({
+    toolchainGitConfig: { key: "core.hooksPath", value: ".githooks" },
+    codexGitConfigMutation: { key: "credential.helper", value: sensitiveValue },
+  });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /phase=Codex review/);
+  assert.match(report.reason, /mismatched_fields=config/);
+  assert.match(report.reason, new RegExp(`expected_head=${fixture.syntheticMergeSha}; actual_head=${fixture.syntheticMergeSha}`));
+  assert.match(report.reason, new RegExp(`expected_tree=${fixture.mergeTreeSha}; actual_tree=${fixture.mergeTreeSha}`));
+  assert.match(report.reason, new RegExp(`expected_parent=${fixture.baseSha}; actual_parent=${fixture.baseSha}`));
+  const expectedConfig = report.reason.match(/expected_config_sha256=([0-9a-f]{64})/)?.[1];
+  const actualConfig = report.reason.match(/actual_config_sha256=([0-9a-f]{64})/)?.[1];
+  assert.ok(expectedConfig);
+  assert.ok(actualConfig);
+  assert.notEqual(expectedConfig, actualConfig);
+  assert.match(report.reason, /changed_git_config_keys=credential\.helper/);
+  assert.doesNotMatch(report.reason, /\.githooks|sensitive-review-helper-value/);
+  assert.deepEqual(report.validation_commands, [
+    `pnpm check:changed --base ${fixture.baseSha} --head ${fixture.syntheticMergeSha}`,
+    `git diff --check ${fixture.baseSha}...${fixture.syntheticMergeSha}`,
+    "git diff --check",
+  ]);
+  assert.deepEqual(report.codex_review, { status: "clean", findings: 0 });
+});
+
 test("external merge preflight accepts #100910 assignee and harmless label drift after final recheck", () => {
   const fixture = makeFixture({
     issueUpdatedAt: "2026-07-06T13:38:20Z",
@@ -2758,6 +2797,8 @@ function makeFixture({
   validationFailure = null,
   syntheticMergeFailure = null,
   codexMutatesCheckout = false,
+  toolchainGitConfig = null,
+  codexGitConfigMutation = null,
   codexReview = {
     status: "clean",
     summary: "clean fixture review",
@@ -2792,6 +2833,7 @@ function makeFixture({
   const gitCommandsPath = path.join(root, "git-commands.log");
   const pnpmCommandsPath = path.join(root, "pnpm-commands.log");
   const codexPromptPath = path.join(root, "codex-prompt.txt");
+  const gitConfigStatePath = path.join(root, "git-config-state");
   const finalIssueComments = rehydratedIssueComments ?? issueComments;
   const finalReviewComments = rehydratedReviewComments ?? reviewComments;
   const finalReviewThreads = rehydratedReviewThreads ?? [];
@@ -2924,6 +2966,12 @@ const mainFetchCountPath = path.join(${JSON.stringify(root)}, "main-fetch-count"
 const commandLog = ${JSON.stringify(gitCommandsPath)};
 fs.appendFileSync(commandLog, args.join(" ") + "\\n");
 const state = fs.existsSync(statePath) ? fs.readFileSync(statePath, "utf8") : "pr";
+if (args[0] === "config" && args[1] === "--local" && args[2] === "--list" && args[3] === "--null") {
+  if (fs.existsSync(${JSON.stringify(gitConfigStatePath)})) {
+    process.stdout.write(fs.readFileSync(${JSON.stringify(gitConfigStatePath)}));
+  }
+  process.exit(0);
+}
 if (args[0] === "rev-parse") {
   if (args[1] === "origin/main") {
     console.log(fs.existsSync(refreshedMainPath) ? refreshedMain : currentMain);
@@ -2984,6 +3032,13 @@ process.exit(0);
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(pnpmCommandsPath)}, args.join(" ") + "\\n");
+const toolchainGitConfig = ${JSON.stringify(toolchainGitConfig)};
+if (toolchainGitConfig && args[0] === "install") {
+  fs.writeFileSync(
+    ${JSON.stringify(gitConfigStatePath)},
+    toolchainGitConfig.key + "\\n" + toolchainGitConfig.value + "\\0",
+  );
+}
 const failure = ${JSON.stringify(validationFailure)};
 if (failure && args[0] === "check:changed") {
   process.stdout.write(String(failure.stdout ?? ""));
@@ -3001,6 +3056,18 @@ const index = args.indexOf("--output-last-message");
 fs.writeFileSync(${JSON.stringify(codexPromptPath)}, fs.readFileSync(0, "utf8"));
 if (${JSON.stringify(codexMutatesCheckout)}) {
   fs.writeFileSync("src/effective.ts", "mutated by fixture review\\n");
+}
+const codexGitConfigMutation = ${JSON.stringify(codexGitConfigMutation)};
+if (codexGitConfigMutation) {
+  const configPath = ${JSON.stringify(gitConfigStatePath)};
+  const currentConfig = fs.existsSync(configPath) ? fs.readFileSync(configPath) : Buffer.alloc(0);
+  fs.writeFileSync(
+    configPath,
+    Buffer.concat([
+      currentConfig,
+      Buffer.from(codexGitConfigMutation.key + "\\n" + codexGitConfigMutation.value + "\\0"),
+    ]),
+  );
 }
 fs.writeFileSync(args[index + 1], JSON.stringify(${JSON.stringify(codexReview)}));
 `,

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -39,6 +39,11 @@ test("external merge preflight is exact-head, read-only, and refuses unresolved 
   assert.match(script, /CLOWNFISH_EXTERNAL_PREFLIGHT_CODEX_SANDBOX \?\? defaultCodexReviewSandbox/);
   assert.match(script, /--sandbox",\s*codexReviewSandbox/);
   assert.match(script, /--config\.enable-pre-post-scripts=false/);
+  assert.match(script, /GIT_ALLOW_PROTOCOL: "https:ssh"/);
+  assert.match(script, /GIT_CONFIG_KEY_0: "core\.hooksPath"/);
+  assert.match(script, /GIT_CONFIG_VALUE_0: "\/dev\/null"/);
+  assert.match(script, /GIT_CONFIG_KEY_1: "protocol\.ext\.allow"/);
+  assert.match(script, /GIT_CONFIG_VALUE_1: "never"/);
   assert.match(script, /GIT_NO_REPLACE_OBJECTS: "1"/);
   assert.match(script, /function verifyTrackedFilesystem/);
   assert.match(script, /function gitBlobSha/);
@@ -252,18 +257,38 @@ test("external merge preflight blocks tracked checkout mutation after review", (
 
 test("external merge preflight allows target setup to update local Git config", () => {
   const fixture = makeFixture({
-    toolchainGitConfig: { key: "core.hooksPath", value: ".githooks" },
+    toolchainGitConfig: { key: "core.hooksPath", value: "git-hooks" },
   });
   const { report, result } = runPreflightFixture(fixture);
 
   assert.equal(report.status, "passed", report.reason);
   assert.equal(result.actions[0]?.action, "merge_canonical");
+  assert.match(
+    fs.readFileSync(fixture.gitCommandsPath, "utf8"),
+    /config --local --includes --list --null/,
+  );
+});
+
+test("external merge preflight rejects unrecognized target setup Git config", () => {
+  const sensitiveValue = "ext::malicious-review-helper";
+  const fixture = makeFixture({
+    toolchainGitConfig: { key: "remote.origin.url", value: sensitiveValue },
+  });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /phase=target toolchain preparation/);
+  assert.match(report.reason, /mismatched_fields=config/);
+  assert.match(report.reason, /changed_git_config_keys=remote\.\[redacted\]\.url/);
+  assert.doesNotMatch(report.reason, new RegExp(sensitiveValue));
+  assert.deepEqual(report.validation_commands, []);
+  assert.equal(report.codex_review, null);
 });
 
 test("external merge preflight blocks later Git config mutation with precise diagnostics", () => {
   const sensitiveValue = "sensitive-review-helper-value";
   const fixture = makeFixture({
-    toolchainGitConfig: { key: "core.hooksPath", value: ".githooks" },
+    toolchainGitConfig: { key: "core.hooksPath", value: "git-hooks" },
     codexGitConfigMutation: { key: "credential.helper", value: sensitiveValue },
   });
   const { report } = runPreflightFixture(fixture);
@@ -280,13 +305,30 @@ test("external merge preflight blocks later Git config mutation with precise dia
   assert.ok(actualConfig);
   assert.notEqual(expectedConfig, actualConfig);
   assert.match(report.reason, /changed_git_config_keys=credential\.helper/);
-  assert.doesNotMatch(report.reason, /\.githooks|sensitive-review-helper-value/);
+  assert.doesNotMatch(report.reason, /git-hooks|sensitive-review-helper-value/);
   assert.deepEqual(report.validation_commands, [
     `pnpm check:changed --base ${fixture.baseSha} --head ${fixture.syntheticMergeSha}`,
     `git diff --check ${fixture.baseSha}...${fixture.syntheticMergeSha}`,
     "git diff --check",
   ]);
   assert.deepEqual(report.codex_review, { status: "clean", findings: 0 });
+});
+
+test("external merge preflight fingerprints included Git config values", () => {
+  const initialValue = "initial-credential-helper";
+  const sensitiveValue = "mutated-credential-helper";
+  const fixture = makeFixture({
+    initialGitConfig: { key: "include.path", value: "../review-config" },
+    initialIncludedGitConfig: { key: "credential.helper", value: initialValue },
+    codexIncludedGitConfigMutation: { key: "credential.helper", value: sensitiveValue },
+  });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /phase=Codex review/);
+  assert.match(report.reason, /mismatched_fields=config/);
+  assert.match(report.reason, /changed_git_config_keys=credential\.helper/);
+  assert.doesNotMatch(report.reason, new RegExp(`${initialValue}|${sensitiveValue}`));
 });
 
 test("external merge preflight accepts #100910 assignee and harmless label drift after final recheck", () => {
@@ -2797,8 +2839,11 @@ function makeFixture({
   validationFailure = null,
   syntheticMergeFailure = null,
   codexMutatesCheckout = false,
+  initialGitConfig = null,
+  initialIncludedGitConfig = null,
   toolchainGitConfig = null,
   codexGitConfigMutation = null,
+  codexIncludedGitConfigMutation = null,
   codexReview = {
     status: "clean",
     summary: "clean fixture review",
@@ -2834,6 +2879,7 @@ function makeFixture({
   const pnpmCommandsPath = path.join(root, "pnpm-commands.log");
   const codexPromptPath = path.join(root, "codex-prompt.txt");
   const gitConfigStatePath = path.join(root, "git-config-state");
+  const gitIncludedConfigStatePath = path.join(root, "git-included-config-state");
   const finalIssueComments = rehydratedIssueComments ?? issueComments;
   const finalReviewComments = rehydratedReviewComments ?? reviewComments;
   const finalReviewThreads = rehydratedReviewThreads ?? [];
@@ -2844,6 +2890,18 @@ function makeFixture({
   const finalHeadSha = rehydratedHeadSha ?? headSha;
   const finalState = rehydratedState ?? "open";
   fs.mkdirSync(binDir, { recursive: true });
+  if (initialGitConfig) {
+    fs.writeFileSync(
+      gitConfigStatePath,
+      `${initialGitConfig.key}\n${initialGitConfig.value}\0`,
+    );
+  }
+  if (initialIncludedGitConfig) {
+    fs.writeFileSync(
+      gitIncludedConfigStatePath,
+      `${initialIncludedGitConfig.key}\n${initialIncludedGitConfig.value}\0`,
+    );
+  }
   fs.writeFileSync(
     jobPath,
     `---
@@ -2966,9 +3024,12 @@ const mainFetchCountPath = path.join(${JSON.stringify(root)}, "main-fetch-count"
 const commandLog = ${JSON.stringify(gitCommandsPath)};
 fs.appendFileSync(commandLog, args.join(" ") + "\\n");
 const state = fs.existsSync(statePath) ? fs.readFileSync(statePath, "utf8") : "pr";
-if (args[0] === "config" && args[1] === "--local" && args[2] === "--list" && args[3] === "--null") {
+if (args[0] === "config" && args.includes("--local") && args.includes("--list") && args.includes("--null")) {
   if (fs.existsSync(${JSON.stringify(gitConfigStatePath)})) {
     process.stdout.write(fs.readFileSync(${JSON.stringify(gitConfigStatePath)}));
+  }
+  if (args.includes("--includes") && fs.existsSync(${JSON.stringify(gitIncludedConfigStatePath)})) {
+    process.stdout.write(fs.readFileSync(${JSON.stringify(gitIncludedConfigStatePath)}));
   }
   process.exit(0);
 }
@@ -3067,6 +3128,13 @@ if (codexGitConfigMutation) {
       currentConfig,
       Buffer.from(codexGitConfigMutation.key + "\\n" + codexGitConfigMutation.value + "\\0"),
     ]),
+  );
+}
+const codexIncludedGitConfigMutation = ${JSON.stringify(codexIncludedGitConfigMutation)};
+if (codexIncludedGitConfigMutation) {
+  fs.writeFileSync(
+    ${JSON.stringify(gitIncludedConfigStatePath)},
+    codexIncludedGitConfigMutation.key + "\\n" + codexIncludedGitConfigMutation.value + "\\0",
   );
 }
 fs.writeFileSync(args[index + 1], JSON.stringify(${JSON.stringify(codexReview)}));

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -52,8 +52,8 @@ test("external merge preflight is exact-head, read-only, and refuses unresolved 
   assert.match(script, /delete env\[key\]/);
   assert.match(script, /if \(process\.env\.GITHUB_ACTIONS === "true"\) \{\s*delete env\.OPENAI_API_KEY;\s*delete env\.CODEX_API_KEY;/s);
   assert.match(script, /function validationEnv\(\)[\s\S]*?"CLOWNFISH_READ_GH_TOKEN"/);
-  assert.match(script, /function validationEnv\(\)[\s\S]*?GIT_NO_REPLACE_OBJECTS: "1"/);
-  assert.match(script, /function codexEnv\(\)[\s\S]*?GIT_NO_REPLACE_OBJECTS: "1"/);
+  assert.match(script, /function validationEnv\(\)[\s\S]*?\.\.\.gitIntegrityEnv\(\)/);
+  assert.match(script, /function codexEnv\(\)[\s\S]*?gitIntegrityEnv\(\)/);
   assert.doesNotMatch(script, /pr", "merge"/);
   assert.doesNotMatch(script, /resolveReviewThread/);
 });
@@ -3023,6 +3023,16 @@ const refreshedMainPath = path.join(${JSON.stringify(root)}, "main-refreshed");
 const mainFetchCountPath = path.join(${JSON.stringify(root)}, "main-fetch-count");
 const commandLog = ${JSON.stringify(gitCommandsPath)};
 fs.appendFileSync(commandLog, args.join(" ") + "\\n");
+if (
+  process.env.GIT_ALLOW_PROTOCOL !== "https:ssh" ||
+  process.env.GIT_CONFIG_KEY_0 !== "core.hooksPath" ||
+  process.env.GIT_CONFIG_VALUE_0 !== "/dev/null" ||
+  process.env.GIT_CONFIG_KEY_1 !== "protocol.ext.allow" ||
+  process.env.GIT_CONFIG_VALUE_1 !== "never"
+) {
+  process.stderr.write("missing Git hardening");
+  process.exit(97);
+}
 const state = fs.existsSync(statePath) ? fs.readFileSync(statePath, "utf8") : "pr";
 if (args[0] === "config" && args.includes("--local") && args.includes("--list") && args.includes("--null")) {
   if (fs.existsSync(${JSON.stringify(gitConfigStatePath)})) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -255,6 +255,15 @@ test("external merge preflight blocks tracked checkout mutation after review", (
   assert.match(report.reason, /synthetic review checkout changed tracked bytes/);
 });
 
+test("external merge preflight refuses a reused target before running Git", () => {
+  const fixture = makeFixture({ preexistingTargetCheckout: true });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /target checkout path already exists; refusing reused target/);
+  assert.equal(fs.existsSync(fixture.gitCommandsPath), false);
+});
+
 test("external merge preflight allows target setup to update local Git config", () => {
   const fixture = makeFixture({
     toolchainGitConfig: { key: "core.hooksPath", value: "git-hooks" },
@@ -2841,6 +2850,7 @@ function makeFixture({
   codexMutatesCheckout = false,
   initialGitConfig = null,
   initialIncludedGitConfig = null,
+  preexistingTargetCheckout = false,
   toolchainGitConfig = null,
   codexGitConfigMutation = null,
   codexIncludedGitConfigMutation = null,
@@ -2890,6 +2900,9 @@ function makeFixture({
   const finalHeadSha = rehydratedHeadSha ?? headSha;
   const finalState = rehydratedState ?? "open";
   fs.mkdirSync(binDir, { recursive: true });
+  if (preexistingTargetCheckout) {
+    fs.mkdirSync(path.join(runDir, "target", ".git"), { recursive: true });
+  }
   if (initialGitConfig) {
     fs.writeFileSync(
       gitConfigStatePath,


### PR DESCRIPTION
## Summary

- accept only the known OpenClaw setup mutation `core.hooksPath=git-hooks` when establishing the post-toolchain integrity baseline
- fingerprint effective local Git config, including included files, without exposing config values
- neutralize hooks and unsafe transport configuration across clone, checkout, fetch, validation, and Codex review phases
- reject reused target directories before any Git command runs
- preserve completed validation and review evidence when a later integrity check blocks

## Validation

- exact-head CI `validate` passed, including `npm test`, all job specs, prompt rendering, dry-run worker, offline artifact build, and script syntax checks
- CodeQL and Socket checks passed
- focused adversarial setup/config/reused-target cases passed
- independent integrity review clean on `ee4c34191`

This unblocks deterministic external preflight for OpenClaw PR #89997 without trusting arbitrary setup-time Git configuration.