### PR TITLE
chore(queue): add exact merge preflight jobs

### DIFF
--- a/jobs/openclaw/inbox/exact-merge-batch-98505-20260706.md
+++ b/jobs/openclaw/inbox/exact-merge-batch-98505-20260706.md
@@ -1,0 +1,40 @@
+---
+repo: openclaw/openclaw
+cluster_id: exact-merge-batch-98505-20260706
+mode: autonomous
+allowed_actions:
+  - "merge"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "fix"
+  - "raise_pr"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unresolved_review"
+  - "unclear_canonical"
+canonical:
+  - "#98505"
+candidates:
+  - "#98505"
+cluster_refs:
+  - "#98505"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: false
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Merge only PR #98505 after the deterministic external preflight binds validation and review to its exact live head."
+notes: "Batch head at dispatch preparation: d70b907331cf4bae4f2b160a5660059715e93826. Re-fetch live state and stop if the head or merge policy changes."
+---
+
+# Exact Merge Batch: #98505
+
+Run the deterministic external merge preflight for
+https://github.com/openclaw/openclaw/pull/98505 and apply only the resulting
+exact-head merge action. No comments, labels, fixes, or adjacent cluster work.

--- a/jobs/openclaw/inbox/exact-merge-canary-89997-20260706.md
+++ b/jobs/openclaw/inbox/exact-merge-canary-89997-20260706.md
@@ -1,0 +1,40 @@
+---
+repo: openclaw/openclaw
+cluster_id: exact-merge-canary-89997-20260706
+mode: autonomous
+allowed_actions:
+  - "merge"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "fix"
+  - "raise_pr"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unresolved_review"
+  - "unclear_canonical"
+canonical:
+  - "#89997"
+candidates:
+  - "#89997"
+cluster_refs:
+  - "#89997"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: false
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Merge only PR #89997 after the deterministic external preflight binds validation and review to its exact live head."
+notes: "Canary head at dispatch preparation: 8b0a69186e625521d1c72f1938bb80c5b538f092. Re-fetch live state and stop if the head or merge policy changes."
+---
+
+# Exact Merge Canary: #89997
+
+Run the deterministic external merge preflight for
+https://github.com/openclaw/openclaw/pull/89997 and apply only the resulting
+exact-head merge action. No comments, labels, fixes, or adjacent cluster work.


### PR DESCRIPTION
## Summary

- add one merge-only exact-head job for OpenClaw #98505
- add one merge-only exact-head job for OpenClaw #89997
- prohibit comments, labels, fixes, force-pushes, and check bypasses

Both recorded heads were reverified immediately before commit.

## Validation

- `npm run validate:job -- jobs/openclaw/inbox/exact-merge-batch-98505-20260706.md`
- `npm run validate:job -- jobs/openclaw/inbox/exact-merge-canary-89997-20260706.md`
- `git diff --check`