### PR TITLE
fix(preflight): accept current positive bot comments

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -1517,7 +1517,7 @@ function hasClawSweeperReadyReviewSignal(body) {
   return (
     isClawSweeperMaintainerReviewHeader(firstLine) &&
     /result:\s*ready for maintainer review\./.test(body) &&
-    /(review metrics:\*\*\s*none identified|review metrics:\s*none identified|no (?:clawsweeper |automated )?repair(?: job)? is needed|no concrete contributor-facing blocker left|remaining action is normal maintainer review)/.test(
+    /(review metrics:\*\*\s*none identified|review metrics:\s*none identified|no (?:clawsweeper |automated )?repair(?: job| lane)? is needed|no concrete (?:code finding|contributor-facing blocker left)|remaining action is normal maintainer review)/.test(
       body,
     )
   );
@@ -1535,12 +1535,57 @@ function hasActionableClawSweeperReviewSignal(body) {
   ) {
     return true;
   }
-  return [
+  return hasExplicitMergeObjection(withoutAdvisoryReviewSections(body)) || [
     /\*\*merge readiness\*\*[\s\S]{0,1200}\bresult:\s*blocked until\b/,
     /\*\*proof guidance\*\*[\s\S]{0,1600}\b(?:needs?|requires?) (?:stronger )?real behavior proof before merge\b/,
     /\*\*risk before merge\*\*[\s\S]{0,1600}\b(?:blocker|must|needs?|required|missing)\b/,
     /\*\*next step before merge\*\*[\s\S]{0,1200}\bremaining (?:merge )?blocker\b/,
   ].some((pattern) => pattern.test(body));
+}
+
+function withoutAdvisoryReviewSections(body) {
+  return String(body).replace(
+    /\*\*maintainer options:\*\*[\s\S]*?(?=\n\*\*[^*\n]+\*\*\s*(?:\n|$)|$)/gi,
+    "",
+  );
+}
+
+function hasExplicitMergeObjection(body) {
+  return String(body)
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/^[-*]\s+/, "").replace(/^#{1,6}\s*/, ""))
+    .filter(Boolean)
+    .some((line) => {
+      if (isNegatedOrResolvedMergeObjection(line)) return false;
+      return [
+        /\b(?:maintainers?\s+)?(?:do not|don't|must not|mustn't|should not|shouldn't|cannot|can't)\s+(?:merge|land|ship)\b/,
+        /\b(?:this|the)?\s*(?:pr|patch|change)\s+(?:must not|mustn't|should not|shouldn't|cannot|can't)\s+be\s+(?:merged|landed|shipped)\b/,
+        /\b(?:do not|don't|must not|mustn't)\s+proceed with (?:the )?(?:merge|landing|shipping)\b/,
+        /\b(?:this|it|the (?:pr|patch|change))\s+is\s+not safe to\s+(?:merge|land|ship)\b/,
+        /\b(?:this|it|the (?:pr|patch|change))\s+is\s+unsafe to\s+(?:merge|land|ship)\b/,
+        /\bnot ready to\s+(?:merge|land|ship)\b/,
+        /\bhold (?:the )?(?:merge|landing|shipping)\s+until\b/,
+        /\b(?:the )?(?:pr|patch|change)\s+remains\s+blocked\b/,
+        /\b(?:merge|merging|landing|shipping)\s+(?:is\s+)?(?:still\s+)?(?:blocked|not allowed)\b/,
+        /\b(?:merge|merging|landing|shipping)\s+remains\s+blocked\b/,
+        /\b(?:merge|merging|landing|shipping)\s+(?:cannot|can't|must not|mustn't|should not|shouldn't)\s+(?:proceed|continue)\b/,
+        /\b(?:merge|merging|landing|shipping)\s+(?:must|should)\s+(?:wait|be delayed|remain blocked)\b/,
+        /\b(?:pending|awaiting)\s+(?:(?:maintainer|policy|risk)\s+){1,2}(?:decision|approval|acceptance)\b/,
+        /\b(?:maintainer|policy|risk)(?:\s+(?:policy|risk))?\s+(?:decision|approval|acceptance)\s+(?:is\s+)?(?:still\s+)?(?:pending|unresolved)\b/,
+        /\b(?:maintainer|policy|risk)(?:\s+(?:policy|risk))?\s+(?:decision|approval|acceptance)\s+(?:is\s+)?required before (?:merge|merging|landing|shipping)\b/,
+      ].some((pattern) => pattern.test(line));
+    });
+}
+
+function isNegatedOrResolvedMergeObjection(line) {
+  return [
+    /^no\s+(?:pending|unresolved)\s+(?:(?:maintainer|policy|risk)\s+){1,2}(?:decision|approval|acceptance)\s+(?:remains?|exists?)\.?$/,
+    /^no\s+(?:maintainer|policy|risk)(?:\s+(?:policy|risk))?\s+(?:decision|approval|acceptance)\s+is\s+(?:pending|unresolved)\.?$/,
+    /^(?:maintainer|policy|risk)(?:\s+(?:policy|risk))?\s+(?:decision|approval|acceptance)\s+is\s+(?:not|no longer)\s+(?:pending|unresolved)\.?$/,
+    /^(?:the\s+)?(?:previously|previous|earlier|formerly|prior)\b.*\b(?:resolved|addressed|cleared|granted|accepted|no longer applies)\.?$/,
+    /^there is no reason (?:the )?(?:merge|landing|shipping) is blocked\.?$/,
+    /^(?:merge|landing|shipping) is not allowed to remain blocked\.?$/,
+  ].some((pattern) => pattern.test(line));
 }
 
 function isClawSweeperMaintainerReviewHeader(line) {
@@ -1558,7 +1603,14 @@ function findHighRiskMergeLabel(labels) {
 function isAutomationAuthor(author) {
   return (
     /\[bot\]$|bot$/.test(author) ||
-    ["clawsweeper", "openclaw-clownfish", "openclaw-barnacle", "barnacle-openclaw", "greptile-apps"].includes(author)
+    [
+      "clawsweeper",
+      "github-actions",
+      "openclaw-clownfish",
+      "openclaw-barnacle",
+      "barnacle-openclaw",
+      "greptile-apps",
+    ].includes(author)
   );
 }
 

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -1119,6 +1119,122 @@ test("external merge preflight accepts #99607 timestamped exact-head live review
   assert.equal(report.status, "passed", report.reason);
 });
 
+test("external merge preflight accepts #98505 current-head ready review phrasing", () => {
+  const fixture = makeFixture({
+    pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+    issueComments: [
+      {
+        author: { login: "clawsweeper" },
+        authorAssociation: "CONTRIBUTOR",
+        body: [
+          "Codex review: needs maintainer review before merge. _Reviewed July 6, 2026, 5:44 PM ET / 21:44 UTC._",
+          "",
+          "**Review metrics:** 1 noteworthy metric.",
+          "",
+          "**Merge readiness**",
+          "Result: ready for maintainer review.",
+          "",
+          "**Next step before merge**",
+          "- No ClawSweeper repair lane is needed; the latest head has no concrete code finding, and the remaining action is maintainer review, CI completion, and risk acceptance.",
+          "",
+          `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+          "",
+          "<!-- clawsweeper-review item=123 -->",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/98505#issuecomment-4852565769",
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+  assert.equal(report.status, "passed", report.reason);
+});
+
+test("external merge preflight blocks explicit objections appended to positive ready-review phrasing", () => {
+  for (const objection of [
+    "No concrete code finding, but maintainers must not merge this.",
+    "No concrete code finding, but maintainers mustn't merge this.",
+    "No ClawSweeper repair lane is needed, but merge remains blocked.",
+    "No concrete code finding, but merge is still blocked.",
+    "No concrete code finding, but merging remains blocked.",
+    "No concrete code finding, but this is not safe to merge.",
+    "No concrete code finding, but this PR must not be merged.",
+    "No concrete code finding, but merge cannot proceed.",
+    "No concrete code finding, but merge should wait.",
+    "No concrete code finding; do not proceed with the merge.",
+    "No concrete code finding; this is not ready to merge.",
+    "Hold merge until the compatibility concern is resolved.",
+    "The PR remains blocked pending compatibility proof.",
+    "It is unsafe to merge until the availability risk is accepted.",
+    "No concrete code finding; merge must wait for maintainer approval.",
+    "No concrete code finding; maintainer approval is required before merge.",
+    "No concrete code finding; awaiting maintainer risk acceptance.",
+    "No pending maintainer decision remains, but merge is still blocked.",
+    "The earlier concern is resolved, but maintainers must not merge.",
+    "Prior objection addressed; merge must wait for policy approval.",
+  ]) {
+    const fixture = makeFixture({
+      pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+      issueComments: [
+        {
+          author: { login: "clawsweeper" },
+          authorAssociation: "CONTRIBUTOR",
+          body: [
+            "Codex review: needs maintainer review before merge.",
+            "",
+            "**Merge readiness**",
+            "Result: ready for maintainer review.",
+            "",
+            objection,
+            "",
+            `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+            "<!-- clawsweeper-review item=123 -->",
+          ].join("\n"),
+          url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+        },
+      ],
+    });
+    const { report } = runPreflightFixture(fixture);
+    assert.equal(report.status, "blocked", objection);
+    assert.match(report.reason, /actionable top-level issue comment/, objection);
+  }
+});
+
+test("external merge preflight accepts negated or resolved historical objection wording", () => {
+  for (const resolved of [
+    "No pending maintainer decision remains.",
+    "No maintainer approval is pending.",
+    "Previously pending maintainer risk acceptance is now granted.",
+    'The earlier review said "must not merge", but that concern is resolved.',
+    "There is no reason the merge is blocked.",
+    "Merge is not allowed to remain blocked.",
+  ]) {
+    const fixture = makeFixture({
+      pullLabels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+      issueComments: [
+        {
+          author: { login: "clawsweeper" },
+          authorAssociation: "CONTRIBUTOR",
+          body: [
+            "Codex review: needs maintainer review before merge.",
+            "",
+            "**Merge readiness**",
+            "Result: ready for maintainer review.",
+            "",
+            "No concrete code finding.",
+            resolved,
+            "",
+            `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
+            "<!-- clawsweeper-review item=123 -->",
+          ].join("\n"),
+          url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+        },
+      ],
+    });
+    const { report } = runPreflightFixture(fixture);
+    assert.equal(report.status, "passed", resolved);
+  }
+});
+
 test("external merge preflight ignores #98821 stale QA and refresh comments after a newer exact-head ready review", () => {
   const fixture = makeFixture({
     pullUser: { login: "harjothkhara" },
@@ -2382,6 +2498,31 @@ test("external merge preflight accepts exact-head dependency guard authorization
   assert.equal(report.status, "passed", report.reason);
   const result = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "result.json"), "utf8"));
   assert.equal(result.actions[0]?.action, "merge_canonical");
+});
+
+test("external merge preflight accepts GraphQL github-actions cleared dependency guard", () => {
+  const headSha = "a".repeat(40);
+  const fixture = makeFixture({
+    headSha,
+    issueComments: [
+      {
+        author: { login: "github-actions" },
+        authorAssociation: "CONTRIBUTOR",
+        body: [
+          "<!-- openclaw:dependency-graph-guard -->",
+          "",
+          "### Dependency graph guard cleared",
+          "",
+          "This PR no longer has blocked dependency graph changes. A future dependency graph change requires a fresh `/allow-dependencies-change` comment after the guard blocks that new head SHA.",
+          "",
+          `- Current SHA: \`${headSha}\``,
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/98505#issuecomment-4853327954",
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+  assert.equal(report.status, "passed", report.reason);
 });
 
 test("external merge preflight blocks stale dependency guard authorization", () => {


### PR DESCRIPTION
## Summary

- accept exact-head ClawSweeper ready reviews using the current "no repair lane / no concrete code finding" wording
- recognize GraphQL `github-actions` as the author of exact-head dependency guard notices
- preserve fail-closed handling for explicit objections while ignoring advisory maintainer-option alternatives
- add regressions from the live OpenClaw #98505 comment shapes and objection variants

## Validation

- `node --test test/preflight-external-pr-merge.test.mjs` - 112/112 passed
- `npm run validate` - 6,647 jobs valid
- `node --check scripts/preflight-external-pr-merge.mjs`
- `node --check test/preflight-external-pr-merge.test.mjs`
- `git diff --check`
- exact-head GitHub validate, CodeQL, and Socket checks passed

Unblocks the guarded exact-head merge preflight without weakening stale-SHA or actionable-comment handling.