### PR TITLE
chore(queue): refresh exact merge heads

### DIFF
--- a/jobs/openclaw/inbox/exact-merge-wave-101062-20260707.md
+++ b/jobs/openclaw/inbox/exact-merge-wave-101062-20260707.md
@@ -1,8 +1,8 @@
 ---
 repo: openclaw/openclaw
-cluster_id: exact-merge-wave-101062-20260706
+cluster_id: exact-merge-wave-101062-20260707
 mode: autonomous
-expected_head_sha: aa89aa6e495c54e39b4c8205b4f0c0185456b481
+expected_head_sha: 95dcf76ad3d7b1564f70beb22cc06d1c7ce28ab6
 allowed_actions:
   - "merge"
 blocked_actions:
@@ -31,7 +31,7 @@ allow_merge: true
 allow_post_merge_close: false
 require_fix_before_close: false
 canonical_hint: "Merge only PR #101062 after the deterministic external preflight binds validation and review to its exact live head."
-notes: "Prepared head: aa89aa6e495c54e39b4c8205b4f0c0185456b481. Re-fetch live state and stop if the head or merge policy changes."
+notes: "Refreshed exact head: 95dcf76ad3d7b1564f70beb22cc06d1c7ce28ab6. Maintainers updated the contributor branch onto OpenClaw main c1b9e3622162483d544131f04ce7665f8ad169c6, recorded as the merge commit's second parent. Re-fetch live state and stop if the head or merge policy changes."
 ---
 
 # Exact Merge Wave: #101062

--- a/jobs/openclaw/inbox/exact-merge-wave-85238-20260707.md
+++ b/jobs/openclaw/inbox/exact-merge-wave-85238-20260707.md
@@ -1,8 +1,8 @@
 ---
 repo: openclaw/openclaw
-cluster_id: exact-merge-wave-85238-20260706
+cluster_id: exact-merge-wave-85238-20260707
 mode: autonomous
-expected_head_sha: abd4e903c5f38c550aa7b9d1ab6c40bb9965f0c6
+expected_head_sha: 7ec70049e5278491c9842ab92c52e04044c82b56
 allowed_actions:
   - "merge"
 blocked_actions:
@@ -31,7 +31,7 @@ allow_merge: true
 allow_post_merge_close: false
 require_fix_before_close: false
 canonical_hint: "Merge only PR #85238 after the deterministic external preflight binds validation and review to its exact live head."
-notes: "Prepared head: abd4e903c5f38c550aa7b9d1ab6c40bb9965f0c6. Re-fetch live state and stop if the head or merge policy changes."
+notes: "Refreshed exact head: 7ec70049e5278491c9842ab92c52e04044c82b56. Maintainers updated the contributor branch onto OpenClaw main c1b9e3622162483d544131f04ce7665f8ad169c6, recorded as the merge commit's second parent. Re-fetch live state and stop if the head or merge policy changes."
 ---
 
 # Exact Merge Wave: #85238

--- a/jobs/openclaw/outbox/stale/exact-merge-wave-101062-20260706.md
+++ b/jobs/openclaw/outbox/stale/exact-merge-wave-101062-20260706.md
@@ -1,0 +1,41 @@
+---
+repo: openclaw/openclaw
+cluster_id: exact-merge-wave-101062-20260706
+mode: autonomous
+expected_head_sha: aa89aa6e495c54e39b4c8205b4f0c0185456b481
+allowed_actions:
+  - "merge"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "fix"
+  - "raise_pr"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unresolved_review"
+  - "unclear_canonical"
+canonical:
+  - "#101062"
+candidates:
+  - "#101062"
+cluster_refs:
+  - "#101062"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: false
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Merge only PR #101062 after the deterministic external preflight binds validation and review to its exact live head."
+notes: "Stale prepared head: aa89aa6e495c54e39b4c8205b4f0c0185456b481. Maintainers updated the contributor branch onto OpenClaw main c1b9e3622162483d544131f04ce7665f8ad169c6, producing refreshed exact head 95dcf76ad3d7b1564f70beb22cc06d1c7ce28ab6. Do not dispatch this archived job."
+---
+
+# Exact Merge Wave: #101062
+
+Run the deterministic external merge preflight for
+https://github.com/openclaw/openclaw/pull/101062 and apply only the resulting
+exact-head merge action. No comments, labels, fixes, or adjacent cluster work.

--- a/jobs/openclaw/outbox/stale/exact-merge-wave-85238-20260706.md
+++ b/jobs/openclaw/outbox/stale/exact-merge-wave-85238-20260706.md
@@ -1,0 +1,41 @@
+---
+repo: openclaw/openclaw
+cluster_id: exact-merge-wave-85238-20260706
+mode: autonomous
+expected_head_sha: abd4e903c5f38c550aa7b9d1ab6c40bb9965f0c6
+allowed_actions:
+  - "merge"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "fix"
+  - "raise_pr"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unresolved_review"
+  - "unclear_canonical"
+canonical:
+  - "#85238"
+candidates:
+  - "#85238"
+cluster_refs:
+  - "#85238"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: false
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Merge only PR #85238 after the deterministic external preflight binds validation and review to its exact live head."
+notes: "Stale prepared head: abd4e903c5f38c550aa7b9d1ab6c40bb9965f0c6. Maintainers updated the contributor branch onto OpenClaw main c1b9e3622162483d544131f04ce7665f8ad169c6, producing refreshed exact head 7ec70049e5278491c9842ab92c52e04044c82b56. Do not dispatch this archived job."
+---
+
+# Exact Merge Wave: #85238
+
+Run the deterministic external merge preflight for
+https://github.com/openclaw/openclaw/pull/85238 and apply only the resulting
+exact-head merge action. No comments, labels, fixes, or adjacent cluster work.


### PR DESCRIPTION
## Summary

- archive the superseded exact-merge jobs for https://github.com/openclaw/openclaw/pull/85238 and https://github.com/openclaw/openclaw/pull/101062 with explicit head-refresh notes
- queue new 20260707 autonomous merge-only jobs for exact heads `7ec70049e5278491c9842ab92c52e04044c82b56` and `95dcf76ad3d7b1564f70beb22cc06d1c7ce28ab6`
- record OpenClaw main `c1b9e3622162483d544131f04ce7665f8ad169c6` as the second parent of both refreshed merge commits

## Validation

- `npm run validate:job -- jobs/openclaw/inbox/exact-merge-wave-85238-20260707.md`
- `npm run validate:job -- jobs/openclaw/inbox/exact-merge-wave-101062-20260707.md`
- `npm run validate:job` for both archived stale jobs
- `npm run validate` (6655 jobs)
- `git diff --check`