### PR TITLE
chore(queue): archive merged 89997 retry

### DIFF
--- a/jobs/openclaw/outbox/stale/exact-merge-retry-89997-20260707.md
+++ b/jobs/openclaw/outbox/stale/exact-merge-retry-89997-20260707.md
@@ -31,7 +31,7 @@ allow_merge: true
 allow_post_merge_close: false
 require_fix_before_close: false
 canonical_hint: "Merge only PR #89997 after the deterministic external preflight binds validation and review to its exact live head."
-notes: "Refreshed after contributor update to exact head f3237b42d8faaab8cc0753d8268c6891bca94e90. One SDK-surface check also fails on current main; do not bypass checks, and stop if the head or merge policy changes."
+notes: "Merged externally by vincentkoc at 2026-07-07T00:55:50Z as squash commit ffa6ebda4cd048e7d6d60c803d15d995af7870e7. This retry was never dispatched; do not dispatch this archived job."
 ---
 
 # Exact Merge Retry: #89997


### PR DESCRIPTION
## Summary

- move the unprocessed #89997 exact-head retry out of the inbox
- record the external squash merge commit and prevent redispatch

## Validation

- `npm run validate` (6,655 jobs)

Tracks https://github.com/openclaw/openclaw/pull/89997