### PR TITLE
chore(queue): refresh rebased exact-merge wave

### DIFF
--- a/jobs/openclaw/inbox/exact-merge-wave-101062-20260707.md
+++ b/jobs/openclaw/inbox/exact-merge-wave-101062-20260707.md
@@ -2,7 +2,7 @@
 repo: openclaw/openclaw
 cluster_id: exact-merge-wave-101062-20260707
 mode: autonomous
-expected_head_sha: 95dcf76ad3d7b1564f70beb22cc06d1c7ce28ab6
+expected_head_sha: f4df8861c00d1ae7f70142c845f825905ee11e7d
 allowed_actions:
   - "merge"
 blocked_actions:
@@ -31,7 +31,7 @@ allow_merge: true
 allow_post_merge_close: false
 require_fix_before_close: false
 canonical_hint: "Merge only PR #101062 after the deterministic external preflight binds validation and review to its exact live head."
-notes: "Refreshed exact head: 95dcf76ad3d7b1564f70beb22cc06d1c7ce28ab6. Maintainers updated the contributor branch onto OpenClaw main c1b9e3622162483d544131f04ce7665f8ad169c6, recorded as the merge commit's second parent. Re-fetch live state and stop if the head or merge policy changes."
+notes: "Refreshed exact head: f4df8861c00d1ae7f70142c845f825905ee11e7d. Maintainers rebased the editable contributor branch onto OpenClaw main 82106a18b3beaaff085ca3258a6f09cd19348d03 after its GitHub test-merge ref lagged the live base. Re-fetch live state and stop if the head or merge policy changes."
 ---
 
 # Exact Merge Wave: #101062

--- a/jobs/openclaw/inbox/exact-merge-wave-85238-20260707.md
+++ b/jobs/openclaw/inbox/exact-merge-wave-85238-20260707.md
@@ -2,7 +2,7 @@
 repo: openclaw/openclaw
 cluster_id: exact-merge-wave-85238-20260707
 mode: autonomous
-expected_head_sha: 7ec70049e5278491c9842ab92c52e04044c82b56
+expected_head_sha: d823cb61960aa275c0386171a476a56d28322487
 allowed_actions:
   - "merge"
 blocked_actions:
@@ -31,7 +31,7 @@ allow_merge: true
 allow_post_merge_close: false
 require_fix_before_close: false
 canonical_hint: "Merge only PR #85238 after the deterministic external preflight binds validation and review to its exact live head."
-notes: "Refreshed exact head: 7ec70049e5278491c9842ab92c52e04044c82b56. Maintainers updated the contributor branch onto OpenClaw main c1b9e3622162483d544131f04ce7665f8ad169c6, recorded as the merge commit's second parent. Re-fetch live state and stop if the head or merge policy changes."
+notes: "Refreshed exact head: d823cb61960aa275c0386171a476a56d28322487. Maintainers rebased the editable contributor branch onto OpenClaw main 82106a18b3beaaff085ca3258a6f09cd19348d03 after its GitHub test-merge ref lagged the live base. Re-fetch live state and stop if the head or merge policy changes."
 ---
 
 # Exact Merge Wave: #85238

--- a/jobs/openclaw/inbox/exact-merge-wave-98505-20260707b.md
+++ b/jobs/openclaw/inbox/exact-merge-wave-98505-20260707b.md
@@ -1,0 +1,41 @@
+---
+repo: openclaw/openclaw
+cluster_id: exact-merge-wave-98505-20260707b
+mode: autonomous
+expected_head_sha: 7c0278ea0a36cd1d4b52cb9159a24e6c781a73a4
+allowed_actions:
+  - "merge"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "fix"
+  - "raise_pr"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unresolved_review"
+  - "unclear_canonical"
+canonical:
+  - "#98505"
+candidates:
+  - "#98505"
+cluster_refs:
+  - "#98505"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: false
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Merge only PR #98505 after the deterministic external preflight binds validation and review to its exact live head."
+notes: "Refreshed exact head: 7c0278ea0a36cd1d4b52cb9159a24e6c781a73a4. Maintainers rebased the editable contributor branch onto OpenClaw main 82106a18b3beaaff085ca3258a6f09cd19348d03 after its GitHub test-merge ref lagged the live base. Re-fetch live state and stop if the head or merge policy changes."
+---
+
+# Exact Merge Wave: #98505
+
+Run the deterministic external merge preflight for
+https://github.com/openclaw/openclaw/pull/98505 and apply only the resulting
+exact-head merge action. No comments, labels, fixes, or adjacent cluster work.


### PR DESCRIPTION
## Summary

- refresh #85238 and #101062 jobs to their rebased exact heads
- enqueue a fresh #98505 exact-head retry after the stale GitHub test-merge block
- preserve the previous finalized #98505 artifact as historical evidence

## Validation

- `npm run validate` (6,656 jobs)
- `git diff --check`