### PR TITLE
fix(merge): adopt proven disjoint main drift

### DIFF
--- a/schemas/codex-result.schema.json
+++ b/schemas/codex-result.schema.json
@@ -202,7 +202,8 @@
           "bot_comments_status",
           "bot_comments_evidence",
           "codex_review",
-          "validation_commands"
+          "validation_commands",
+          "base_adoption_manifest"
         ],
         "additionalProperties": false,
         "properties": {
@@ -285,6 +286,91 @@
             "type": "array",
             "items": {
               "type": "string"
+            }
+          },
+          "base_adoption_manifest": {
+            "type": ["object", "null"],
+            "required": [
+              "schema_version",
+              "policy",
+              "reviewed_base_sha",
+              "reviewed_head_sha",
+              "reviewed_synthetic_merge_sha",
+              "reviewed_merge_tree_sha",
+              "effective_diff_sha256",
+              "effective_diff_files",
+              "effective_paths",
+              "affected_areas",
+              "validation_gate",
+              "reviewed_paths",
+              "validation_controls",
+              "review_context"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "schema_version": {
+                "type": "integer",
+                "const": 1
+              },
+              "policy": {
+                "type": "string",
+                "const": "bounded-fast-forward-v1"
+              },
+              "reviewed_base_sha": {
+                "type": "string",
+                "pattern": "^[0-9a-fA-F]{40}$"
+              },
+              "reviewed_head_sha": {
+                "type": "string",
+                "pattern": "^[0-9a-fA-F]{40}$"
+              },
+              "reviewed_synthetic_merge_sha": {
+                "type": "string",
+                "pattern": "^[0-9a-fA-F]{40}$"
+              },
+              "reviewed_merge_tree_sha": {
+                "type": "string",
+                "pattern": "^[0-9a-fA-F]{40}$"
+              },
+              "effective_diff_sha256": {
+                "type": "string",
+                "pattern": "^[0-9a-fA-F]{64}$"
+              },
+              "effective_diff_files": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "effective_paths": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "affected_areas": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "validation_gate": {
+                "type": "string",
+                "const": "pnpm check:changed"
+              },
+              "reviewed_paths": {
+                "$ref": "#/$defs/baseAdoptionBlobSnapshot"
+              },
+              "validation_controls": {
+                "$ref": "#/$defs/baseAdoptionBlobSnapshot"
+              },
+              "review_context": {
+                "$ref": "#/$defs/baseAdoptionBlobSnapshot"
+              }
             }
           }
         }
@@ -384,6 +470,49 @@
           }
         }
       ]
+    }
+  },
+  "$defs": {
+    "baseAdoptionBlobSnapshot": {
+      "type": "object",
+      "required": ["complete", "files", "sha256", "blobs"],
+      "additionalProperties": false,
+      "properties": {
+        "complete": {
+          "type": "boolean"
+        },
+        "files": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        },
+        "blobs": {
+          "type": "array",
+          "maxItems": 2048,
+          "items": {
+            "type": "object",
+            "required": ["path", "reviewed_base_entry", "reviewed_result_entry"],
+            "additionalProperties": false,
+            "properties": {
+              "path": {
+                "type": "string",
+                "minLength": 1
+              },
+              "reviewed_base_entry": {
+                "type": ["string", "null"],
+                "pattern": "^[0-7]{6}:[a-z]+:[0-9a-fA-F]{40}$"
+              },
+              "reviewed_result_entry": {
+                "type": ["string", "null"],
+                "pattern": "^[0-7]{6}:[a-z]+:[0-9a-fA-F]{40}$"
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -85,6 +85,12 @@ const report = {
   applied_at: new Date().toISOString(),
   actions: [],
 };
+const reportPath =
+  typeof reportPathArg === "string"
+    ? path.resolve(reportPathArg)
+    : path.join(path.dirname(resultPath), "apply-report.json");
+const priorApplyReport = readApplyReport(reportPath);
+const priorApplyAttempts = readApplyAttempts(priorApplyReport);
 let githubRateLimitBlockReason = "";
 
 const allowedRefs = new Set(
@@ -109,12 +115,8 @@ for (const action of result.actions ?? []) {
   report.actions.push(applyAction({ job, result, action, dryRun, allowMissingUpdatedAt }));
 }
 
-const reportPath =
-  typeof reportPathArg === "string"
-    ? path.resolve(reportPathArg)
-    : path.join(path.dirname(resultPath), "apply-report.json");
 report.apply_attempts = [
-  ...readApplyAttempts(reportPath),
+  ...priorApplyAttempts,
   {
     dry_run: report.dry_run,
     result_path: report.result_path,
@@ -125,9 +127,13 @@ report.apply_attempts = [
 fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
 console.log(JSON.stringify(report, null, 2));
 
-function readApplyAttempts(reportPath) {
-  if (!fs.existsSync(reportPath)) return [];
-  const previous = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+function readApplyReport(reportPath) {
+  if (!fs.existsSync(reportPath)) return null;
+  return JSON.parse(fs.readFileSync(reportPath, "utf8"));
+}
+
+function readApplyAttempts(previous) {
+  if (!previous) return [];
   if (Array.isArray(previous.apply_attempts)) return previous.apply_attempts;
   if (!Array.isArray(previous.actions)) return [];
   return [
@@ -512,12 +518,19 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
         merge_commit_sha: pullRequest.merge_commit_sha ?? view.mergeCommit?.oid ?? null,
       };
     }
+    const replayBinding = restoreBaseAdoptionBinding({
+      action,
+      target,
+      expectedHeadSha,
+      preflight: findMergePreflight(result, target),
+    });
     const mergedProof = verifyActualMergedCommit({
       result,
       action,
       target,
       expectedHeadSha,
       pullRequest,
+      effectiveDiffBinding: replayBinding,
     });
     if (mergedProof?.reason) {
       return {
@@ -542,6 +555,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       merge_commit_sha: pullRequest.merge_commit_sha ?? view.mergeCommit?.oid ?? null,
       effective_diff_sha256: mergedProof?.merged_effective_diff_sha256 ?? null,
       verified_main_sha: mergedProof?.verified_parent_sha ?? null,
+      ...externalMergeHeadReport(action, expectedHeadSha, replayBinding),
     };
   }
 
@@ -748,7 +762,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
         effectiveDiffBinding.merge_commit_sha.toLowerCase() ||
       checkedMainSha !== effectiveDiffBinding.verified_main_sha ||
       checkedIssue.updated_at !== live.updated_at ||
-      (effectiveDiffBinding.branch_refresh
+      (effectiveDiffBinding.branch_refresh || effectiveDiffBinding.base_adoption
         ? externalRefreshMetadataBlock({
             repo: result.repo,
             beforeIssue: live,
@@ -778,11 +792,70 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
         ...externalMergeHeadReport(action, expectedHeadSha, effectiveDiffBinding),
       };
     }
+    if (effectiveDiffBinding.base_adoption) {
+      persistBaseAdoptionCheckpoint({
+        base,
+        action,
+        expectedHeadSha,
+        effectiveDiffBinding,
+      });
+    }
     try {
-      exactMergeCheck = publishExactMergeCheck({
+      exactMergeCheck = prepareExactMergeCheck({
         repo: result.repo,
         action,
         target,
+        effectiveDiffBinding,
+      });
+    } catch (error) {
+      return {
+        ...base,
+        status: "blocked",
+        reason: `could not publish exact-merge check: ${compactErrorText(commandErrorText(error), 500)}`,
+        retry_recommended: true,
+        live_state: live.state,
+        live_updated_at: live.updated_at,
+        expected_head_sha: expectedHeadSha,
+        effective_diff_sha256: effectiveDiffBinding.live_effective_diff_sha256,
+        verified_main_sha: effectiveDiffBinding.verified_main_sha,
+        ...externalMergeHeadReport(action, expectedHeadSha, effectiveDiffBinding),
+      };
+    }
+    const authorizationState = verifyExactMergeAuthorizationState({
+      result,
+      action,
+      target,
+      expectedHeadSha,
+      mergeHeadSha,
+      effectiveDiffBinding,
+      beforeIssue: checkedIssue,
+      beforePull: checkedPull,
+    });
+    if (authorizationState.reason) {
+      return withExactMergeRevocation({
+        repo: result.repo,
+        exactMergeCheck,
+        result: {
+          ...base,
+          status: "blocked",
+          reason: authorizationState.reason,
+          retry_recommended: true,
+          live_state: live.state,
+          live_updated_at: live.updated_at,
+          expected_head_sha: expectedHeadSha,
+          effective_diff_sha256: effectiveDiffBinding.live_effective_diff_sha256,
+          verified_main_sha: effectiveDiffBinding.verified_main_sha,
+          current_main_sha: authorizationState.current_main_sha ?? null,
+          exact_merge_check: exactMergeCheck,
+          ...externalMergeHeadReport(action, expectedHeadSha, effectiveDiffBinding),
+        },
+      });
+    }
+    try {
+      exactMergeCheck = authorizeExactMergeCheck({
+        repo: result.repo,
+        target,
+        exactMergeCheck,
         expectedHeadSha,
         mergeHeadSha,
         effectiveDiffBinding,
@@ -791,7 +864,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       return {
         ...base,
         status: "blocked",
-        reason: `could not publish exact-merge check: ${compactErrorText(commandErrorText(error), 500)}`,
+        reason: `could not authorize exact merge: ${compactErrorText(commandErrorText(error), 500)}`,
         retry_recommended: true,
         live_state: live.state,
         live_updated_at: live.updated_at,
@@ -923,6 +996,7 @@ function buildMergedActionResult({
     expectedHeadSha,
     mergeHeadSha,
     pullRequest: merged,
+    effectiveDiffBinding,
   });
   if (mergedProof?.reason) {
     return {
@@ -1117,6 +1191,22 @@ function validateExternalMergeBindingFields({ action, preflight, expectedHeadSha
   if (!Number.isInteger(preflight.effective_diff_files) || preflight.effective_diff_files < 0) {
     return "external merge preflight effective_diff_files is missing or invalid";
   }
+  const manifest = preflight.base_adoption_manifest;
+  if (manifest != null) {
+    if (manifest.schema_version !== 1 || manifest.policy !== "bounded-fast-forward-v1") {
+      return "external merge preflight base adoption manifest is unsupported";
+    }
+    if (
+      String(manifest.reviewed_base_sha ?? "").toLowerCase() !==
+        String(preflight.reviewed_base_sha).toLowerCase() ||
+      String(manifest.reviewed_head_sha ?? "").toLowerCase() !== expectedHeadSha.toLowerCase() ||
+      String(manifest.effective_diff_sha256 ?? "").toLowerCase() !==
+        String(preflight.effective_diff_sha256).toLowerCase() ||
+      manifest.effective_diff_files !== preflight.effective_diff_files
+    ) {
+      return "external merge preflight base adoption manifest does not match reviewed binding";
+    }
+  }
   return "";
 }
 
@@ -1129,6 +1219,7 @@ function externalMergeHeadReport(action, expectedHeadSha, binding) {
   return {
     reviewed_head_sha: binding?.reviewed_head_sha ?? expectedHeadSha,
     merge_head_sha: binding?.merge_head_sha ?? expectedHeadSha,
+    ...(binding?.base_adoption ? { base_adoption: binding.base_adoption } : {}),
     ...(binding?.branch_refresh ? { branch_refresh: binding.branch_refresh } : {}),
   };
 }
@@ -1152,11 +1243,14 @@ function verifyExternalMergeBinding({
   let lastReason = "GitHub test merge ref was unavailable";
   let lastProblem = "unavailable";
   let staleTestMerge = null;
+  let lastVerifiedMainSha = reviewedBaseSha;
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
       const verifiedMainSha = fetchBranchHeadSha(result.repo, "main");
-      if (verifiedMainSha !== reviewedBaseSha) {
+      lastVerifiedMainSha = verifiedMainSha;
+      const adoptingNewerMain = verifiedMainSha !== reviewedBaseSha;
+      if (adoptingNewerMain && !preflight.base_adoption_manifest) {
         return {
           reason: "main changed since external validation and Codex review",
           reviewed_effective_diff_sha256: reviewedFingerprint,
@@ -1186,18 +1280,25 @@ function verifyExternalMergeBinding({
         const parents = mergeCommit.parents ?? [];
         const mergeBaseSha = String(parents[0]?.sha ?? "");
         const mergeHeadSha = String(parents[1]?.sha ?? "");
+        const requiredMergeBaseSha = adoptingNewerMain ? verifiedMainSha : reviewedBaseSha;
         if (parents.length !== 2) {
           lastReason = "GitHub test merge commit does not have exactly two parents";
           lastProblem = "ambiguous";
-        } else if (mergeBaseSha.toLowerCase() !== reviewedBaseSha) {
-          lastReason = "GitHub test merge commit is not based on the reviewed main SHA";
+        } else if (mergeBaseSha.toLowerCase() !== requiredMergeBaseSha) {
+          lastReason = adoptingNewerMain
+            ? "GitHub test merge commit is not based on the current main SHA"
+            : "GitHub test merge commit is not based on the reviewed main SHA";
           if (mergeHeadSha.toLowerCase() === expectedHeadSha.toLowerCase()) {
-            lastProblem = "stale_test_merge";
-            staleTestMerge = {
-              merge_commit_sha: mergeCommitSha.toLowerCase(),
-              merge_base_sha: mergeBaseSha.toLowerCase(),
-              merge_head_sha: mergeHeadSha.toLowerCase(),
-            };
+            if (adoptingNewerMain) {
+              lastProblem = "awaiting_adopted_test_merge";
+            } else {
+              lastProblem = "stale_test_merge";
+              staleTestMerge = {
+                merge_commit_sha: mergeCommitSha.toLowerCase(),
+                merge_base_sha: mergeBaseSha.toLowerCase(),
+                merge_head_sha: mergeHeadSha.toLowerCase(),
+              };
+            }
           } else {
             lastProblem = "ambiguous";
           }
@@ -1231,6 +1332,38 @@ function verifyExternalMergeBinding({
               retry_recommended: true,
               reviewed_head_sha: expectedHeadSha,
               merge_head_sha: expectedHeadSha,
+            };
+          }
+          if (adoptingNewerMain) {
+            const baseAdoption = runApplyTimeBaseAdoptionValidation({
+              preflight,
+              target,
+              adoptedBaseSha: verifiedMainSha,
+              expectedHeadSha,
+              testMergeSha: mergeCommitSha.toLowerCase(),
+            });
+            if (baseAdoption.status !== "adopted") {
+              return {
+                reason: baseAdoption.reason || "apply-time main adoption validation failed",
+                reviewed_effective_diff_sha256: reviewedFingerprint,
+                live_effective_diff_sha256: liveFingerprint.sha256,
+                verified_main_sha: verifiedMainSha,
+                retry_recommended: true,
+                reviewed_head_sha: expectedHeadSha,
+                merge_head_sha: expectedHeadSha,
+                base_adoption: baseAdoption,
+              };
+            }
+            return {
+              reviewed_effective_diff_sha256: reviewedFingerprint,
+              live_effective_diff_sha256: liveFingerprint.sha256,
+              effective_diff_files: liveFingerprint.files,
+              verified_main_sha: verifiedMainSha,
+              merge_commit_sha: mergeCommitSha,
+              reviewed_head_sha: expectedHeadSha,
+              merge_head_sha: expectedHeadSha,
+              base_drift_proof: baseAdoption.drift_proof,
+              base_adoption: baseAdoption,
             };
           }
           return {
@@ -1270,10 +1403,142 @@ function verifyExternalMergeBinding({
   return {
     reason: lastReason,
     reviewed_effective_diff_sha256: reviewedFingerprint,
+    verified_main_sha: lastVerifiedMainSha,
     retry_recommended: true,
     reviewed_head_sha: expectedHeadSha,
     merge_head_sha: expectedHeadSha,
   };
+}
+
+function runApplyTimeBaseAdoptionValidation({
+  preflight,
+  target,
+  adoptedBaseSha,
+  expectedHeadSha,
+  testMergeSha,
+}) {
+  const tempRoot = fs.mkdtempSync(
+    path.join(path.dirname(resultPath), `.base-adoption-${target}-`),
+  );
+  const manifestPath = path.join(tempRoot, "manifest.json");
+  const proofPath = path.join(tempRoot, "proof.json");
+  fs.writeFileSync(
+    manifestPath,
+    `${JSON.stringify(preflight.base_adoption_manifest, null, 2)}\n`,
+  );
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        path.join(repoRoot(), "scripts", "preflight-external-pr-merge.mjs"),
+        jobPath,
+        "--pr",
+        String(target),
+        "--run-dir",
+        tempRoot,
+        "--target-dir",
+        path.join(tempRoot, "target"),
+        "--adoption-manifest",
+        manifestPath,
+        "--adopted-base-sha",
+        adoptedBaseSha,
+        "--expected-head-sha",
+        expectedHeadSha,
+        "--test-merge-sha",
+        testMergeSha,
+        "--output",
+        proofPath,
+      ],
+      {
+        cwd: repoRoot(),
+        env: githubCliEnv(),
+        encoding: "utf8",
+        timeout: positiveInteger(
+          process.env.CLOWNFISH_APPLY_BASE_ADOPTION_TIMEOUT_MS,
+          30 * 60 * 1000,
+        ),
+        maxBuffer: 64 * 1024 * 1024,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    if (!fs.existsSync(proofPath)) {
+      return {
+        schema_version: 1,
+        policy: "bounded-fast-forward-v1",
+        status: "blocked",
+        reason: "apply-time adoption validator did not write a proof",
+      };
+    }
+    return JSON.parse(fs.readFileSync(proofPath, "utf8"));
+  } catch (error) {
+    return {
+      schema_version: 1,
+      policy: "bounded-fast-forward-v1",
+      status: "blocked",
+      reason: `apply-time adoption validator failed: ${compactErrorText(commandErrorText(error), 500)}`,
+    };
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function captureApplyTimeAdoptionState({
+  target,
+  adoptedBaseSha,
+  expectedHeadSha,
+  testMergeSha,
+}) {
+  const tempRoot = fs.mkdtempSync(
+    path.join(path.dirname(resultPath), `.base-adoption-state-${target}-`),
+  );
+  const statePath = path.join(tempRoot, "state.json");
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        path.join(repoRoot(), "scripts", "preflight-external-pr-merge.mjs"),
+        jobPath,
+        "--pr",
+        String(target),
+        "--run-dir",
+        tempRoot,
+        "--adoption-state-only",
+        "--adopted-base-sha",
+        adoptedBaseSha,
+        "--expected-head-sha",
+        expectedHeadSha,
+        "--test-merge-sha",
+        testMergeSha,
+        "--output",
+        statePath,
+      ],
+      {
+        cwd: repoRoot(),
+        env: githubCliEnv(),
+        encoding: "utf8",
+        timeout: positiveInteger(
+          process.env.CLOWNFISH_APPLY_BASE_ADOPTION_STATE_TIMEOUT_MS,
+          5 * 60 * 1000,
+        ),
+        maxBuffer: 16 * 1024 * 1024,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    if (!fs.existsSync(statePath)) {
+      return {
+        status: "blocked",
+        reason: "apply-time adoption state recheck did not write a result",
+      };
+    }
+    return JSON.parse(fs.readFileSync(statePath, "utf8"));
+  } catch (error) {
+    return {
+      status: "blocked",
+      reason: `apply-time adoption state recheck failed: ${compactErrorText(commandErrorText(error), 500)}`,
+    };
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
 }
 
 function refreshStaleExternalMergeBinding({
@@ -1653,6 +1918,195 @@ function externalRefreshMetadataBlock({
   return "";
 }
 
+function persistBaseAdoptionCheckpoint({
+  base,
+  action,
+  expectedHeadSha,
+  effectiveDiffBinding,
+}) {
+  const checkpoint = {
+    ...report,
+    checkpoint: "base_adoption_verified",
+    actions: [
+      ...report.actions,
+      {
+        ...base,
+        status: "authorizing",
+        reason: "apply-time base adoption validated; exact-merge authorization pending",
+        expected_head_sha: expectedHeadSha,
+        effective_diff_sha256: effectiveDiffBinding.live_effective_diff_sha256,
+        verified_main_sha: effectiveDiffBinding.verified_main_sha,
+        ...externalMergeHeadReport(action, expectedHeadSha, effectiveDiffBinding),
+      },
+    ],
+    apply_attempts: priorApplyAttempts,
+  };
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  fs.writeFileSync(reportPath, `${JSON.stringify(checkpoint, null, 2)}\n`);
+}
+
+function restoreBaseAdoptionBinding({ action, target, expectedHeadSha, preflight }) {
+  const priorActions = [
+    ...(priorApplyReport?.apply_attempts ?? []).flatMap((attempt) => attempt?.actions ?? []),
+    ...(priorApplyReport?.actions ?? []),
+  ].reverse();
+  for (const priorAction of priorActions) {
+    const proof = priorAction?.base_adoption;
+    if (
+      String(priorAction?.target ?? "") !== String(action.target ?? target) ||
+      proof?.schema_version !== 1 ||
+      proof?.policy !== "bounded-fast-forward-v1" ||
+      proof?.status !== "adopted"
+    ) {
+      continue;
+    }
+    const authorization = baseAdoptionAuthorization(proof);
+    const authorizationSha256 = createHash("sha256")
+      .update(JSON.stringify(authorization))
+      .digest("hex");
+    const verifiedMainSha = String(priorAction.verified_main_sha ?? "").toLowerCase();
+    const effectiveDiffSha256 = String(
+      priorAction.effective_diff_sha256 ?? "",
+    ).toLowerCase();
+    if (
+      proof.authorization_sha256 !== authorizationSha256 ||
+      String(proof.reviewed_base_sha ?? "").toLowerCase() !==
+        String(preflight?.reviewed_base_sha ?? "").toLowerCase() ||
+      String(proof.reviewed_head_sha ?? "").toLowerCase() !==
+        expectedHeadSha.toLowerCase() ||
+      String(proof.adopted_base_sha ?? "").toLowerCase() !== verifiedMainSha ||
+      String(proof.effective_diff_sha256 ?? "").toLowerCase() !==
+        String(preflight?.effective_diff_sha256 ?? "").toLowerCase() ||
+      effectiveDiffSha256 !== String(preflight?.effective_diff_sha256 ?? "").toLowerCase() ||
+      proof.effective_diff_files !== preflight?.effective_diff_files ||
+      !/^[0-9a-f]{40}$/.test(verifiedMainSha)
+    ) {
+      continue;
+    }
+    return {
+      reviewed_effective_diff_sha256: effectiveDiffSha256,
+      live_effective_diff_sha256: effectiveDiffSha256,
+      effective_diff_files: proof.effective_diff_files,
+      verified_main_sha: verifiedMainSha,
+      merge_commit_sha: String(proof.test_merge_sha ?? "").toLowerCase(),
+      reviewed_head_sha: expectedHeadSha.toLowerCase(),
+      merge_head_sha: expectedHeadSha.toLowerCase(),
+      base_drift_proof: proof.drift_proof ?? null,
+      base_adoption: proof,
+    };
+  }
+  return null;
+}
+
+function baseAdoptionAuthorization(proof) {
+  return {
+    policy: proof.policy,
+    reviewed_base_sha: proof.reviewed_base_sha,
+    adopted_base_sha: proof.adopted_base_sha,
+    reviewed_head_sha: proof.reviewed_head_sha,
+    test_merge_sha: proof.test_merge_sha,
+    test_merge_tree_sha: proof.test_merge_tree_sha,
+    effective_diff_files: proof.effective_diff_files,
+    effective_diff_sha256: proof.effective_diff_sha256,
+    drift_commit_count: proof.drift_commit_count,
+    drift_file_count: proof.drift_file_count,
+    drift_paths_sha256: proof.drift_paths_sha256,
+    reviewed_paths_sha256: proof.reviewed_paths_sha256,
+    validation_controls_sha256: proof.validation_controls_sha256,
+    review_context_sha256: proof.review_context_sha256,
+    validation_commands: proof.validation_commands,
+    github_state_sha256: proof.github_state_sha256,
+    issue_updated_at: proof.issue_updated_at,
+    pull_updated_at: proof.pull_updated_at,
+  };
+}
+
+function verifyExactMergeAuthorizationState({
+  result,
+  action,
+  target,
+  expectedHeadSha,
+  mergeHeadSha,
+  effectiveDiffBinding,
+  beforeIssue,
+  beforePull,
+}) {
+  try {
+    const currentMainSha = fetchBranchHeadSha(result.repo, "main");
+    const currentIssue = fetchIssue(result.repo, target);
+    const currentPull = fetchPullRequest(result.repo, target);
+    const currentView = fetchSettledPullRequestView(result.repo, target);
+    const metadataBlock = externalRefreshMetadataBlock({
+      repo: result.repo,
+      beforeIssue,
+      beforePull,
+      afterIssue: currentIssue,
+      afterPull: currentPull,
+    });
+    const riskLabel = findHighRiskMergeLabel(currentIssue.labels);
+    const mergeBlock = validateMergeablePullRequest({
+      pullRequest: currentPull,
+      view: currentView,
+      allowExactMergeState: true,
+    });
+    const preflightBlock = validateMergePreflight({
+      result,
+      action,
+      target,
+      expectedHeadSha,
+    });
+    let adoptionStateBlock = "";
+    if (effectiveDiffBinding.base_adoption) {
+      const adoptionState = captureApplyTimeAdoptionState({
+        target,
+        adoptedBaseSha: effectiveDiffBinding.verified_main_sha,
+        expectedHeadSha,
+        testMergeSha: effectiveDiffBinding.merge_commit_sha,
+      });
+      if (adoptionState.status !== "clean") {
+        adoptionStateBlock =
+          adoptionState.reason || "fresh adoption authorization state is not clean";
+      } else if (
+        adoptionState.github_state_sha256 !==
+        effectiveDiffBinding.base_adoption.github_state_sha256
+      ) {
+        adoptionStateBlock =
+          "GitHub comments, reviews, metadata, or checks changed during exact-merge authorization";
+      }
+    }
+    if (
+      currentMainSha !== effectiveDiffBinding.verified_main_sha ||
+      String(currentPull.head?.sha ?? "").toLowerCase() !== mergeHeadSha.toLowerCase() ||
+      String(currentPull.merge_commit_sha ?? "").toLowerCase() !==
+        effectiveDiffBinding.merge_commit_sha.toLowerCase() ||
+      currentIssue.updated_at !== beforeIssue.updated_at ||
+      metadataBlock ||
+      hasSecuritySignal(currentIssue) ||
+      riskLabel ||
+      mergeBlock ||
+      preflightBlock ||
+      adoptionStateBlock
+    ) {
+      return {
+        reason:
+          preflightBlock ||
+          mergeBlock ||
+          adoptionStateBlock ||
+          metadataBlock ||
+          (riskLabel ? `target has blocked live label: ${riskLabel}` : "") ||
+          "head, test merge, main, metadata, comments, checks, or risk changed during exact-merge authorization",
+        current_main_sha: currentMainSha,
+      };
+    }
+    return { reason: "", current_main_sha: currentMainSha };
+  } catch (error) {
+    return {
+      reason: `could not recheck exact-merge authorization: ${compactErrorText(commandErrorText(error), 500)}`,
+      current_main_sha: null,
+    };
+  }
+}
+
 function validateExactMergeRule(repo) {
   const appId = positiveInteger(process.env.CLOWNFISH_APP_ID, 0);
   if (!appId) return "external merge requires CLOWNFISH_APP_ID for exact-merge rule verification";
@@ -1672,26 +2126,29 @@ function validateExactMergeRule(repo) {
     : `main must strictly require ${EXACT_MERGE_CHECK_NAME} from GitHub App ${appId}`;
 }
 
-function publishExactMergeCheck({
+function prepareExactMergeCheck({
   repo,
   action,
   target,
-  expectedHeadSha,
-  mergeHeadSha,
   effectiveDiffBinding,
 }) {
   const appId = positiveInteger(process.env.CLOWNFISH_APP_ID, 0);
   const mergeCommitSha = effectiveDiffBinding.merge_commit_sha.toLowerCase();
-  const externalId = String(action.idempotency_key);
+  const adoptionProofSha = effectiveDiffBinding.base_adoption?.authorization_sha256 ?? null;
+  const externalId = adoptionProofSha
+    ? `${String(action.idempotency_key)}:adopt:${adoptionProofSha}`
+    : String(action.idempotency_key);
   const detailsUrl =
     process.env.GITHUB_RUN_ID && process.env.GITHUB_REPOSITORY
       ? `${process.env.GITHUB_SERVER_URL ?? "https://github.com"}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
       : undefined;
   let pending = findExactMergeCheckCandidate({ repo, mergeCommitSha, externalId, appId });
   if (pending?.status === "completed" && pending?.conclusion === "success") {
-    const exactMergeCheck = exactMergeCheckRecord(pending, mergeCommitSha, externalId);
-    setActiveExactMergeAuthorization(repo, exactMergeCheck);
-    return exactMergeCheck;
+    const staleAuthorization = exactMergeCheckRecord(pending, mergeCommitSha, externalId);
+    setActiveExactMergeAuthorization(repo, staleAuthorization);
+    revokeExactMergeCheck({ repo, exactMergeCheck: staleAuthorization });
+    clearActiveExactMergeAuthorization(staleAuthorization);
+    pending = null;
   }
   if (!pending) {
     const pendingPayloadPath = writePayload(`pending-exact-merge-check-${target}`, {
@@ -1720,9 +2177,11 @@ function publishExactMergeCheck({
     }
   }
   if (pending?.status === "completed" && pending?.conclusion === "success") {
-    const exactMergeCheck = exactMergeCheckRecord(pending, mergeCommitSha, externalId);
-    setActiveExactMergeAuthorization(repo, exactMergeCheck);
-    return exactMergeCheck;
+    const staleAuthorization = exactMergeCheckRecord(pending, mergeCommitSha, externalId);
+    setActiveExactMergeAuthorization(repo, staleAuthorization);
+    revokeExactMergeCheck({ repo, exactMergeCheck: staleAuthorization });
+    clearActiveExactMergeAuthorization(staleAuthorization);
+    return prepareExactMergeCheck({ repo, action, target, effectiveDiffBinding });
   }
   if (
     !pending ||
@@ -1737,6 +2196,35 @@ function publishExactMergeCheck({
   }
 
   const pendingRecord = exactMergeCheckRecord(pending, mergeCommitSha, externalId);
+  setActiveExactMergeAuthorization(repo, pendingRecord);
+  return pendingRecord;
+}
+
+function authorizeExactMergeCheck({
+  repo,
+  target,
+  exactMergeCheck,
+  expectedHeadSha,
+  mergeHeadSha,
+  effectiveDiffBinding,
+}) {
+  const appId = positiveInteger(process.env.CLOWNFISH_APP_ID, 0);
+  const mergeCommitSha = effectiveDiffBinding.merge_commit_sha.toLowerCase();
+  const adoptionProofSha = effectiveDiffBinding.base_adoption?.authorization_sha256 ?? null;
+  const detailsUrl =
+    process.env.GITHUB_RUN_ID && process.env.GITHUB_REPOSITORY
+      ? `${process.env.GITHUB_SERVER_URL ?? "https://github.com"}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+      : undefined;
+  if (
+    !exactMergeCheck ||
+    exactMergeCheck.name !== EXACT_MERGE_CHECK_NAME ||
+    exactMergeCheck.head_sha !== mergeCommitSha ||
+    exactMergeCheck.status !== "in_progress" ||
+    exactMergeCheck.conclusion != null ||
+    exactMergeCheck.app_id !== appId
+  ) {
+    throw new Error("exact-merge authorization requires a valid pending check");
+  }
   const successPayloadPath = writePayload(`authorize-exact-merge-check-${target}`, {
     name: EXACT_MERGE_CHECK_NAME,
     status: "completed",
@@ -1747,30 +2235,40 @@ function publishExactMergeCheck({
       summary:
         `Reviewed base ${effectiveDiffBinding.verified_main_sha}, reviewed head ${expectedHeadSha}, ` +
         `merge head ${mergeHeadSha}, ` +
-        `test merge ${mergeCommitSha}, effective diff ${effectiveDiffBinding.live_effective_diff_sha256}.`,
+        `test merge ${mergeCommitSha}, effective diff ${effectiveDiffBinding.live_effective_diff_sha256}` +
+        `${adoptionProofSha ? `, adoption proof ${adoptionProofSha}` : ""}.`,
     },
   });
   let authorized;
   try {
     authorized = ghJson([
       "api",
-      `repos/${repo}/check-runs/${pending.id}`,
+      `repos/${repo}/check-runs/${exactMergeCheck.id}`,
       "--method",
       "PATCH",
       "--input",
       successPayloadPath,
     ]);
   } catch (error) {
-    const recovered = findExactMergeCheck({ repo, mergeCommitSha, externalId, appId });
-    if (recovered) {
-      const exactMergeCheck = exactMergeCheckRecord(recovered, mergeCommitSha, externalId);
-      setActiveExactMergeAuthorization(repo, exactMergeCheck);
-      return exactMergeCheck;
+    const recovered = findExactMergeCheck({
+      repo,
+      mergeCommitSha,
+      externalId: exactMergeCheck.external_id,
+      appId,
+    });
+    if (recovered?.id === exactMergeCheck.id) {
+      const recoveredCheck = exactMergeCheckRecord(
+        recovered,
+        mergeCommitSha,
+        exactMergeCheck.external_id,
+      );
+      setActiveExactMergeAuthorization(repo, recoveredCheck);
+      return recoveredCheck;
     }
-    setActiveExactMergeAuthorization(repo, pendingRecord);
+    setActiveExactMergeAuthorization(repo, exactMergeCheck);
     try {
-      revokeExactMergeCheck({ repo, exactMergeCheck: pendingRecord });
-      clearActiveExactMergeAuthorization(pendingRecord);
+      revokeExactMergeCheck({ repo, exactMergeCheck });
+      clearActiveExactMergeAuthorization(exactMergeCheck);
     } catch {
       // The exit guard retries in case GitHub accepted the authorization update.
     }
@@ -1778,26 +2276,30 @@ function publishExactMergeCheck({
   }
   if (
     !authorized ||
-    authorized.id !== pending.id ||
+    authorized.id !== exactMergeCheck.id ||
     authorized.name !== EXACT_MERGE_CHECK_NAME ||
     authorized.head_sha?.toLowerCase() !== mergeCommitSha ||
     authorized.status !== "completed" ||
     authorized.conclusion !== "success" ||
-    authorized.external_id !== externalId ||
+    authorized.external_id !== exactMergeCheck.external_id ||
     Number(authorized.app?.id) !== appId
   ) {
-    setActiveExactMergeAuthorization(repo, pendingRecord);
+    setActiveExactMergeAuthorization(repo, exactMergeCheck);
     try {
-      revokeExactMergeCheck({ repo, exactMergeCheck: pendingRecord });
-      clearActiveExactMergeAuthorization(pendingRecord);
+      revokeExactMergeCheck({ repo, exactMergeCheck });
+      clearActiveExactMergeAuthorization(exactMergeCheck);
     } catch {
       // The exit guard retries cleanup if GitHub accepted the authorization update.
     }
     throw new Error("GitHub returned an invalid exact-merge authorization");
   }
-  const exactMergeCheck = exactMergeCheckRecord(authorized, mergeCommitSha, externalId);
-  setActiveExactMergeAuthorization(repo, exactMergeCheck);
-  return exactMergeCheck;
+  const authorizedCheck = exactMergeCheckRecord(
+    authorized,
+    mergeCommitSha,
+    exactMergeCheck.external_id,
+  );
+  setActiveExactMergeAuthorization(repo, authorizedCheck);
+  return authorizedCheck;
 }
 
 function findExactMergeCheck({ repo, mergeCommitSha, externalId, appId }) {
@@ -1942,6 +2444,7 @@ function verifyActualMergedCommit({
   expectedHeadSha,
   mergeHeadSha = expectedHeadSha,
   pullRequest,
+  effectiveDiffBinding = null,
 }) {
   if (!isExternalMergeAction(action)) return null;
   const preflight = findMergePreflight(result, target);
@@ -1954,8 +2457,14 @@ function verifyActualMergedCommit({
   if (String(pullRequest?.head?.sha ?? "").toLowerCase() !== mergeHeadSha.toLowerCase()) {
     return { reason: "merged pull request head does not match the authorized merge head" };
   }
-  const reviewedFingerprint = String(preflight.effective_diff_sha256).toLowerCase();
-  const reviewedBaseSha = String(preflight.reviewed_base_sha).toLowerCase();
+  const reviewedFingerprint = String(
+    effectiveDiffBinding?.live_effective_diff_sha256 ??
+      preflight.effective_diff_sha256,
+  ).toLowerCase();
+  const reviewedBaseSha = String(
+    effectiveDiffBinding?.verified_main_sha ??
+      preflight.reviewed_base_sha,
+  ).toLowerCase();
   const mergeCommitSha = String(pullRequest?.merge_commit_sha ?? "").toLowerCase();
   if (!/^[0-9a-f]{40}$/.test(mergeCommitSha)) {
     return {
@@ -1968,7 +2477,7 @@ function verifyActualMergedCommit({
     const parents = mergeCommit.parents ?? [];
     if (parents.length !== 1 || String(parents[0]?.sha ?? "").toLowerCase() !== reviewedBaseSha) {
       return {
-        reason: "actual squash commit is not based on the reviewed main SHA",
+        reason: "actual squash commit is not based on the authorized main SHA",
         reviewed_effective_diff_sha256: reviewedFingerprint,
         verified_parent_sha: String(parents[0]?.sha ?? "").toLowerCase() || null,
       };

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -4,18 +4,25 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { assertAllowedOwner, parseArgs, parseJob, repoRoot, validateJob } from "./lib.mjs";
-import { isValidationDriftControlFile } from "./base-drift-validation.mjs";
+import {
+  evaluateValidationBaseDrift,
+  isValidationDriftControlFile,
+} from "./base-drift-validation.mjs";
 import { hasSecuritySensitiveText } from "./security-sensitive.mjs";
 
 const PASSING_CHECK_CONCLUSIONS = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"]);
 const CLEAN_MERGE_STATES = new Set(["CLEAN"]);
 const PRE_AUTHORIZATION_MERGE_STATES = new Set(["UNSTABLE", "BLOCKED", "BEHIND"]);
 const IGNORED_CHECKS = new Set(["auto-response", "Labeler", "Stale"]);
+const EXACT_MERGE_CHECK_NAME = "clownfish/exact-merge";
 const REVIEW_BOT_PATTERN = /\b(?:greptile|codex|asile|coderabbit|copilot)\b/i;
 const INSTALL_TIMEOUT_MS = positiveInteger(process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_INSTALL_TIMEOUT_MS, 10 * 60 * 1000);
 const VALIDATION_TIMEOUT_MS = positiveInteger(process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_VALIDATION_TIMEOUT_MS, 20 * 60 * 1000);
 const FAILURE_REASON_MAX_CHARS = 4000;
 const FAILURE_STREAM_MAX_CHARS = 1800;
+const ADOPTION_MANIFEST_SCHEMA_VERSION = 1;
+const ADOPTION_POLICY = "bounded-fast-forward-v1";
+const MAX_ADOPTION_MANIFEST_BLOBS = 2048;
 
 const args = parseArgs(process.argv.slice(2));
 const sourceJobPath = args._[0];
@@ -23,6 +30,9 @@ const pullRequest = Number(args.pr ?? args["pull-request"]);
 const runDir = path.resolve(String(args["run-dir"] ?? path.join(repoRoot(), ".projectclownfish", "external-merge-preflight")));
 const targetDir = path.resolve(String(args["target-dir"] ?? path.join(runDir, "target")));
 const baseBranch = String(args["base-branch"] ?? "main");
+const adoptionManifestPath = args["adoption-manifest"]
+  ? path.resolve(String(args["adoption-manifest"]))
+  : null;
 
 if (!sourceJobPath || !Number.isInteger(pullRequest) || pullRequest < 1) {
   console.error("usage: node scripts/preflight-external-pr-merge.mjs <source-job.md> --pr <number> [--run-dir <path>]");
@@ -50,6 +60,59 @@ if (!sourceRefs.has(targetRef)) {
 }
 
 fs.mkdirSync(runDir, { recursive: true });
+
+if (args["adoption-state-only"]) {
+  const outputPath = path.resolve(
+    String(args.output ?? path.join(runDir, "base-adoption-state.json")),
+  );
+  let state;
+  try {
+    state = captureFreshAdoptionGithubState({
+      sourceJob,
+      pullRequest,
+      expectedHeadSha: String(args["expected-head-sha"] ?? "").toLowerCase(),
+      expectedTestMergeSha: String(args["test-merge-sha"] ?? "").toLowerCase(),
+      adoptedBaseSha: String(args["adopted-base-sha"] ?? "").toLowerCase(),
+    });
+  } catch (error) {
+    state = {
+      status: "blocked",
+      reason: redact(String(error?.message ?? error)),
+    };
+  }
+  writeJson(outputPath, state);
+  console.log(JSON.stringify(state, null, 2));
+  process.exit(0);
+}
+
+if (adoptionManifestPath) {
+  const outputPath = path.resolve(
+    String(args.output ?? path.join(runDir, "base-adoption-proof.json")),
+  );
+  let proof;
+  try {
+    proof = runBaseAdoptionValidation({
+      sourceJob,
+      pullRequest,
+      manifest: JSON.parse(fs.readFileSync(adoptionManifestPath, "utf8")),
+      adoptedBaseSha: String(args["adopted-base-sha"] ?? "").toLowerCase(),
+      expectedHeadSha: String(args["expected-head-sha"] ?? "").toLowerCase(),
+      expectedTestMergeSha: String(args["test-merge-sha"] ?? "").toLowerCase(),
+      targetDir,
+      baseBranch,
+    });
+  } catch (error) {
+    proof = {
+      schema_version: ADOPTION_MANIFEST_SCHEMA_VERSION,
+      policy: ADOPTION_POLICY,
+      status: "blocked",
+      reason: redact(String(error?.message ?? error)),
+    };
+  }
+  writeJson(outputPath, proof);
+  console.log(JSON.stringify(proof, null, 2));
+  process.exit(0);
+}
 
 let pull = null;
 let issue = null;
@@ -179,7 +242,7 @@ try {
   reviewContext.codexReviewedMergeTreeSha = codexReviewedMergeTreeSha;
   reviewContext.baseDriftProof = unchangedBaseDriftProof(codexReviewedBaseSha);
 
-  const maxBaseRevalidations = positiveInteger(
+  const maxBaseRevalidations = nonNegativeInteger(
     process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_MAX_BASE_REVALIDATIONS,
     2,
   );
@@ -187,6 +250,7 @@ try {
   let refreshedIssue = null;
   let refreshedView = null;
   let verifiedMainSha = reviewContext.reviewedBaseSha;
+  let pendingApplyAdoption = null;
   for (let attempt = 0; attempt <= maxBaseRevalidations; attempt += 1) {
     refreshedPull = stage("rehydrate GitHub state after review", () =>
       ghJson(["api", `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}`]),
@@ -233,17 +297,6 @@ try {
       reviewContext.verifiedMergeTreeSha = reviewContext.mergeTreeSha;
       break;
     }
-    if (attempt === maxBaseRevalidations) {
-      writeBlockedArtifacts({
-        reason:
-          `origin/${baseBranch} kept changing after ${maxBaseRevalidations} base revalidation(s): ` +
-          `validated ${reviewContext.reviewedBaseSha}, current ${verifiedMainSha}`,
-        validationCommands,
-        codexReview,
-        currentMainSha: verifiedMainSha,
-      });
-      process.exit(0);
-    }
 
     const verifiedMergeContext = stage("verify effective diff against latest main", () =>
       computeEffectiveMergeContext({
@@ -252,11 +305,15 @@ try {
         exactHeadSha: reviewedHeadSha,
       }),
     );
-    if (verifiedMergeContext.effectiveDiffSha256 !== reviewContext.effectiveDiffSha256) {
+    if (
+      verifiedMergeContext.effectiveDiffFiles !== reviewContext.effectiveDiffFiles ||
+      verifiedMergeContext.effectiveDiffSha256 !== reviewContext.effectiveDiffSha256
+    ) {
       writeBlockedArtifacts({
         reason:
-          `effective merge diff changed while review was running: reviewed ${reviewContext.effectiveDiffSha256}, ` +
-          `current ${verifiedMergeContext.effectiveDiffSha256}`,
+          `effective merge diff changed while review was running: reviewed ` +
+          `${reviewContext.effectiveDiffFiles}/${reviewContext.effectiveDiffSha256}, current ` +
+          `${verifiedMergeContext.effectiveDiffFiles}/${verifiedMergeContext.effectiveDiffSha256}`,
         validationCommands,
         codexReview,
         currentMainSha: verifiedMainSha,
@@ -279,6 +336,58 @@ try {
         currentMainSha: verifiedMainSha,
       });
       process.exit(0);
+    }
+    if (attempt === maxBaseRevalidations) {
+      if (driftEligibility.requires_codex_rereview) {
+        writeBlockedArtifacts({
+          reason:
+            `origin/${baseBranch} kept changing after ${maxBaseRevalidations} base revalidation(s), ` +
+            `and the newest drift requires another Codex review: ${driftEligibility.codex_rereview_reasons.join(", ")}`,
+          validationCommands,
+          codexReview,
+          currentMainSha: verifiedMainSha,
+        });
+        process.exit(0);
+      }
+      const terminalAdoptionManifest = buildBaseAdoptionManifest({
+        targetDir,
+        reviewContext,
+        pull: refreshedPull,
+      });
+      const incompleteSnapshots = [
+        ["reviewed paths", terminalAdoptionManifest.reviewed_paths],
+        ["validation controls", terminalAdoptionManifest.validation_controls],
+        ["review context", terminalAdoptionManifest.review_context],
+      ]
+        .filter(([, snapshot]) => snapshot.complete !== true)
+        .map(([label]) => label);
+      if (
+        terminalAdoptionManifest.effective_diff_files < 1 ||
+        incompleteSnapshots.length > 0
+      ) {
+        writeBlockedArtifacts({
+          reason:
+            `origin/${baseBranch} kept changing after ${maxBaseRevalidations} base revalidation(s), ` +
+            `but the durable adoption manifest is incomplete: ` +
+            `${incompleteSnapshots.join(", ") || "empty effective diff"}`,
+          validationCommands,
+          codexReview,
+          currentMainSha: verifiedMainSha,
+        });
+        process.exit(0);
+      }
+      pendingApplyAdoption = {
+        status: "required",
+        from_base_sha: reviewContext.reviewedBaseSha,
+        observed_main_sha: verifiedMainSha,
+        drift_commit_count: driftEligibility.drift_commit_count,
+        drift_file_count: driftEligibility.drift_file_count,
+        drift_paths_sha256: driftEligibility.drift_paths_sha256,
+        exhausted_revalidations: maxBaseRevalidations,
+      };
+      reviewContext.verifiedMainSha = reviewContext.reviewedBaseSha;
+      reviewContext.verifiedMergeTreeSha = reviewContext.mergeTreeSha;
+      break;
     }
 
     const refreshedReviewContext = stage("prepare refreshed synthetic merge validation", () =>
@@ -372,7 +481,9 @@ try {
   pull = refreshedPull;
   issue = refreshedIssue;
   view = refreshedView;
-  const finalBaseDriftAllowed = verifiedMainSha !== pull.base.sha && canTolerateBaseDrift(view);
+  const validatedMainSha = reviewContext.reviewedBaseSha;
+  const observedMainSha = pendingApplyAdoption?.observed_main_sha ?? verifiedMainSha;
+  const finalBaseDriftAllowed = observedMainSha !== pull.base.sha && canTolerateBaseDrift(view);
   const rehydratedAt = new Date().toISOString();
   const result = buildMergeResult({
     sourceJob,
@@ -383,9 +494,11 @@ try {
     pullRequest,
     validationCommands,
     codexReview,
-    currentMainSha: verifiedMainSha,
+    currentMainSha: validatedMainSha,
+    observedMainSha,
     baseDriftAllowed: finalBaseDriftAllowed,
     reviewContext,
+    pendingApplyAdoption,
   });
   report = {
     ...report,
@@ -397,9 +510,12 @@ try {
     codex_reviewed_base_sha: reviewContext.codexReviewedBaseSha,
     codex_reviewed_synthetic_merge_sha: reviewContext.codexReviewedSyntheticMergeSha,
     codex_reviewed_merge_tree_sha: reviewContext.codexReviewedMergeTreeSha,
-    current_main_sha: verifiedMainSha,
+    current_main_sha: observedMainSha,
+    validated_main_sha: validatedMainSha,
     pull_request_base_sha: pull.base.sha,
     base_drift_allowed: finalBaseDriftAllowed,
+    apply_time_adoption_required: Boolean(pendingApplyAdoption),
+    pending_apply_adoption: pendingApplyAdoption,
     synthetic_merge_sha: reviewContext.syntheticMergeSha,
     synthetic_merge_tree_sha: reviewContext.mergeTreeSha,
     verified_merge_tree_sha: reviewContext.verifiedMergeTreeSha,
@@ -618,12 +734,24 @@ function hasUnknownMergeability(view) {
   return ["", "UNKNOWN"].includes(String(view?.mergeable ?? "").toUpperCase()) || ["", "UNKNOWN"].includes(String(view?.mergeStateStatus ?? "").toUpperCase());
 }
 
-function readOnlyBlockers({ sourceJob, pull, view, issueComments, pullRequest }) {
+function readOnlyBlockers({
+  sourceJob,
+  pull,
+  view,
+  issueComments,
+  pullRequest,
+  reviewComments: hydratedReviewComments = null,
+  threads: hydratedThreads = null,
+}) {
   const blockers = [];
   const trustedAuthorEvidenceApprovalAt = trustedAuthorEvidenceApprovalTimestamp(issueComments, { pull });
   const trustedAuthorProgressApprovalAt = trustedAuthorProgressApprovalTimestamp(issueComments, { pull });
-  const reviewComments = ghJson(["api", `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}/comments?per_page=100`]);
-  const threads = fetchReviewThreads({ repo: sourceJob.frontmatter.repo, pullRequest });
+  const reviewComments =
+    hydratedReviewComments ??
+    ghJson(["api", `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}/comments?per_page=100`]);
+  const threads =
+    hydratedThreads ??
+    fetchReviewThreads({ repo: sourceJob.frontmatter.repo, pullRequest });
   const texts = [
     pull.title,
     pull.body,
@@ -666,6 +794,7 @@ function readOnlyBlockers({ sourceJob, pull, view, issueComments, pullRequest })
   const unresolved = threads.nodes.filter((thread) => !thread.isResolved);
   if (unresolved.length > 0) blockers.push(`PR has ${unresolved.length} unresolved review thread(s)`);
   if (issueComments.length >= 100) blockers.push("PR has at least 100 top-level issue comments; comment history may be truncated");
+  if (reviewComments.length >= 100) blockers.push("PR has at least 100 inline review comments; comment history may be truncated");
   const actionableIssueComments = issueComments.filter(
     (comment, index) =>
       !isSupersededDependencyGuardNotice(comment, issueComments.slice(index + 1), { pull, view }) &&
@@ -962,6 +1091,10 @@ function verifyBoundedDisjointBaseDrift({
     drift_commit_count: driftCommitCount,
     drift_file_count: driftPaths.length,
     drift_paths_sha256: createHash("sha256").update(driftPaths.sort().join("\0")).digest("hex"),
+    drift_paths: driftPaths,
+    reviewed_areas: [...reviewedAreas].sort(),
+    drift_areas: driftAreas,
+    validation_control_files: controlFiles,
     requires_codex_rereview: controlFiles.length > 0 || overlappingAreas.length > 0,
     codex_rereview_reasons: [
       ...(controlFiles.length > 0 ? ["validation_control_file_drift"] : []),
@@ -1060,6 +1193,556 @@ function fingerprintTreeEntries(baseEntries, resultEntries) {
     changes,
     resultEntries,
   };
+}
+
+function buildBaseAdoptionManifest({ targetDir, reviewContext, pull }) {
+  const baseEntries = readGitTreeEntries({
+    cwd: targetDir,
+    treeish: reviewContext.reviewedBaseSha,
+  });
+  const resultEntries = reviewContext.expectedTreeEntries;
+  const effectivePaths = [...new Set(reviewContext.changedFiles ?? [])].sort();
+  const affectedAreas = affectedAreasForFiles(effectivePaths);
+  const effectivePathSet = new Set(effectivePaths);
+  const affectedAreaSet = new Set(affectedAreas);
+  return {
+    schema_version: ADOPTION_MANIFEST_SCHEMA_VERSION,
+    policy: ADOPTION_POLICY,
+    reviewed_base_sha: reviewContext.reviewedBaseSha,
+    reviewed_head_sha: String(pull.head.sha).toLowerCase(),
+    reviewed_synthetic_merge_sha: reviewContext.syntheticMergeSha,
+    reviewed_merge_tree_sha: reviewContext.mergeTreeSha,
+    effective_diff_sha256: reviewContext.effectiveDiffSha256,
+    effective_diff_files: reviewContext.effectiveDiffFiles,
+    effective_paths: effectivePaths,
+    affected_areas: affectedAreas,
+    validation_gate: "pnpm check:changed",
+    reviewed_paths: buildBlobSnapshot({
+      baseEntries,
+      resultEntries,
+      includePath: (filePath) => effectivePathSet.has(filePath),
+    }),
+    validation_controls: buildBlobSnapshot({
+      baseEntries,
+      resultEntries,
+      includePath: isValidationDriftControlFile,
+    }),
+    review_context: buildBlobSnapshot({
+      baseEntries,
+      resultEntries,
+      includePath: (filePath) => affectedAreaSet.has(affectedAreaForFile(filePath)),
+    }),
+  };
+}
+
+function buildBlobSnapshot({
+  baseEntries,
+  resultEntries,
+  includePath,
+  maxBlobs = MAX_ADOPTION_MANIFEST_BLOBS,
+}) {
+  const paths = [...new Set([...baseEntries.keys(), ...resultEntries.keys()])]
+    .filter(includePath)
+    .sort();
+  const blobs = paths.map((filePath) => ({
+    path: filePath,
+    reviewed_base_entry: baseEntries.get(filePath) ?? null,
+    reviewed_result_entry: resultEntries.get(filePath) ?? null,
+  }));
+  return {
+    complete: blobs.length <= maxBlobs,
+    files: blobs.length,
+    sha256: hashBlobSnapshot(blobs),
+    blobs: blobs.slice(0, maxBlobs),
+  };
+}
+
+function hashBlobSnapshot(blobs) {
+  return createHash("sha256")
+    .update(`${blobs.map((entry) => JSON.stringify(entry)).join("\n")}\n`)
+    .digest("hex");
+}
+
+function assertBlobSnapshotMatches(label, expected, actual) {
+  if (expected?.complete !== true) {
+    throw new Error(`${label} manifest is incomplete`);
+  }
+  if (
+    actual.complete !== true ||
+    expected.files !== actual.files ||
+    expected.sha256 !== actual.sha256 ||
+    JSON.stringify(expected.blobs) !== JSON.stringify(actual.blobs)
+  ) {
+    throw new Error(`${label} changed since the reviewed base`);
+  }
+}
+
+function assertBaseAdoptionManifest(manifest, { expectedHeadSha, adoptedBaseSha }) {
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+    throw new Error("base adoption manifest is missing");
+  }
+  if (
+    manifest.schema_version !== ADOPTION_MANIFEST_SCHEMA_VERSION ||
+    manifest.policy !== ADOPTION_POLICY
+  ) {
+    throw new Error("base adoption manifest version or policy is unsupported");
+  }
+  for (const [label, value] of [
+    ["reviewed base", manifest.reviewed_base_sha],
+    ["reviewed head", manifest.reviewed_head_sha],
+    ["reviewed synthetic merge", manifest.reviewed_synthetic_merge_sha],
+    ["reviewed merge tree", manifest.reviewed_merge_tree_sha],
+    ["adopted base", adoptedBaseSha],
+    ["expected head", expectedHeadSha],
+  ]) {
+    if (!/^[0-9a-f]{40}$/i.test(String(value ?? ""))) {
+      throw new Error(`${label} SHA is missing or invalid`);
+    }
+  }
+  if (String(manifest.reviewed_head_sha).toLowerCase() !== expectedHeadSha) {
+    throw new Error("base adoption manifest reviewed head does not match expected head");
+  }
+  if (!/^[0-9a-f]{64}$/i.test(String(manifest.effective_diff_sha256 ?? ""))) {
+    throw new Error("base adoption manifest effective diff fingerprint is invalid");
+  }
+  if (
+    !Number.isInteger(manifest.effective_diff_files) ||
+    manifest.effective_diff_files < 1 ||
+    !Array.isArray(manifest.effective_paths) ||
+    manifest.effective_paths.length !== manifest.effective_diff_files ||
+    !Array.isArray(manifest.affected_areas) ||
+    manifest.validation_gate !== "pnpm check:changed"
+  ) {
+    throw new Error("base adoption manifest effective diff evidence is incomplete");
+  }
+  for (const key of ["reviewed_paths", "validation_controls", "review_context"]) {
+    const snapshot = manifest[key];
+    if (
+      !snapshot ||
+      snapshot.complete !== true ||
+      !Number.isInteger(snapshot.files) ||
+      snapshot.files < 0 ||
+      !/^[0-9a-f]{64}$/i.test(String(snapshot.sha256 ?? "")) ||
+      !Array.isArray(snapshot.blobs) ||
+      snapshot.blobs.length !== snapshot.files
+    ) {
+      throw new Error(`base adoption manifest ${key} snapshot is incomplete`);
+    }
+  }
+}
+
+function captureFreshAdoptionGithubState({
+  sourceJob,
+  pullRequest,
+  expectedHeadSha,
+  expectedTestMergeSha,
+  adoptedBaseSha,
+}) {
+  for (const [label, value] of [
+    ["expected head", expectedHeadSha],
+    ["GitHub test merge", expectedTestMergeSha],
+    ["adopted base", adoptedBaseSha],
+  ]) {
+    if (!/^[0-9a-f]{40}$/i.test(String(value ?? ""))) {
+      throw new Error(`${label} SHA is missing or invalid`);
+    }
+  }
+  const pull = ghJson([
+    "api",
+    `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}`,
+  ]);
+  const issue = ghJson([
+    "api",
+    `repos/${sourceJob.frontmatter.repo}/issues/${pullRequest}`,
+  ]);
+  const issueComments = fetchIssueComments({
+    repo: sourceJob.frontmatter.repo,
+    pullRequest,
+  });
+  const reviewComments = ghJson([
+    "api",
+    `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}/comments?per_page=100`,
+  ]);
+  const threads = fetchReviewThreads({
+    repo: sourceJob.frontmatter.repo,
+    pullRequest,
+  });
+  const view = fetchSettledPullRequestView({
+    repo: sourceJob.frontmatter.repo,
+    pullRequest,
+  });
+  const blockers = [
+    ...(String(pull.head?.sha ?? "").toLowerCase() !== expectedHeadSha
+      ? ["PR head changed during apply-time adoption validation"]
+      : []),
+    ...(String(pull.merge_commit_sha ?? "").toLowerCase() !== expectedTestMergeSha
+      ? ["GitHub test merge changed during apply-time adoption validation"]
+      : []),
+    ...readOnlyBlockers({
+      sourceJob,
+      pull,
+      view,
+      issueComments,
+      pullRequest,
+      reviewComments,
+      threads,
+    }),
+  ];
+  const mainRef = ghJson([
+    "api",
+    `repos/${sourceJob.frontmatter.repo}/git/ref/heads/${baseBranch}`,
+  ]);
+  const currentMainSha = String(mainRef?.object?.sha ?? "").toLowerCase();
+  if (currentMainSha !== adoptedBaseSha) {
+    blockers.push(
+      `main changed during apply-time adoption validation: expected ${adoptedBaseSha}, current ${currentMainSha || "unknown"}`,
+    );
+  }
+  const testMerge = ghJson([
+    "api",
+    `repos/${sourceJob.frontmatter.repo}/git/commits/${expectedTestMergeSha}`,
+  ]);
+  const testMergeParents = testMerge.parents ?? [];
+  if (
+    testMergeParents.length !== 2 ||
+    String(testMergeParents[0]?.sha ?? "").toLowerCase() !== adoptedBaseSha ||
+    String(testMergeParents[1]?.sha ?? "").toLowerCase() !== expectedHeadSha
+  ) {
+    blockers.push("GitHub test merge is not bound to [adopted main, reviewed head]");
+  }
+  if (blockers.length > 0) {
+    throw new Error(blockers.join("; "));
+  }
+  const state = {
+    issue: {
+      state: issue.state ?? null,
+      title: issue.title ?? null,
+      body: issue.body ?? null,
+      updated_at: issue.updated_at ?? null,
+      locked: issue.locked ?? false,
+      labels: sortedStrings((issue.labels ?? []).map((label) => label?.name ?? label)),
+      assignees: sortedStrings((issue.assignees ?? []).map((assignee) => assignee?.login)),
+      milestone: issue.milestone?.number ?? null,
+    },
+    pull: {
+      state: pull.state ?? null,
+      draft: pull.draft ?? false,
+      title: pull.title ?? null,
+      body: pull.body ?? null,
+      updated_at: pull.updated_at ?? null,
+      base_ref: pull.base?.ref ?? null,
+      base_sha: String(pull.base?.sha ?? "").toLowerCase() || null,
+      head_ref: pull.head?.ref ?? null,
+      head_sha: String(pull.head?.sha ?? "").toLowerCase() || null,
+      head_repo: pull.head?.repo?.full_name ?? null,
+      merge_commit_sha: String(pull.merge_commit_sha ?? "").toLowerCase() || null,
+    },
+    view: {
+      mergeable: view.mergeable ?? null,
+      review_decision: view.reviewDecision ?? null,
+      reviews: sortedObjects((view.reviews ?? []).map(normalizeReviewState)),
+      checks: sortedObjects(
+        latestStatusChecks(view.statusCheckRollup ?? [])
+          .filter((check) => checkName(check) !== EXACT_MERGE_CHECK_NAME)
+          .map(normalizeCheckState),
+      ),
+    },
+    issue_comments: sortedObjects(issueComments.map(normalizeCommentState)),
+    review_comments: sortedObjects(reviewComments.map(normalizeReviewCommentState)),
+    review_threads: sortedObjects(
+      (threads.nodes ?? []).map((thread) => ({
+        is_resolved: thread?.isResolved === true,
+        path: thread?.path ?? null,
+        line: thread?.line ?? null,
+      })),
+    ),
+  };
+  return {
+    status: "clean",
+    reason: "fresh GitHub comments, reviews, metadata, checks, and risk state are clean",
+    github_state_sha256: createHash("sha256")
+      .update(JSON.stringify(state))
+      .digest("hex"),
+    issue_updated_at: issue.updated_at ?? null,
+    pull_updated_at: pull.updated_at ?? null,
+    test_merge_tree_sha: String(testMerge.tree?.sha ?? "").toLowerCase() || null,
+  };
+}
+
+function normalizeCommentState(comment) {
+  return {
+    author: comment?.author?.login ?? comment?.user?.login ?? null,
+    association: comment?.authorAssociation ?? comment?.author_association ?? null,
+    body: comment?.body ?? "",
+    created_at: comment?.createdAt ?? comment?.created_at ?? null,
+    updated_at: comment?.updatedAt ?? comment?.updated_at ?? null,
+    minimized: comment?.isMinimized === true,
+    minimized_reason: comment?.minimizedReason ?? null,
+    url: comment?.url ?? comment?.html_url ?? null,
+  };
+}
+
+function normalizeReviewCommentState(comment) {
+  return {
+    ...normalizeCommentState(comment),
+    path: comment?.path ?? null,
+    line: comment?.line ?? null,
+    commit_id: String(comment?.commit_id ?? "").toLowerCase() || null,
+  };
+}
+
+function normalizeReviewState(review) {
+  return {
+    ...normalizeCommentState(review),
+    state: review?.state ?? null,
+    commit_oid: String(review?.commit?.oid ?? review?.commit_id ?? "").toLowerCase() || null,
+    submitted_at: review?.submittedAt ?? review?.submitted_at ?? null,
+  };
+}
+
+function normalizeCheckState(check) {
+  return {
+    name: checkName(check),
+    workflow: check?.workflowName ?? null,
+    status: String(check?.status ?? check?.state ?? "").toUpperCase() || null,
+    conclusion: String(check?.conclusion ?? "").toUpperCase() || null,
+    started_at: check?.startedAt ?? check?.started_at ?? null,
+    completed_at: check?.completedAt ?? check?.completed_at ?? null,
+  };
+}
+
+function sortedStrings(values) {
+  return values
+    .map((value) => String(value ?? "").trim())
+    .filter(Boolean)
+    .sort();
+}
+
+function sortedObjects(values) {
+  return values.sort((left, right) =>
+    JSON.stringify(left).localeCompare(JSON.stringify(right)),
+  );
+}
+
+function runBaseAdoptionValidation({
+  sourceJob,
+  pullRequest,
+  manifest,
+  adoptedBaseSha,
+  expectedHeadSha,
+  expectedTestMergeSha,
+  targetDir,
+  baseBranch,
+}) {
+  assertBaseAdoptionManifest(manifest, { expectedHeadSha, adoptedBaseSha });
+  if (!/^[0-9a-f]{40}$/i.test(expectedTestMergeSha)) {
+    throw new Error("GitHub test merge SHA is missing or invalid");
+  }
+
+  checkoutExactPullHead({
+    repo: sourceJob.frontmatter.repo,
+    pullRequest,
+    expectedHeadSha,
+  });
+  const fetchedMainSha = run("git", ["rev-parse", `origin/${baseBranch}`], {
+    cwd: targetDir,
+    env: gitIntegrityEnv(),
+  }).trim();
+  if (fetchedMainSha !== adoptedBaseSha) {
+    throw new Error(
+      `main changed before adoption validation: expected ${adoptedBaseSha}, current ${fetchedMainSha}`,
+    );
+  }
+
+  const reviewedMergeContext = computeEffectiveMergeContext({
+    targetDir,
+    baseSha: manifest.reviewed_base_sha,
+    exactHeadSha: expectedHeadSha,
+  });
+  if (
+    reviewedMergeContext.mergeTreeSha !== manifest.reviewed_merge_tree_sha ||
+    reviewedMergeContext.effectiveDiffFiles !== manifest.effective_diff_files ||
+    reviewedMergeContext.effectiveDiffSha256 !== manifest.effective_diff_sha256
+  ) {
+    throw new Error("reviewed synthetic merge no longer matches the adoption manifest");
+  }
+  const reviewedBaseEntries = readGitTreeEntries({
+    cwd: targetDir,
+    treeish: manifest.reviewed_base_sha,
+  });
+  verifyBaseAdoptionSnapshots({
+    manifest,
+    baseEntries: reviewedBaseEntries,
+    resultEntries: reviewedMergeContext.resultEntries,
+    phase: "reviewed",
+  });
+
+  const driftEligibility = verifyBoundedDisjointBaseDrift({
+    targetDir,
+    reviewedBaseSha: manifest.reviewed_base_sha,
+    currentBaseSha: adoptedBaseSha,
+    reviewedChangedFiles: manifest.effective_paths,
+  });
+  if (driftEligibility.status === "blocked") {
+    throw new Error(driftEligibility.reason);
+  }
+  const driftDecision = evaluateValidationBaseDrift({
+    validationCommands: [manifest.validation_gate],
+    validatedHeadSha: manifest.reviewed_head_sha,
+    currentHeadSha: expectedHeadSha,
+    validatedBaseSha: manifest.reviewed_base_sha,
+    currentBaseSha: adoptedBaseSha,
+    validatedBaseIsAncestorOfHead: true,
+    validatedBaseIsAncestorOfCurrentBase: true,
+    driftCommitCount: driftEligibility.drift_commit_count,
+    branchFiles: manifest.effective_paths,
+    baseDriftFiles: driftEligibility.drift_paths,
+    branchAreas: manifest.affected_areas,
+    baseDriftAreas: driftEligibility.drift_areas,
+    evidenceComplete: true,
+    maxCommits: positiveInteger(
+      process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_MAX_DISJOINT_BASE_COMMITS,
+      20,
+    ),
+    maxFiles: positiveInteger(
+      process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_MAX_DISJOINT_BASE_FILES,
+      128,
+    ),
+  });
+  if (driftDecision.status !== "reused") {
+    throw new Error(`base adoption rejected: ${driftDecision.reason}`);
+  }
+  const adoptedReviewContext = prepareSyntheticMergeReview({
+    targetDir,
+    baseBranch,
+    currentMainSha: adoptedBaseSha,
+    exactHeadSha: expectedHeadSha,
+  });
+  if (
+    adoptedReviewContext.effectiveDiffFiles !== manifest.effective_diff_files ||
+    adoptedReviewContext.effectiveDiffSha256 !== manifest.effective_diff_sha256
+  ) {
+    throw new Error("effective merge fingerprint changed on adopted main");
+  }
+  const adoptedBaseEntries = readGitTreeEntries({
+    cwd: targetDir,
+    treeish: adoptedBaseSha,
+  });
+  verifyBaseAdoptionSnapshots({
+    manifest,
+    baseEntries: adoptedBaseEntries,
+    resultEntries: adoptedReviewContext.expectedTreeEntries,
+    phase: "adopted",
+  });
+
+  prepareTargetToolchain(targetDir);
+  adoptedReviewContext.integrityBaseline = verifySyntheticReviewCheckout({
+    targetDir,
+    expectedSnapshot: adoptedReviewContext.preToolchainSnapshot,
+    expectedEntries: adoptedReviewContext.expectedTreeEntries,
+    phase: "adopted target toolchain preparation",
+    allowToolchainGitConfigChange: true,
+  });
+  const validationCommands = runValidation({
+    targetDir,
+    reviewContext: adoptedReviewContext,
+  });
+  verifySyntheticReviewCheckout({
+    targetDir,
+    expectedSnapshot: adoptedReviewContext.integrityBaseline,
+    expectedEntries: adoptedReviewContext.expectedTreeEntries,
+    phase: "adopted target validation",
+  });
+
+  const githubState = captureFreshAdoptionGithubState({
+    sourceJob,
+    pullRequest,
+    expectedHeadSha,
+    expectedTestMergeSha,
+    adoptedBaseSha,
+  });
+  if (githubState.test_merge_tree_sha !== adoptedReviewContext.mergeTreeSha) {
+    throw new Error("GitHub test merge is not the validated [adopted main, reviewed head] merge");
+  }
+  const finalMainSha = refreshTargetMain({ targetDir, baseBranch });
+  if (finalMainSha !== adoptedBaseSha) {
+    throw new Error(
+      `main changed during apply-time adoption validation: expected ${adoptedBaseSha}, current ${finalMainSha}`,
+    );
+  }
+
+  const authorization = {
+    policy: ADOPTION_POLICY,
+    reviewed_base_sha: manifest.reviewed_base_sha,
+    adopted_base_sha: adoptedBaseSha,
+    reviewed_head_sha: expectedHeadSha,
+    test_merge_sha: expectedTestMergeSha,
+    test_merge_tree_sha: adoptedReviewContext.mergeTreeSha,
+    effective_diff_files: adoptedReviewContext.effectiveDiffFiles,
+    effective_diff_sha256: adoptedReviewContext.effectiveDiffSha256,
+    drift_commit_count: driftEligibility.drift_commit_count,
+    drift_file_count: driftEligibility.drift_file_count,
+    drift_paths_sha256: driftEligibility.drift_paths_sha256,
+    reviewed_paths_sha256: manifest.reviewed_paths.sha256,
+    validation_controls_sha256: manifest.validation_controls.sha256,
+    review_context_sha256: manifest.review_context.sha256,
+    validation_commands: validationCommands,
+    github_state_sha256: githubState.github_state_sha256,
+    issue_updated_at: githubState.issue_updated_at,
+    pull_updated_at: githubState.pull_updated_at,
+  };
+  return {
+    schema_version: ADOPTION_MANIFEST_SCHEMA_VERSION,
+    policy: ADOPTION_POLICY,
+    status: "adopted",
+    reason: "validated newer fast-forward main without another Codex review",
+    ...authorization,
+    authorization_sha256: createHash("sha256")
+      .update(JSON.stringify(authorization))
+      .digest("hex"),
+    synthetic_merge_sha: adoptedReviewContext.syntheticMergeSha,
+    drift_proof: driftDecision.proof,
+    context_proof: {
+      reviewed_paths_unchanged: true,
+      validation_controls_unchanged: true,
+      review_context_unchanged: true,
+    },
+    validated_at: new Date().toISOString(),
+  };
+}
+
+function verifyBaseAdoptionSnapshots({
+  manifest,
+  baseEntries,
+  resultEntries,
+  phase,
+}) {
+  const effectivePathSet = new Set(manifest.effective_paths);
+  const affectedAreaSet = new Set(manifest.affected_areas);
+  for (const [label, expected, includePath] of [
+    [
+      "reviewed paths",
+      manifest.reviewed_paths,
+      (filePath) => effectivePathSet.has(filePath),
+    ],
+    [
+      "validation controls",
+      manifest.validation_controls,
+      isValidationDriftControlFile,
+    ],
+    [
+      "review context",
+      manifest.review_context,
+      (filePath) => affectedAreaSet.has(affectedAreaForFile(filePath)),
+    ],
+  ]) {
+    const actual = buildBlobSnapshot({ baseEntries, resultEntries, includePath });
+    try {
+      assertBlobSnapshotMatches(label, expected, actual);
+    } catch (error) {
+      throw new Error(`${phase} ${String(error?.message ?? error)}`);
+    }
+  }
 }
 
 function verifySyntheticReviewCheckout({
@@ -1400,26 +2083,33 @@ function buildMergeResult({
   validationCommands,
   codexReview,
   currentMainSha,
+  observedMainSha,
   baseDriftAllowed,
   reviewContext,
+  pendingApplyAdoption,
 }) {
   const codexReviewedBaseSha = reviewContext.codexReviewedBaseSha ?? reviewContext.reviewedBaseSha;
   const codexReviewedSyntheticMergeSha =
     reviewContext.codexReviewedSyntheticMergeSha ?? reviewContext.syntheticMergeSha;
   const codexReviewedMergeTreeSha = reviewContext.codexReviewedMergeTreeSha ?? reviewContext.mergeTreeSha;
   const validationAndReviewSharedBase = codexReviewedBaseSha === reviewContext.reviewedBaseSha;
+  const baseAdoptionManifest = buildBaseAdoptionManifest({ targetDir, reviewContext, pull });
   const evidence = [
     `Exact PR head ${pull.head.sha} checked out from refs/pull/${pullRequest}/head.`,
     validationAndReviewSharedBase
       ? `Validation and Codex review ran on synthetic squash-result commit ${reviewContext.syntheticMergeSha} with origin/main ${reviewContext.reviewedBaseSha} as its parent and merge tree ${reviewContext.mergeTreeSha} computed from exact PR head ${pull.head.sha}.`
       : `Codex review ran on synthetic squash-result commit ${codexReviewedSyntheticMergeSha} with origin/main ${codexReviewedBaseSha} as its parent and merge tree ${codexReviewedMergeTreeSha}; validation was rerun on synthetic commit ${reviewContext.syntheticMergeSha} with refreshed origin/main ${reviewContext.reviewedBaseSha}.`,
     `Review surface narrowed from ${reviewContext.rawDiffFiles} raw PR file(s) to ${reviewContext.effectiveDiffFiles} effective merge file(s).`,
-    `Effective blob delta ${reviewContext.effectiveDiffSha256} was unchanged after refreshing origin/main to ${reviewContext.verifiedMainSha}.`,
+    pendingApplyAdoption
+      ? `Effective blob delta ${reviewContext.effectiveDiffSha256} stayed unchanged through observed origin/main ${observedMainSha}; the last fully validated base ${reviewContext.reviewedBaseSha} was preserved for apply-time adoption.`
+      : `Effective blob delta ${reviewContext.effectiveDiffSha256} was unchanged after refreshing origin/main to ${reviewContext.verifiedMainSha}.`,
     reviewContext.baseDriftProof.drift_commit_count > 0
       ? `Base stabilization accepted ${reviewContext.baseDriftProof.drift_commit_count} bounded disjoint main commit(s) across ${reviewContext.baseDriftProof.drift_file_count} changed file(s), reran validation ${reviewContext.baseDriftProof.validation_reruns} time(s)${reviewContext.baseDriftProof.segments.some((segment) => segment.codex_rereview) ? " and Codex review" : ""}, then bound apply to ${reviewContext.reviewedBaseSha}.`
       : "Review base still matched current origin/main after review.",
     baseDriftAllowed
-      ? reviewContext.baseDriftProof.drift_commit_count > 0
+      ? pendingApplyAdoption
+        ? `PR base ${pull.base.sha} remained mergeable with clean latest checks while origin/main advanced to ${observedMainSha}; apply must adopt from validated base ${currentMainSha} without changing reviewed head ${pull.head.sha}.`
+        : reviewContext.baseDriftProof.drift_commit_count > 0
         ? `PR base ${pull.base.sha} remained mergeable with clean latest checks; the identical disjoint effective diff was validated against origin/main ${currentMainSha}.`
         : `PR base ${pull.base.sha} drifted from origin/main ${currentMainSha}; exact head remained mergeable with clean latest checks and validation ran against that origin/main snapshot.`
       : `PR base ${pull.base.sha} matched current origin/main ${currentMainSha} before validation.`,
@@ -1493,6 +2183,7 @@ function buildMergeResult({
           ],
         },
         validation_commands: validationCommands,
+        base_adoption_manifest: baseAdoptionManifest,
       },
     ],
     fix_artifact: null,

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -22,8 +22,15 @@ const MERGE_TREE_SHA = "f".repeat(40);
 const CURRENT_MAIN_TREE_SHA = "8".repeat(40);
 const REVIEWED_BASE_SHA = "4".repeat(40);
 const REVIEWED_BASE_TREE_SHA = "5".repeat(40);
+const REVIEWED_MERGE_TREE_SHA = "ab".repeat(20);
 const BASE_BLOB_SHA = "1".repeat(40);
 const MERGE_BLOB_SHA = "2".repeat(40);
+const ADOPTION_BASE_CONTENT = "reviewed base content\n";
+const ADOPTION_MERGE_CONTENT = "reviewed merge content\n";
+const ADOPTION_DOC_CONTENT = "unrelated main documentation\n";
+const ADOPTION_BASE_BLOB_SHA = gitBlobSha(ADOPTION_BASE_CONTENT);
+const ADOPTION_MERGE_BLOB_SHA = gitBlobSha(ADOPTION_MERGE_CONTENT);
+const ADOPTION_DOC_BLOB_SHA = gitBlobSha(ADOPTION_DOC_CONTENT);
 const EFFECTIVE_DIFF_SHA256 = createHash("sha256")
   .update(
     `${JSON.stringify([
@@ -33,6 +40,22 @@ const EFFECTIVE_DIFF_SHA256 = createHash("sha256")
     ])}\n`,
   )
   .digest("hex");
+const ADOPTION_EFFECTIVE_DIFF_SHA256 = createHash("sha256")
+  .update(
+    `${JSON.stringify([
+      "src/cli/effective.ts",
+      `100644:blob:${ADOPTION_BASE_BLOB_SHA}`,
+      `100644:blob:${ADOPTION_MERGE_BLOB_SHA}`,
+    ])}\n`,
+  )
+  .digest("hex");
+
+function gitBlobSha(content) {
+  return createHash("sha1")
+    .update(`blob ${Buffer.byteLength(content)}\0`)
+    .update(content)
+    .digest("hex");
+}
 
 test("apply-result maps the applicator token into gh CLI auth", () => {
   const source = fs.readFileSync(path.join(repoRoot, "scripts", "apply-result.mjs"), "utf8");
@@ -617,7 +640,17 @@ for (const mergeStateStatus of ["BLOCKED", "BEHIND"]) {
     );
     const mergeIndex = ghCalls.findIndex((args) => args[0] === "pr" && args[1] === "merge");
     assert.ok(authorizationIndex >= 0);
-    assert.equal(mergeIndex, authorizationIndex + 1);
+    assert.ok(mergeIndex > authorizationIndex);
+    assert.equal(
+      ghCalls
+        .slice(authorizationIndex + 1, mergeIndex)
+        .some(
+          (args) =>
+            args[0] === "api" &&
+            args[1] === "repos/openclaw/openclaw/git/ref/heads/main",
+        ),
+      false,
+    );
   });
 }
 
@@ -951,6 +984,307 @@ test("apply-result blocks overlapping main drift since external review", () => {
   assert.equal(fs.existsSync(mergeStatePath), false);
 });
 
+test("apply-result adopts newer fast-forward main without updating the reviewed branch", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(
+    binDir,
+    adoptionStubOptions({
+      adoptionDriftPath: "src/other/unrelated.ts",
+      currentMainExtraPath: "src/other/unrelated.ts",
+    }),
+  );
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(adoptionMergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    mergeStatePath,
+    env: { CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0" },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "executed");
+  assert.equal(report.actions[0].reviewed_head_sha, EXPECTED_HEAD_SHA);
+  assert.equal(report.actions[0].merge_head_sha, EXPECTED_HEAD_SHA);
+  assert.equal(report.actions[0].verified_main_sha, CURRENT_MAIN_SHA);
+  assert.equal(report.actions[0].base_adoption.status, "adopted");
+  assert.equal(report.actions[0].base_adoption.reviewed_base_sha, REVIEWED_BASE_SHA);
+  assert.equal(report.actions[0].base_adoption.adopted_base_sha, CURRENT_MAIN_SHA);
+  assert.equal(report.actions[0].base_adoption.test_merge_sha, TEST_MERGE_SHA);
+  assert.equal(report.actions[0].base_adoption.context_proof.review_context_unchanged, true);
+  assert.match(report.actions[0].base_adoption.github_state_sha256, /^[0-9a-f]{64}$/);
+  assert.match(report.actions[0].base_adoption.authorization_sha256, /^[0-9a-f]{64}$/);
+  const ghCalls = readCallLog(callLogPath);
+  assert.equal(ghCalls.some((args) => args[1]?.endsWith("/update-branch")), false);
+  const mergeArgs = ghCalls.find((args) => args[0] === "pr" && args[1] === "merge");
+  assert.deepEqual(mergeArgs.slice(-3), [
+    "--squash",
+    "--match-head-commit",
+    EXPECTED_HEAD_SHA,
+  ]);
+  assert.match(report.actions[0].exact_merge_check.external_id, /:adopt:[0-9a-f]{64}$/);
+});
+
+for (const rejection of [
+  {
+    name: "reviewed path overlap",
+    options: { adoptionDriftPath: "src/cli/effective.ts" },
+    reason: /changed reviewed path/,
+  },
+  {
+    name: "review context overlap",
+    options: { adoptionDriftPath: "src/cli/context.ts" },
+    reason: /overlapping_affected_areas/,
+  },
+  {
+    name: "validation control drift",
+    options: { adoptionDriftPath: "package.json" },
+    reason: /validation_control_file_drift/,
+  },
+  {
+    name: "nonlinear main movement",
+    options: { adoptionLinear: false },
+    reason: /changed non-linearly/,
+  },
+  {
+    name: "excessive main movement",
+    options: { adoptionDriftCommitCount: 21 },
+    reason: /bounded review-reuse window/,
+  },
+  {
+    name: "target-native validation failure",
+    options: { adoptionValidationFailure: true },
+    reason: /fixture adopted-main validation failure/,
+  },
+  {
+    name: "fresh actionable comment",
+    options: {
+      issueComments: [
+        {
+          user: { login: "reviewer" },
+          body: "Please do not merge this yet.",
+          created_at: "2026-06-11T05:08:00Z",
+          updated_at: "2026-06-11T05:08:00Z",
+        },
+      ],
+    },
+    reason: /actionable top-level issue comment/,
+  },
+  {
+    name: "fresh risk label",
+    options: { adoptionLabels: [{ name: "merge-risk: availability" }] },
+    reason: /blocked live label/,
+  },
+]) {
+  test(`apply-result rejects newer-main adoption for ${rejection.name}`, () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+    const binDir = path.join(tmp, "bin");
+    const mergeStatePath = path.join(tmp, "merge-state");
+    fs.mkdirSync(binDir, { recursive: true });
+    writeReadyMergeGhStub(binDir, adoptionStubOptions(rejection.options));
+
+    const jobPath = path.join(tmp, "job.md");
+    const resultPath = path.join(tmp, "result.json");
+    const reportPath = path.join(tmp, "apply-report.json");
+    fs.writeFileSync(jobPath, mergeJobMarkdown());
+    fs.writeFileSync(resultPath, `${JSON.stringify(adoptionMergeResultJson(), null, 2)}\n`);
+
+    const result = apply(jobPath, resultPath, reportPath, binDir, {
+      dryRun: false,
+      allowMerge: true,
+      mergeStatePath,
+      env: { CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0" },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "blocked");
+    assert.match(report.actions[0].reason, rejection.reason);
+    assert.equal(fs.existsSync(mergeStatePath), false);
+  });
+}
+
+test("apply-result rejects a changed effective fingerprint during newer-main adoption", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(
+    binDir,
+    adoptionStubOptions({ mergeBlobSha: "3".repeat(40) }),
+  );
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(adoptionMergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+    env: { CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0" },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /effective merge diff changed/);
+  assert.equal(fs.existsSync(mergeStatePath), false);
+});
+
+test("apply-result does not update the branch while waiting for an adopted test merge", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(
+    binDir,
+    adoptionStubOptions({ mergeBaseSha: REVIEWED_BASE_SHA }),
+  );
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(adoptionMergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    env: {
+      CLOWNFISH_APPLY_MERGE_BINDING_ATTEMPTS: "1",
+      CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /not based on the current main SHA/);
+  assert.equal(readCallLog(callLogPath).some((args) => args[1]?.endsWith("/update-branch")), false);
+});
+
+test("apply-result keeps the exact-merge check pending while final state validation catches main drift", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(
+    binDir,
+    adoptionStubOptions({ mainMovesAfterPendingCheck: true }),
+  );
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(adoptionMergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+    env: { CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0" },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /main changed during apply-time adoption validation/);
+  assert.equal(report.actions[0].exact_merge_revocation.status, "revoked");
+  assert.equal(fs.existsSync(mergeStatePath), false);
+});
+
+test("apply-result keeps the exact-merge check pending while final state validation catches comment drift", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(
+    binDir,
+    adoptionStubOptions({
+      pendingCheckIssueComments: [
+        {
+          user: { login: "openclaw-clownfish[bot]" },
+          author_association: "CONTRIBUTOR",
+          body: "Clownfish is on the reef for this PR. I tagged `clownfish:automerge`.",
+          created_at: "2026-06-11T05:08:03Z",
+          updated_at: "2026-06-11T05:08:03Z",
+        },
+      ],
+    }),
+  );
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(adoptionMergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+    env: { CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0" },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(
+    report.actions[0].reason,
+    "GitHub comments, reviews, metadata, or checks changed during exact-merge authorization",
+  );
+  assert.equal(report.actions[0].exact_merge_revocation.status, "revoked");
+  assert.equal(fs.existsSync(mergeStatePath), false);
+});
+
+test("apply-result rejects an adopted squash whose parent is not the authorized main", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(
+    binDir,
+    adoptionStubOptions({ squashParentSha: REVIEWED_BASE_SHA }),
+  );
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(adoptionMergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+    env: { CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0" },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(report.actions[0].reason, "actual squash commit is not based on the authorized main SHA");
+  assert.equal(fs.existsSync(mergeStatePath), true);
+});
+
 test("apply-result does not retry when GitHub reports merge ref movement", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");
@@ -1189,6 +1523,120 @@ test("apply-result verifies an already-merged external preflight result", () => 
   assert.equal(report.actions[0].status, "executed");
   assert.equal(report.actions[0].merge_commit_sha, SQUASH_COMMIT_SHA);
   assert.equal(report.actions[0].effective_diff_sha256, EFFECTIVE_DIFF_SHA256);
+});
+
+test("apply-result restores adopted-base proof when replaying an already-merged result", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(mergeStatePath, "merged");
+  writeReadyMergeGhStub(
+    binDir,
+    adoptionStubOptions({
+      adoptionDriftPath: "src/other/unrelated.ts",
+      currentMainExtraPath: "src/other/unrelated.ts",
+    }),
+  );
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  const proof = baseAdoptionProof();
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(adoptionMergeResultJson(), null, 2)}\n`);
+  fs.writeFileSync(
+    reportPath,
+    `${JSON.stringify(
+      {
+        checkpoint: "base_adoption_verified",
+        actions: [
+          {
+            target: "#60063",
+            status: "authorizing",
+            reviewed_head_sha: EXPECTED_HEAD_SHA,
+            merge_head_sha: EXPECTED_HEAD_SHA,
+            effective_diff_sha256: ADOPTION_EFFECTIVE_DIFF_SHA256,
+            verified_main_sha: CURRENT_MAIN_SHA,
+            base_adoption: proof,
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "executed");
+  assert.equal(report.actions[0].merge_commit_sha, SQUASH_COMMIT_SHA);
+  assert.equal(report.actions[0].effective_diff_sha256, ADOPTION_EFFECTIVE_DIFF_SHA256);
+  assert.equal(report.actions[0].verified_main_sha, CURRENT_MAIN_SHA);
+  assert.equal(report.actions[0].base_adoption.authorization_sha256, proof.authorization_sha256);
+});
+
+test("apply-result rejects a tampered adopted-base replay checkpoint", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(mergeStatePath, "merged");
+  writeReadyMergeGhStub(
+    binDir,
+    adoptionStubOptions({
+      adoptionDriftPath: "src/other/unrelated.ts",
+      currentMainExtraPath: "src/other/unrelated.ts",
+    }),
+  );
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  const proof = { ...baseAdoptionProof(), authorization_sha256: "0".repeat(64) };
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(adoptionMergeResultJson(), null, 2)}\n`);
+  fs.writeFileSync(
+    reportPath,
+    `${JSON.stringify(
+      {
+        checkpoint: "base_adoption_verified",
+        actions: [
+          {
+            target: "#60063",
+            status: "authorizing",
+            reviewed_head_sha: EXPECTED_HEAD_SHA,
+            merge_head_sha: EXPECTED_HEAD_SHA,
+            effective_diff_sha256: ADOPTION_EFFECTIVE_DIFF_SHA256,
+            verified_main_sha: CURRENT_MAIN_SHA,
+            base_adoption: proof,
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.equal(
+    report.actions[0].reason,
+    "actual squash commit is not based on the authorized main SHA",
+  );
 });
 
 test("apply-result rejects an already-merged replay with invalid review policy", () => {
@@ -1469,6 +1917,7 @@ function writeGhStub(
     ghPath,
     `#!/usr/bin/env node
 const fs = require("node:fs");
+const path = require("node:path");
 const args = process.argv.slice(2);
 if (process.env.GH_CALL_LOG) fs.appendFileSync(process.env.GH_CALL_LOG, JSON.stringify(args) + "\\n");
 function write(value) {
@@ -1591,20 +2040,46 @@ function writeReadyMergeGhStub(
     squashParentSha = CURRENT_MAIN_SHA,
     squashBlobSha = mergeBlobSha,
     exactMergeRule = true,
+    adoptionValidation = false,
+    adoptionDriftPath = "docs/main.md",
+    adoptionDriftCommitCount = 1,
+    adoptionLinear = true,
+    adoptionValidationFailure = false,
+    mainMovesAfterPendingCheck = false,
+    adoptionLabels = null,
+    pendingCheckIssueComments = null,
   },
 ) {
   const ghPath = path.join(binDir, "gh");
   const viewCountPath = path.join(binDir, "view-count");
+  const normalizeAdoptionComments = (comments) =>
+    comments.map((comment) => ({
+      author: { login: comment.user?.login ?? "reviewer" },
+      authorAssociation: comment.author_association ?? "NONE",
+      body: comment.body ?? "",
+      createdAt: comment.created_at ?? "2026-06-11T05:07:30Z",
+      updatedAt: comment.updated_at ?? comment.created_at ?? "2026-06-11T05:07:30Z",
+      isMinimized: false,
+      minimizedReason: null,
+      url: "https://github.test/comment",
+    }));
+  const adoptionIssueComments = normalizeAdoptionComments(issueComments);
+  const pendingCheckAdoptionIssueComments =
+    pendingCheckIssueComments == null
+      ? null
+      : normalizeAdoptionComments(pendingCheckIssueComments);
   fs.writeFileSync(
     ghPath,
     `#!/usr/bin/env node
 const fs = require("node:fs");
+const path = require("node:path");
 const args = process.argv.slice(2);
 const merged = Boolean(process.env.MERGE_STATE && fs.existsSync(process.env.MERGE_STATE));
 const mergeViews = ${JSON.stringify(mergeViews)};
 const viewCountPath = ${JSON.stringify(viewCountPath)};
 const checkStatePath = ${JSON.stringify(path.join(binDir, "exact-merge-check.json"))};
 const branchRefreshStatePath = ${JSON.stringify(path.join(binDir, "branch-refresh-state"))};
+const adoptionStatePath = ${JSON.stringify(path.join(binDir, "adoption-started"))};
 const externalBinding = ${JSON.stringify(externalBinding)};
 const reviewedBaseSha = ${JSON.stringify(reviewedBaseSha)};
 const branchRefreshed = () => fs.existsSync(branchRefreshStatePath);
@@ -1622,13 +2097,25 @@ function writeCheck(check) {
   checks.push(check);
   fs.writeFileSync(checkStatePath, JSON.stringify(checks));
 }
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
+if (${JSON.stringify(adoptionValidation)} && args[0] === "repo" && args[1] === "clone") {
+  const target = args[3];
+  fs.mkdirSync(path.join(target, ".git"), { recursive: true });
+  fs.mkdirSync(path.join(target, "src", "cli"), { recursive: true });
+  fs.writeFileSync(path.join(target, "package.json"), JSON.stringify({ packageManager: "pnpm@10.33.0" }));
+  fs.writeFileSync(path.join(target, "src", "cli", "effective.ts"), ${JSON.stringify(ADOPTION_MERGE_CONTENT)});
+  const driftPath = ${JSON.stringify(adoptionDriftPath)};
+  if (driftPath && driftPath !== "src/cli/effective.ts" && driftPath !== "package.json") {
+    fs.mkdirSync(path.dirname(path.join(target, driftPath)), { recursive: true });
+    fs.writeFileSync(path.join(target, driftPath), ${JSON.stringify(ADOPTION_DOC_CONTENT)});
+  }
+  fs.writeFileSync(adoptionStatePath, "started");
+} else if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
   write({
     number: 60063,
     state: merged ? "closed" : "open",
     title: "streaming fix",
     updated_at: branchRefreshed() ? "2026-06-11T05:07:31Z" : ${JSON.stringify(issueUpdatedAt)},
-    labels: ${JSON.stringify(labels)},
+    labels: fs.existsSync(adoptionStatePath) && ${JSON.stringify(adoptionLabels)} ? ${JSON.stringify(adoptionLabels)} : ${JSON.stringify(labels)},
     author_association: "NONE",
     pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/60063" }
   });
@@ -1638,7 +2125,7 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
     state: "open",
     draft: false,
     updated_at: branchRefreshed() ? "2026-06-11T05:07:31Z" : "2026-06-11T05:07:30Z",
-    labels: ${JSON.stringify(labels)},
+    labels: fs.existsSync(adoptionStatePath) && ${JSON.stringify(adoptionLabels)} ? ${JSON.stringify(adoptionLabels)} : ${JSON.stringify(labels)},
     base: { ref: "main", sha: externalBinding ? ${JSON.stringify(CURRENT_MAIN_SHA)} : "current-main" },
     head: {
       sha: branchRefreshed() ? ${JSON.stringify(refreshedHeadSha)} : ${JSON.stringify(headSha)},
@@ -1662,7 +2149,9 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
   write({
     object: {
       sha: externalBinding
-        ? (branchRefreshed() ? ${JSON.stringify(mainAfterRefreshSha)} : ${JSON.stringify(CURRENT_MAIN_SHA)})
+        ? (${JSON.stringify(mainMovesAfterPendingCheck)} && checkRuns().some((check) => check.status === "in_progress")
+            ? ${JSON.stringify(MOVED_MAIN_SHA)}
+            : (branchRefreshed() ? ${JSON.stringify(mainAfterRefreshSha)} : ${JSON.stringify(CURRENT_MAIN_SHA)}))
         : "current-main"
     }
   });
@@ -1780,8 +2269,8 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
   write({
     truncated: false,
     tree: [
-      { path: "src/cli/effective.ts", mode: "100644", type: "blob", sha: ${JSON.stringify(BASE_BLOB_SHA)} },
-      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: "7".repeat(40) }
+      { path: "src/cli/effective.ts", mode: "100644", type: "blob", sha: ${JSON.stringify(adoptionValidation ? ADOPTION_BASE_BLOB_SHA : BASE_BLOB_SHA)} },
+      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: ${JSON.stringify(adoptionValidation ? ADOPTION_DOC_BLOB_SHA : "7".repeat(40))} }
     ]
   });
 } else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/trees/${MERGE_TREE_SHA}?recursive=1") {
@@ -1789,7 +2278,7 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
     truncated: false,
     tree: [
       { path: "src/cli/effective.ts", mode: "100644", type: "blob", sha: ${JSON.stringify(mergeBlobSha)} },
-      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: "7".repeat(40) }
+      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: ${JSON.stringify(adoptionValidation ? ADOPTION_DOC_BLOB_SHA : "7".repeat(40))} }
     ]
   });
 } else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/trees/${REFRESHED_MERGE_TREE_SHA}?recursive=1") {
@@ -1797,7 +2286,7 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
     truncated: false,
     tree: [
       { path: "src/cli/effective.ts", mode: "100644", type: "blob", sha: ${JSON.stringify(refreshedMergeBlobSha)} },
-      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: "7".repeat(40) }
+      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: ${JSON.stringify(adoptionValidation ? ADOPTION_DOC_BLOB_SHA : "7".repeat(40))} }
     ]
   });
 } else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/trees/${SQUASH_TREE_SHA}?recursive=1") {
@@ -1805,7 +2294,7 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
     truncated: false,
     tree: [
       { path: "src/cli/effective.ts", mode: "100644", type: "blob", sha: ${JSON.stringify(squashBlobSha)} },
-      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: "7".repeat(40) }
+      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: ${JSON.stringify(adoptionValidation ? ADOPTION_DOC_BLOB_SHA : "7".repeat(40))} }
     ]
   });
 } else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/trees/${CURRENT_MAIN_TREE_SHA}?recursive=1") {
@@ -1813,16 +2302,28 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
     truncated: false,
     tree: [
       { path: "src/cli/effective.ts", mode: "100644", type: "blob", sha: ${JSON.stringify(currentMainBlobSha)} },
-      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: "7".repeat(40) }
+      { path: ${JSON.stringify(currentMainExtraPath)}, mode: "100644", type: "blob", sha: ${JSON.stringify(adoptionValidation ? ADOPTION_DOC_BLOB_SHA : "7".repeat(40))} }
     ]
   });
 } else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/trees/${REVIEWED_BASE_TREE_SHA}?recursive=1") {
   write({
     truncated: false,
-    tree: [{ path: "src/cli/effective.ts", mode: "100644", type: "blob", sha: ${JSON.stringify(BASE_BLOB_SHA)} }]
+    tree: [{ path: "src/cli/effective.ts", mode: "100644", type: "blob", sha: ${JSON.stringify(adoptionValidation ? ADOPTION_BASE_BLOB_SHA : BASE_BLOB_SHA)} }]
   });
 } else if (args[0] === "api" && args[1] === "graphql") {
-  write({ data: { repository: { pullRequest: { reviewThreads: { pageInfo: { hasNextPage: false }, nodes: [] } } } } });
+  const query = args.find((value) => value.startsWith("query=")) ?? "";
+  if (query.includes("comments(first: 100)")) {
+    const comments =
+      ${JSON.stringify(pendingCheckAdoptionIssueComments)} &&
+      checkRuns().some((check) => check.status === "in_progress")
+        ? ${JSON.stringify(pendingCheckAdoptionIssueComments)}
+        : ${JSON.stringify(adoptionIssueComments)};
+    write({ data: { repository: { pullRequest: { comments: { nodes: comments } } } } });
+  } else {
+    write({ data: { repository: { pullRequest: { reviewThreads: { pageInfo: { hasNextPage: false }, nodes: [] } } } } });
+  }
+} else if (args[0] === "api" && args[1].includes("/pulls/60063/comments")) {
+  write([]);
 } else if (args[0] === "pr" && args[1] === "view" && args[2] === "60063") {
   const count = fs.existsSync(viewCountPath) ? Number(fs.readFileSync(viewCountPath, "utf8")) : 0;
   fs.writeFileSync(viewCountPath, String(count + 1));
@@ -1857,6 +2358,103 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
 `,
   );
   fs.chmodSync(ghPath, 0o755);
+  if (adoptionValidation) {
+    writeAdoptionValidationStubs(binDir, {
+      driftPath: adoptionDriftPath,
+      driftCommitCount: adoptionDriftCommitCount,
+      linear: adoptionLinear,
+      validationFailure: adoptionValidationFailure,
+    });
+  }
+}
+
+function writeAdoptionValidationStubs(
+  binDir,
+  { driftPath, driftCommitCount, linear, validationFailure },
+) {
+  const gitPath = path.join(binDir, "git");
+  const statePath = path.join(binDir, "adoption-git-state");
+  const adoptedSyntheticSha = "cd".repeat(20);
+  const reviewedSyntheticSha = "bc".repeat(20);
+  const extraEntry = `100644 blob ${ADOPTION_DOC_BLOB_SHA}\t${driftPath}\0`;
+  fs.writeFileSync(
+    gitPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const statePath = ${JSON.stringify(statePath)};
+const state = fs.existsSync(statePath) ? fs.readFileSync(statePath, "utf8") : "head";
+const setState = (value) => fs.writeFileSync(statePath, value);
+const baseEntry = ${JSON.stringify(`100644 blob ${ADOPTION_BASE_BLOB_SHA}\tsrc/cli/effective.ts\0`)};
+const mergeEntry = ${JSON.stringify(`100644 blob ${ADOPTION_MERGE_BLOB_SHA}\tsrc/cli/effective.ts\0`)};
+const extraEntry = ${JSON.stringify(extraEntry)};
+if (args[0] === "status") process.exit(0);
+if (args[0] === "config" && args.includes("--list") && args.includes("--null")) process.exit(0);
+if (args[0] === "fetch") process.exit(0);
+if (args[0] === "checkout") {
+  const target = args.at(-1);
+  setState(target === ${JSON.stringify(adoptedSyntheticSha)} ? "adopted" : target === ${JSON.stringify(reviewedSyntheticSha)} ? "reviewed" : "head");
+  process.exit(0);
+}
+if (args[0] === "rev-parse") {
+  if (args[1] === "origin/main") console.log(${JSON.stringify(CURRENT_MAIN_SHA)});
+  else if (args[1] === "--is-shallow-repository") console.log("false");
+  else if (args[1] === "HEAD^{tree}") console.log(${JSON.stringify(MERGE_TREE_SHA)});
+  else if (args[1] === "HEAD^") console.log(${JSON.stringify(CURRENT_MAIN_SHA)});
+  else console.log(state === "adopted" ? ${JSON.stringify(adoptedSyntheticSha)} : state === "reviewed" ? ${JSON.stringify(reviewedSyntheticSha)} : ${JSON.stringify(EXPECTED_HEAD_SHA)});
+  process.exit(0);
+}
+if (args[0] === "merge-base" && args[1] === "--is-ancestor") process.exit(${linear ? 0 : 1});
+if (args[0] === "merge-base") {
+  console.log(${JSON.stringify(REVIEWED_BASE_SHA)});
+  process.exit(0);
+}
+if (args[0] === "rev-list" && args[1] === "--count") {
+  console.log(${JSON.stringify(driftCommitCount)});
+  process.exit(0);
+}
+if (args[0] === "merge-tree" && args[1] === "--write-tree") {
+  console.log(args[2] === ${JSON.stringify(REVIEWED_BASE_SHA)} ? ${JSON.stringify(REVIEWED_MERGE_TREE_SHA)} : ${JSON.stringify(MERGE_TREE_SHA)});
+  process.exit(0);
+}
+if (args[0] === "commit-tree") {
+  console.log(args[1] === ${JSON.stringify(REVIEWED_MERGE_TREE_SHA)} ? ${JSON.stringify(reviewedSyntheticSha)} : ${JSON.stringify(adoptedSyntheticSha)});
+  process.exit(0);
+}
+if (args[0] === "ls-tree") {
+  const treeish = args.at(-1);
+  if (treeish === ${JSON.stringify(REVIEWED_BASE_SHA)}) process.stdout.write(baseEntry);
+  else if (treeish === ${JSON.stringify(REVIEWED_MERGE_TREE_SHA)}) process.stdout.write(mergeEntry);
+  else if (treeish === ${JSON.stringify(CURRENT_MAIN_SHA)}) process.stdout.write(baseEntry + extraEntry);
+  else if (treeish === ${JSON.stringify(MERGE_TREE_SHA)}) process.stdout.write(mergeEntry + extraEntry);
+  process.exit(0);
+}
+if (args[0] === "diff" && args[1] === "--name-only") {
+  if (args.includes("--diff-filter=U")) process.exit(0);
+  const separator = args.includes("-z") ? "\\0" : "\\n";
+  const range = args.find((value) => /^[0-9a-f]{40}\\.\\.[0-9a-f]{40}$/i.test(value));
+  const files = range ? [${JSON.stringify(driftPath)}] : ["src/cli/effective.ts"];
+  process.stdout.write(files.join(separator) + separator);
+  process.exit(0);
+}
+if (args[0] === "diff") process.exit(0);
+process.stderr.write("unexpected git command: " + args.join(" ") + "\\n");
+process.exit(1);
+`,
+  );
+  fs.chmodSync(gitPath, 0o755);
+  fs.writeFileSync(path.join(binDir, "corepack"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  fs.writeFileSync(
+    path.join(binDir, "pnpm"),
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (${JSON.stringify(validationFailure)} && args[0] === "check:changed") {
+  process.stderr.write("fixture adopted-main validation failure\\n");
+  process.exit(1);
+}
+`,
+    { mode: 0o755 },
+  );
 }
 
 function jobMarkdown({ allowUnmergedFixClose }) {
@@ -1952,7 +2550,12 @@ function resultJsonWithHydratedCandidate() {
   };
 }
 
-function mergeResultJson({ externalBinding = false, reviewedBaseSha = CURRENT_MAIN_SHA } = {}) {
+function mergeResultJson({
+  externalBinding = false,
+  reviewedBaseSha = CURRENT_MAIN_SHA,
+  effectiveDiffSha256 = EFFECTIVE_DIFF_SHA256,
+  baseAdoptionManifest = null,
+} = {}) {
   return {
     status: "planned",
     repo: "openclaw/openclaw",
@@ -1967,7 +2570,7 @@ function mergeResultJson({ externalBinding = false, reviewedBaseSha = CURRENT_MA
         status: "planned",
         classification: "fix_pr",
         idempotency_key: externalBinding
-          ? `external-merge-preflight:openclaw/openclaw#60063:${EXPECTED_HEAD_SHA}:${EFFECTIVE_DIFF_SHA256}`
+          ? `external-merge-preflight:openclaw/openclaw#60063:${EXPECTED_HEAD_SHA}:${effectiveDiffSha256}`
           : "openclaw/openclaw#60063:merge:stale-test",
         expected_head_sha: EXPECTED_HEAD_SHA,
       },
@@ -1979,7 +2582,7 @@ function mergeResultJson({ externalBinding = false, reviewedBaseSha = CURRENT_MA
           ? {
               reviewed_base_sha: reviewedBaseSha,
               reviewed_head_sha: EXPECTED_HEAD_SHA,
-              effective_diff_sha256: EFFECTIVE_DIFF_SHA256,
+              effective_diff_sha256: effectiveDiffSha256,
               effective_diff_files: 1,
             }
           : {}),
@@ -1996,7 +2599,122 @@ function mergeResultJson({ externalBinding = false, reviewedBaseSha = CURRENT_MA
           findings_addressed: true,
           evidence: ["Codex /review returned clean"],
         },
+        base_adoption_manifest: baseAdoptionManifest,
       },
     ],
   };
+}
+
+function baseAdoptionManifest() {
+  const reviewedPathBlobs = [
+    {
+      path: "src/cli/effective.ts",
+      reviewed_base_entry: `100644:blob:${ADOPTION_BASE_BLOB_SHA}`,
+      reviewed_result_entry: `100644:blob:${ADOPTION_MERGE_BLOB_SHA}`,
+    },
+  ];
+  return {
+    schema_version: 1,
+    policy: "bounded-fast-forward-v1",
+    reviewed_base_sha: REVIEWED_BASE_SHA,
+    reviewed_head_sha: EXPECTED_HEAD_SHA,
+    reviewed_synthetic_merge_sha: "bc".repeat(20),
+    reviewed_merge_tree_sha: REVIEWED_MERGE_TREE_SHA,
+    effective_diff_sha256: ADOPTION_EFFECTIVE_DIFF_SHA256,
+    effective_diff_files: 1,
+    effective_paths: ["src/cli/effective.ts"],
+    affected_areas: ["src/cli"],
+    validation_gate: "pnpm check:changed",
+    reviewed_paths: blobSnapshot(reviewedPathBlobs),
+    validation_controls: blobSnapshot([]),
+    review_context: blobSnapshot(reviewedPathBlobs),
+  };
+}
+
+function baseAdoptionProof() {
+  const manifest = baseAdoptionManifest();
+  const authorization = {
+    policy: manifest.policy,
+    reviewed_base_sha: REVIEWED_BASE_SHA,
+    adopted_base_sha: CURRENT_MAIN_SHA,
+    reviewed_head_sha: EXPECTED_HEAD_SHA,
+    test_merge_sha: TEST_MERGE_SHA,
+    test_merge_tree_sha: MERGE_TREE_SHA,
+    effective_diff_files: 1,
+    effective_diff_sha256: ADOPTION_EFFECTIVE_DIFF_SHA256,
+    drift_commit_count: 1,
+    drift_file_count: 1,
+    drift_paths_sha256: createHash("sha256")
+      .update("src/other/unrelated.ts")
+      .digest("hex"),
+    reviewed_paths_sha256: manifest.reviewed_paths.sha256,
+    validation_controls_sha256: manifest.validation_controls.sha256,
+    review_context_sha256: manifest.review_context.sha256,
+    validation_commands: ["pnpm check:changed"],
+    github_state_sha256: "9".repeat(64),
+    issue_updated_at: "2026-06-11T05:07:30Z",
+    pull_updated_at: "2026-06-11T05:07:30Z",
+  };
+  return {
+    schema_version: 1,
+    status: "adopted",
+    reason: "validated newer fast-forward main without another Codex review",
+    ...authorization,
+    authorization_sha256: createHash("sha256")
+      .update(JSON.stringify(authorization))
+      .digest("hex"),
+    synthetic_merge_sha: "cd".repeat(20),
+    drift_proof: { status: "reused" },
+    context_proof: {
+      reviewed_paths_unchanged: true,
+      validation_controls_unchanged: true,
+      review_context_unchanged: true,
+    },
+    validated_at: "2026-06-11T05:08:00Z",
+  };
+}
+
+function blobSnapshot(blobs) {
+  return {
+    complete: true,
+    files: blobs.length,
+    sha256: createHash("sha256")
+      .update(`${blobs.map((entry) => JSON.stringify(entry)).join("\n")}\n`)
+      .digest("hex"),
+    blobs,
+  };
+}
+
+function adoptionMergeResultJson() {
+  return mergeResultJson({
+    externalBinding: true,
+    reviewedBaseSha: REVIEWED_BASE_SHA,
+    effectiveDiffSha256: ADOPTION_EFFECTIVE_DIFF_SHA256,
+    baseAdoptionManifest: baseAdoptionManifest(),
+  });
+}
+
+function adoptionStubOptions(overrides = {}) {
+  return {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    reviewedBaseSha: REVIEWED_BASE_SHA,
+    mergeBaseSha: CURRENT_MAIN_SHA,
+    mergeBlobSha: ADOPTION_MERGE_BLOB_SHA,
+    currentMainBlobSha: ADOPTION_BASE_BLOB_SHA,
+    currentMainExtraPath: "docs/main.md",
+    squashParentSha: CURRENT_MAIN_SHA,
+    squashBlobSha: ADOPTION_MERGE_BLOB_SHA,
+    adoptionValidation: true,
+    ...overrides,
+  };
+}
+
+function readCallLog(callLogPath) {
+  return fs
+    .readFileSync(callLogPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
 }

--- a/test/base-drift-validation.test.mjs
+++ b/test/base-drift-validation.test.mjs
@@ -22,15 +22,15 @@ function reusableDrift(overrides = {}) {
     validatedBaseIsAncestorOfCurrentBase: true,
     driftCommitCount: 2,
     branchFiles: ["src/reply/dedupe.ts", "src/reply/dedupe.test.ts"],
-    baseDriftFiles: ["docs/gateway.md"],
+    baseDriftFiles: ["src/infra/cost.ts"],
     branchAreas: ["src/reply"],
-    baseDriftAreas: ["docs"],
+    baseDriftAreas: ["src/infra"],
     evidenceComplete: true,
     ...overrides,
   });
 }
 
-test("accepts bounded irrelevant fast-forward base drift", () => {
+test("accepts bounded disjoint runtime drift with exact head equality", () => {
   const decision = reusableDrift();
 
   assert.equal(decision.status, "reused");
@@ -44,9 +44,9 @@ test("accepts bounded irrelevant fast-forward base drift", () => {
     base_fast_forward: true,
     drift_commit_count: 2,
     branch_changed_files: ["src/reply/dedupe.test.ts", "src/reply/dedupe.ts"],
-    base_drift_files: ["docs/gateway.md"],
+    base_drift_files: ["src/infra/cost.ts"],
     branch_areas: ["src/reply"],
-    base_drift_areas: ["docs"],
+    base_drift_areas: ["src/infra"],
     validation_control_files_changed: [],
     evidence_complete: true,
     bounds: {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -196,6 +196,26 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
   assert.equal(result.merge_preflight[0].reviewed_head_sha, fixture.headSha);
   assert.equal(result.merge_preflight[0].effective_diff_sha256, fixture.effectiveDiffSha256);
   assert.equal(result.merge_preflight[0].effective_diff_files, 1);
+  assert.deepEqual(
+    {
+      schema_version: result.merge_preflight[0].base_adoption_manifest.schema_version,
+      policy: result.merge_preflight[0].base_adoption_manifest.policy,
+      reviewed_base_sha: result.merge_preflight[0].base_adoption_manifest.reviewed_base_sha,
+      reviewed_head_sha: result.merge_preflight[0].base_adoption_manifest.reviewed_head_sha,
+      effective_paths: result.merge_preflight[0].base_adoption_manifest.effective_paths,
+      validation_gate: result.merge_preflight[0].base_adoption_manifest.validation_gate,
+    },
+    {
+      schema_version: 1,
+      policy: "bounded-fast-forward-v1",
+      reviewed_base_sha: fixture.baseSha,
+      reviewed_head_sha: fixture.headSha,
+      effective_paths: ["src/effective.ts"],
+      validation_gate: "pnpm check:changed",
+    },
+  );
+  assert.equal(result.merge_preflight[0].base_adoption_manifest.reviewed_paths.complete, true);
+  assert.equal(result.merge_preflight[0].base_adoption_manifest.review_context.complete, true);
   assert.match(result.actions[0].evidence.join("\n"), /synthetic squash-result commit/);
 
   const report = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "preflight-report.json"), "utf8"));
@@ -560,6 +580,75 @@ test("external merge preflight reuses review across bounded disjoint main drift"
     encoding: "utf8",
   });
   assert.equal(reviewed.status, 0, reviewed.stderr || reviewed.stdout);
+});
+
+test("external merge preflight preserves the last clean review when moving main exhausts revalidations", () => {
+  const firstAdvancedMain = "9".repeat(40);
+  const stillMovingMain = "8".repeat(40);
+  const fixture = makeFixture({
+    refreshedMainShas: [firstAdvancedMain, stillMovingMain],
+  });
+  const { report, result } = runPreflightFixture(fixture, {
+    CLOWNFISH_EXTERNAL_PREFLIGHT_MAX_BASE_REVALIDATIONS: "1",
+  });
+
+  assert.equal(report.status, "passed", report.reason);
+  assert.equal(report.reviewed_base_sha, firstAdvancedMain);
+  assert.equal(report.validated_main_sha, firstAdvancedMain);
+  assert.equal(report.current_main_sha, stillMovingMain);
+  assert.equal(report.apply_time_adoption_required, true);
+  assert.deepEqual(report.pending_apply_adoption, {
+    status: "required",
+    from_base_sha: firstAdvancedMain,
+    observed_main_sha: stillMovingMain,
+    drift_commit_count: 7,
+    drift_file_count: 1,
+    drift_paths_sha256: createHash("sha256").update("docs/main-drift.md").digest("hex"),
+    exhausted_revalidations: 1,
+  });
+  assert.equal(result.merge_preflight[0].reviewed_base_sha, firstAdvancedMain);
+  assert.equal(
+    result.merge_preflight[0].base_adoption_manifest.reviewed_base_sha,
+    firstAdvancedMain,
+  );
+  assert.match(result.actions[0].evidence.join("\n"), /apply must adopt from validated base/);
+  assert.equal(Number(fs.readFileSync(fixture.codexCountPath, "utf8")), 1);
+  assert.equal(
+    fs.readFileSync(fixture.pnpmCommandsPath, "utf8").match(/check:changed/g)?.length,
+    2,
+  );
+
+  const reviewed = spawnSync(process.execPath, ["scripts/review-results.mjs", fixture.runDir], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  assert.equal(reviewed.status, 0, reviewed.stderr || reviewed.stdout);
+});
+
+test("external merge preflight hands bounded disjoint runtime drift to no-model adoption", () => {
+  const fixture = makeFixture({
+    refreshedMainSha: "9".repeat(40),
+    refreshedMainFiles: ["src/other/unrelated.ts"],
+  });
+  const { report, result } = runPreflightFixture(fixture, {
+    CLOWNFISH_EXTERNAL_PREFLIGHT_MAX_BASE_REVALIDATIONS: "0",
+  });
+
+  assert.equal(report.status, "passed", report.reason);
+  assert.equal(report.apply_time_adoption_required, true);
+  assert.deepEqual(report.pending_apply_adoption, {
+    status: "required",
+    from_base_sha: fixture.baseSha,
+    observed_main_sha: "9".repeat(40),
+    drift_commit_count: 7,
+    drift_file_count: 1,
+    drift_paths_sha256: createHash("sha256")
+      .update("src/other/unrelated.ts")
+      .digest("hex"),
+    exhausted_revalidations: 0,
+  });
+  assert.equal(result.actions.length, 1);
+  assert.equal(result.merge_preflight[0].base_adoption_manifest.reviewed_base_sha, fixture.baseSha);
 });
 
 test("external merge preflight blocks main drift that overlaps the reviewed diff", () => {
@@ -2943,6 +3032,21 @@ test("external merge preflight blocks potentially truncated issue comment histor
   assert.match(report.reason, /comment history may be truncated/);
 });
 
+test("external merge preflight blocks potentially truncated inline review comment history", () => {
+  const fixture = makeFixture({
+    reviewComments: Array.from({ length: 100 }, (_, index) => ({
+      user: { login: `reviewer-${index}` },
+      body: "resolved inline review context",
+      path: "src/effective.ts",
+      line: 1,
+    })),
+  });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /inline review comments; comment history may be truncated/);
+});
+
 test("external merge preflight blocks non-keyword human objections", () => {
   const fixture = makeFixture({
     issueComments: [
@@ -3266,6 +3370,7 @@ function makeFixture({
   rehydratedState = null,
   currentMainSha = null,
   refreshedMainSha = null,
+  refreshedMainShas = null,
   refreshedMainCommitCount = 7,
   refreshedMainFiles = ["docs/main-drift.md"],
   validationFailure = null,
@@ -3453,6 +3558,10 @@ const head = ${JSON.stringify(headSha)};
 const base = ${JSON.stringify(baseSha)};
 const currentMain = ${JSON.stringify(currentMainSha)} || base;
 const refreshedMain = ${JSON.stringify(refreshedMainSha)} || currentMain;
+const mainSequence = [
+  currentMain,
+  ...(${JSON.stringify(refreshedMainShas)} || [refreshedMain]),
+];
 const refreshedMainCommitCount = ${JSON.stringify(refreshedMainCommitCount)};
 const refreshedMainFiles = ${JSON.stringify(refreshedMainFiles)};
 const mergeTree = ${JSON.stringify(mergeTreeSha)};
@@ -3460,9 +3569,14 @@ const synthetic = ${JSON.stringify(syntheticMergeSha)};
 const baseBlob = ${JSON.stringify(baseBlobSha)};
 const mergeBlob = ${JSON.stringify(mergeBlobSha)};
 const statePath = path.join(${JSON.stringify(root)}, "git-state");
-const refreshedMainPath = path.join(${JSON.stringify(root)}, "main-refreshed");
 const mainFetchCountPath = path.join(${JSON.stringify(root)}, "main-fetch-count");
 const commandLog = ${JSON.stringify(gitCommandsPath)};
+function mainFetchCount() {
+  return fs.existsSync(mainFetchCountPath) ? Number(fs.readFileSync(mainFetchCountPath, "utf8")) : 0;
+}
+function currentMainRef() {
+  return mainSequence[Math.min(Math.max(mainFetchCount() - 1, 0), mainSequence.length - 1)];
+}
 fs.appendFileSync(commandLog, args.join(" ") + "\\n");
 if (
   process.env.GIT_ALLOW_PROTOCOL !== "https:ssh" ||
@@ -3485,19 +3599,16 @@ if (args[0] === "config" && args.includes("--local") && args.includes("--list") 
   process.exit(0);
 }
 if (args[0] === "rev-parse") {
-  if (args[1] === "origin/main") {
-    console.log(fs.existsSync(refreshedMainPath) ? refreshedMain : currentMain);
-  }
-  else if (args[1] === "HEAD^") console.log(fs.existsSync(refreshedMainPath) ? refreshedMain : currentMain);
+  if (args[1] === "origin/main") console.log(currentMainRef());
+  else if (args[1] === "HEAD^") console.log(currentMainRef());
   else if (args[1] === "HEAD^{tree}") console.log(mergeTree);
   else if (args[1] === "--is-shallow-repository") console.log("false");
   else console.log(state === "synthetic" ? synthetic : state === "main" ? currentMain : head);
   process.exit(0);
 }
 if (args[0] === "fetch" && args.some((arg) => arg === "main:refs/remotes/origin/main")) {
-  const count = fs.existsSync(mainFetchCountPath) ? Number(fs.readFileSync(mainFetchCountPath, "utf8")) : 0;
+  const count = mainFetchCount();
   fs.writeFileSync(mainFetchCountPath, String(count + 1));
-  if (count >= 1) fs.writeFileSync(refreshedMainPath, "refreshed");
   process.exit(0);
 }
 if (args[0] === "merge-base") {


### PR DESCRIPTION
## Summary

- preserve the last fully validated exact-head result when busy `main` exhausts preflight revalidation
- adopt a bounded fast-forward base only when paths/subsystems and validation controls are disjoint, the effective tree delta is unchanged, and `pnpm check:changed` passes again
- keep the exact-merge check pending through final state verification, bind the final squash parent/tree, and recover the adopted-base proof after a crash
- fail closed on truncated inline review history

This removes the starvation seen in https://github.com/openclaw/openclaw/pull/101062 without updating the contributor branch or relaxing exact-head review.

## Validation

- `node --test test/preflight-external-pr-merge.test.mjs` (129/129)
- `node --test test/apply-result.test.mjs` (61/61 including focused tamper replay test)
- `node --test test/base-drift-validation.test.mjs test/review-results.test.mjs` (58/58)
- `npm run validate` (6,656 jobs)
- `node --check scripts/preflight-external-pr-merge.mjs`
- `node --check scripts/apply-result.mjs`
- `git diff --check`