### PR TITLE
fix(schema): remove unsupported response constraint

### DIFF
--- a/schemas/codex-result.schema.json
+++ b/schemas/codex-result.schema.json
@@ -343,7 +343,6 @@
               "effective_paths": {
                 "type": "array",
                 "minItems": 1,
-                "uniqueItems": true,
                 "items": {
                   "type": "string",
                   "minLength": 1
@@ -352,7 +351,6 @@
               "affected_areas": {
                 "type": "array",
                 "minItems": 1,
-                "uniqueItems": true,
                 "items": {
                   "type": "string",
                   "minLength": 1

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -1310,7 +1310,9 @@ function assertBaseAdoptionManifest(manifest, { expectedHeadSha, adoptedBaseSha 
     manifest.effective_diff_files < 1 ||
     !Array.isArray(manifest.effective_paths) ||
     manifest.effective_paths.length !== manifest.effective_diff_files ||
+    !hasUniqueNonEmptyStrings(manifest.effective_paths) ||
     !Array.isArray(manifest.affected_areas) ||
+    !hasUniqueNonEmptyStrings(manifest.affected_areas) ||
     manifest.validation_gate !== "pnpm check:changed"
   ) {
     throw new Error("base adoption manifest effective diff evidence is incomplete");
@@ -1324,11 +1326,21 @@ function assertBaseAdoptionManifest(manifest, { expectedHeadSha, adoptedBaseSha 
       snapshot.files < 0 ||
       !/^[0-9a-f]{64}$/i.test(String(snapshot.sha256 ?? "")) ||
       !Array.isArray(snapshot.blobs) ||
-      snapshot.blobs.length !== snapshot.files
+      snapshot.blobs.length !== snapshot.files ||
+      snapshot.blobs.length > MAX_ADOPTION_MANIFEST_BLOBS ||
+      !hasUniqueNonEmptyStrings(snapshot.blobs.map((entry) => entry?.path), { allowEmpty: true })
     ) {
       throw new Error(`base adoption manifest ${key} snapshot is incomplete`);
     }
   }
+}
+
+function hasUniqueNonEmptyStrings(values, { allowEmpty = false } = {}) {
+  return (
+    (allowEmpty || values.length > 0) &&
+    values.every((value) => typeof value === "string" && value.length > 0) &&
+    new Set(values).size === values.length
+  );
 }
 
 function captureFreshAdoptionGithubState({

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -1037,6 +1037,35 @@ test("apply-result adopts newer fast-forward main without updating the reviewed 
   assert.match(report.actions[0].exact_merge_check.external_id, /:adopt:[0-9a-f]{64}$/);
 });
 
+test("apply-result rejects duplicate base adoption manifest evidence", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(binDir, adoptionStubOptions());
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  const mergeResult = adoptionMergeResultJson();
+  mergeResult.merge_preflight[0].base_adoption_manifest.affected_areas.push("src/cli");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResult, null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+    env: { CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0" },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /base adoption manifest effective diff evidence is incomplete/);
+  assert.equal(fs.existsSync(mergeStatePath), false);
+});
+
 for (const rejection of [
   {
     name: "reviewed path overlap",

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -16,6 +16,15 @@ test("codex result schema requires every object property for strict response for
   assert.deepEqual(failures, []);
 });
 
+test("codex result schema avoids unsupported structured output keywords", () => {
+  const schema = JSON.parse(fs.readFileSync(path.join(repoRoot, "schemas/codex-result.schema.json"), "utf8"));
+  const failures = [];
+
+  visitUnsupportedKeywords(schema, "$", failures);
+
+  assert.deepEqual(failures, []);
+});
+
 test("strict schema guard covers definitions, nullable objects, and exact required keys", () => {
   const failures = [];
 
@@ -88,6 +97,25 @@ function visitStrictObjects(schema, schemaPath, failures) {
       value.forEach((nestedSchema, index) => {
         visitStrictObjects(nestedSchema, `${schemaPath}.${key}[${index}]`, failures);
       });
+    }
+  }
+}
+
+function visitUnsupportedKeywords(schema, schemaPath, failures) {
+  if (!schema || typeof schema !== "object") return;
+
+  if (Object.hasOwn(schema, "uniqueItems")) {
+    failures.push(`${schemaPath}: uniqueItems is not supported by OpenAI Structured Outputs`);
+  }
+
+  for (const [key, value] of Object.entries(schema)) {
+    if (!value || typeof value !== "object") continue;
+    if (Array.isArray(value)) {
+      value.forEach((nestedSchema, index) => {
+        visitUnsupportedKeywords(nestedSchema, `${schemaPath}.${key}[${index}]`, failures);
+      });
+    } else {
+      visitUnsupportedKeywords(value, `${schemaPath}.${key}`, failures);
     }
   }
 }


### PR DESCRIPTION
## Summary

- remove `uniqueItems` from the Codex strict response schema after the live API rejected it
- preserve uniqueness, non-empty, and snapshot-size enforcement in the adoption runtime validator
- guard the response schema against reintroducing unsupported `uniqueItems` and cover duplicate adoption evidence

## Validation

- `node --test test/review-results.test.mjs` (51 passed)
- `node --test --test-name-pattern="base adoption|adopt" test/preflight-external-pr-merge.test.mjs` (1 passed)
- `node --test --test-name-pattern="base adoption|adopt" test/apply-result.test.mjs` (15 passed)
- duplicate adoption manifest regression (1 passed)
- `npm run validate` (6,656 jobs)
- `git diff --check`

## Live failure

Unblocks the `#101062` retry that failed before model execution with `Invalid schema for response_format ... uniqueItems is not permitted`.
