### PR TITLE
fix(auth): use App token for exact checks

### DIFF
--- a/.github/workflows/cluster-worker.yml
+++ b/.github/workflows/cluster-worker.yml
@@ -587,6 +587,8 @@ jobs:
       - name: Run external merge preflights
         if: ${{ env.CLOWNFISH_ALLOW_EXECUTE == '1' }}
         timeout-minutes: 45
+        env:
+          CLOWNFISH_CHECKS_GH_TOKEN: ${{ steps.app_token.outputs.token || steps.workflow_app_token.outputs.token }}
         run: |
           npm run run-external-merge-preflights -- "${{ needs.prepare.outputs.job }}" \
             --latest \
@@ -595,6 +597,8 @@ jobs:
 
       - name: Apply safe closure actions
         if: ${{ env.CLOWNFISH_ALLOW_EXECUTE == '1' }}
+        env:
+          CLOWNFISH_CHECKS_GH_TOKEN: ${{ steps.app_token.outputs.token || steps.workflow_app_token.outputs.token }}
         run: npm run apply-result -- "${{ needs.prepare.outputs.job }}" --latest
 
       - name: Post-flight finalize fix PRs
@@ -603,6 +607,8 @@ jobs:
 
       - name: Apply post-flight closeouts
         if: ${{ env.CLOWNFISH_ALLOW_EXECUTE == '1' }}
+        env:
+          CLOWNFISH_CHECKS_GH_TOKEN: ${{ steps.app_token.outputs.token || steps.workflow_app_token.outputs.token }}
         run: npm run apply-result -- "${{ needs.prepare.outputs.job }}" --latest
 
       - name: Tag Clownfish targets

--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -608,6 +608,20 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       live_updated_at: live.updated_at,
     };
   }
+  if (
+    externalMergeAction &&
+    !dryRun &&
+    process.env.CLOWNFISH_ALLOW_MERGE === "1" &&
+    !process.env.CLOWNFISH_CHECKS_GH_TOKEN
+  ) {
+    return {
+      ...base,
+      status: "blocked",
+      reason: "external merge requires CLOWNFISH_CHECKS_GH_TOKEN before branch refresh",
+      live_state: live.state,
+      live_updated_at: live.updated_at,
+    };
+  }
   const effectiveDiffBinding = verifyExternalMergeBinding({
     result,
     action,
@@ -2163,7 +2177,7 @@ function prepareExactMergeCheck({
       },
     });
     try {
-      pending = ghJson([
+      pending = exactMergeGhJson([
         "api",
         `repos/${repo}/check-runs`,
         "--method",
@@ -2241,7 +2255,7 @@ function authorizeExactMergeCheck({
   });
   let authorized;
   try {
-    authorized = ghJson([
+    authorized = exactMergeGhJson([
       "api",
       `repos/${repo}/check-runs/${exactMergeCheck.id}`,
       "--method",
@@ -2367,7 +2381,7 @@ function revokeExactMergeCheck({ repo, exactMergeCheck }) {
       summary: "The authorization was not consumed by a verified merge.",
     },
   });
-  const revoked = ghJson([
+  const revoked = exactMergeGhJson([
     "api",
     `repos/${repo}/check-runs/${exactMergeCheck.id}`,
     "--method",
@@ -2977,17 +2991,26 @@ function ghJson(ghArgs) {
   return JSON.parse(stripAnsi(text) || "null");
 }
 
+function exactMergeGhJson(ghArgs) {
+  const token = process.env.CLOWNFISH_CHECKS_GH_TOKEN;
+  if (!token) {
+    throw new Error("exact-merge check mutation requires CLOWNFISH_CHECKS_GH_TOKEN");
+  }
+  const text = ghWithRetry(ghArgs, 6, githubCliEnv({ ghToken: token }));
+  return JSON.parse(stripAnsi(text) || "null");
+}
+
 function ghPaged(apiPath) {
   const pages = ghJson(["api", apiPath, "--paginate", "--slurp"]);
   if (!Array.isArray(pages)) return [];
   return pages.flatMap((page) => (Array.isArray(page) ? page : []));
 }
 
-function ghWithRetry(ghArgs, attempts = 6) {
+function ghWithRetry(ghArgs, attempts = 6, env = githubCliEnv()) {
   let lastError;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     try {
-      return ghOnce(ghArgs);
+      return ghOnce(ghArgs, env);
     } catch (error) {
       lastError = error;
       if (!shouldRetryGh(error) || attempt === attempts - 1) throw error;
@@ -2998,19 +3021,20 @@ function ghWithRetry(ghArgs, attempts = 6) {
   throw lastError;
 }
 
-function ghOnce(ghArgs) {
+function ghOnce(ghArgs, env = githubCliEnv()) {
   return execFileSync("gh", ghArgs, {
     cwd: repoRoot(),
     encoding: "utf8",
-    env: githubCliEnv(),
+    env,
     maxBuffer: 64 * 1024 * 1024,
     stdio: ["ignore", "pipe", "pipe"],
   }).trim();
 }
 
-function githubCliEnv() {
+function githubCliEnv({ ghToken } = {}) {
   const env = { ...process.env, NO_COLOR: "1", CLICOLOR: "0" };
-  if (!env.GH_TOKEN && env.CLOWNFISH_GH_TOKEN) env.GH_TOKEN = env.CLOWNFISH_GH_TOKEN;
+  if (ghToken) env.GH_TOKEN = ghToken;
+  else if (!env.GH_TOKEN && env.CLOWNFISH_GH_TOKEN) env.GH_TOKEN = env.CLOWNFISH_GH_TOKEN;
   delete env.FORCE_COLOR;
   return env;
 }

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -3194,6 +3194,7 @@ function validationEnv() {
     "OPENCLAW_GH_TOKEN",
     "CLOWNFISH_GH_TOKEN",
     "CLOWNFISH_READ_GH_TOKEN",
+    "CLOWNFISH_CHECKS_GH_TOKEN",
     "CLOWNFISH_CODEX_GH_TOKEN",
   ]) {
     delete env[key];
@@ -3209,6 +3210,7 @@ function codexEnv() {
     "OPENCLAW_GH_TOKEN",
     "CLOWNFISH_GH_TOKEN",
     "CLOWNFISH_READ_GH_TOKEN",
+    "CLOWNFISH_CHECKS_GH_TOKEN",
     "CLOWNFISH_CODEX_GH_TOKEN",
   ]) {
     delete env[key];

--- a/test/app-token-auth.test.mjs
+++ b/test/app-token-auth.test.mjs
@@ -416,6 +416,19 @@ test("cluster-worker snapshots write gates before the queued worker starts", () 
   assert.match(workflow, /CLOWNFISH_ALLOW_MERGE: \$\{\{ needs\.prepare\.outputs\.allow_merge \}\}/);
 });
 
+test("cluster-worker exports a dedicated App token for exact checks", () => {
+  const workflow = fs.readFileSync(path.join(repoRoot, ".github/workflows/cluster-worker.yml"), "utf8");
+
+  assert.equal(
+    (
+      workflow.match(
+        /CLOWNFISH_CHECKS_GH_TOKEN: \$\{\{ steps\.app_token\.outputs\.token \|\| steps\.workflow_app_token\.outputs\.token \}\}/g,
+      ) ?? []
+    ).length,
+    3,
+  );
+});
+
 function makeFixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-app-auth-"));
   const inbox = path.join(root, "inbox");

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -654,6 +654,101 @@ for (const mergeStateStatus of ["BLOCKED", "BEHIND"]) {
   });
 }
 
+test("apply-result uses the dedicated App token only for exact-check mutations", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const authLogPath = path.join(tmp, "gh-auth.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(authLogPath, "");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+    env: {
+      GH_TOKEN: "write-token",
+      CLOWNFISH_CHECKS_GH_TOKEN: "checks-app-token",
+      GH_AUTH_LOG: authLogPath,
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "executed");
+  const calls = fs
+    .readFileSync(authLogPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  const checkMutations = calls.filter(
+    ({ args }) =>
+      args[0] === "api" &&
+      args[1].startsWith("repos/openclaw/openclaw/check-runs") &&
+      (args.includes("POST") || args.includes("PATCH")),
+  );
+  assert.ok(checkMutations.length >= 2);
+  assert.equal(checkMutations.every(({ ghToken }) => ghToken === "checks-app-token"), true);
+  const mergeCall = calls.find(({ args }) => args[0] === "pr" && args[1] === "merge");
+  assert.equal(mergeCall?.ghToken, "write-token");
+});
+
+test("apply-result fails closed when the exact-check App token is missing", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    branchRefresh: true,
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    mergeStatePath,
+    env: {
+      CLOWNFISH_CHECKS_GH_TOKEN: "",
+      CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0",
+      CLOWNFISH_APPLY_BRANCH_REFRESH_DELAY_MS: "0",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /requires CLOWNFISH_CHECKS_GH_TOKEN/);
+  const mutationCalls = readCallLog(callLogPath).filter(
+    (args) =>
+      args[1]?.endsWith("/update-branch") ||
+      args[1]?.startsWith("repos/openclaw/openclaw/check-runs") ||
+      (args[0] === "pr" && args[1] === "merge"),
+  );
+  assert.deepEqual(mutationCalls, []);
+  assert.equal(fs.existsSync(mergeStatePath), false);
+});
+
 test("apply-result blocks external merge when the strict exact-merge rule is missing", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");
@@ -1212,8 +1307,10 @@ test("apply-result does not update the branch while waiting for an adopted test 
 test("apply-result keeps the exact-merge check pending while final state validation catches main drift", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");
+  const authLogPath = path.join(tmp, "gh-auth.jsonl");
   const mergeStatePath = path.join(tmp, "merge-state");
   fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(authLogPath, "");
   writeReadyMergeGhStub(
     binDir,
     adoptionStubOptions({ mainMovesAfterPendingCheck: true }),
@@ -1229,7 +1326,12 @@ test("apply-result keeps the exact-merge check pending while final state validat
     dryRun: false,
     allowMerge: true,
     mergeStatePath,
-    env: { CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0" },
+    env: {
+      GH_TOKEN: "write-token",
+      CLOWNFISH_CHECKS_GH_TOKEN: "checks-app-token",
+      CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0",
+      GH_AUTH_LOG: authLogPath,
+    },
   });
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
@@ -1237,6 +1339,27 @@ test("apply-result keeps the exact-merge check pending while final state validat
   assert.equal(report.actions[0].status, "blocked");
   assert.match(report.actions[0].reason, /main changed during apply-time adoption validation/);
   assert.equal(report.actions[0].exact_merge_revocation.status, "revoked");
+  const checkMutations = fs
+    .readFileSync(authLogPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    .filter(
+      ({ args }) =>
+        args[0] === "api" &&
+        args[1].startsWith("repos/openclaw/openclaw/check-runs") &&
+        (args.includes("POST") || args.includes("PATCH")),
+    );
+  assert.ok(checkMutations.length >= 2);
+  assert.equal(checkMutations.every(({ ghToken }) => ghToken === "checks-app-token"), true);
+  const revocation = checkMutations.find(({ args }) => {
+    if (!args.includes("PATCH")) return false;
+    const inputIndex = args.indexOf("--input");
+    if (inputIndex < 0) return false;
+    return JSON.parse(fs.readFileSync(args[inputIndex + 1], "utf8")).conclusion === "failure";
+  });
+  assert.ok(revocation);
   assert.equal(fs.existsSync(mergeStatePath), false);
 });
 
@@ -1922,6 +2045,7 @@ function apply(jobPath, resultPath, reportPath, binDir, { dryRun = true, callLog
         PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
         CLOWNFISH_ALLOW_EXECUTE: "1",
         CLOWNFISH_APP_ID: "3535277",
+        CLOWNFISH_CHECKS_GH_TOKEN: "checks-app-token",
         ...(callLogPath ? { GH_CALL_LOG: callLogPath } : {}),
         ...(allowMerge ? { CLOWNFISH_ALLOW_MERGE: "1" } : {}),
         ...(mergeStatePath ? { MERGE_STATE: mergeStatePath } : {}),
@@ -2113,6 +2237,12 @@ const externalBinding = ${JSON.stringify(externalBinding)};
 const reviewedBaseSha = ${JSON.stringify(reviewedBaseSha)};
 const branchRefreshed = () => fs.existsSync(branchRefreshStatePath);
 if (process.env.GH_CALL_LOG) fs.appendFileSync(process.env.GH_CALL_LOG, JSON.stringify(args) + "\\n");
+if (process.env.GH_AUTH_LOG) {
+  fs.appendFileSync(
+    process.env.GH_AUTH_LOG,
+    JSON.stringify({ args, ghToken: process.env.GH_TOKEN ?? null }) + "\\n",
+  );
+}
 function write(value) {
   process.stdout.write(JSON.stringify(value));
 }

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -54,6 +54,7 @@ test("external merge preflight is exact-head, read-only, and refuses unresolved 
   assert.match(script, /delete env\[key\]/);
   assert.match(script, /if \(process\.env\.GITHUB_ACTIONS === "true"\) \{\s*delete env\.OPENAI_API_KEY;\s*delete env\.CODEX_API_KEY;/s);
   assert.match(script, /function validationEnv\(\)[\s\S]*?"CLOWNFISH_READ_GH_TOKEN"/);
+  assert.equal((script.match(/"CLOWNFISH_CHECKS_GH_TOKEN"/g) ?? []).length, 2);
   assert.match(script, /function validationEnv\(\)[\s\S]*?\.\.\.gitIntegrityEnv\(\)/);
   assert.match(script, /function codexEnv\(\)[\s\S]*?gitIntegrityEnv\(\)/);
   assert.doesNotMatch(script, /pr", "merge"/);


### PR DESCRIPTION
## Summary

- keep the existing write token for branch, issue, and merge mutations
- use a step-scoped GitHub App token for exact-check POST/PATCH operations
- fail before branch refresh when exact-check App auth is unavailable
- scrub the dedicated token from external preflight validation and Codex subprocesses

## Validation

- `node --test test/app-token-auth.test.mjs test/apply-result.test.mjs test/preflight-external-pr-merge.test.mjs` (205 passed)
- focused auth/early-guard tests (3 passed)
- `npm run validate` (6,656 jobs)
- `git diff --check`

Fixes the Checks API 403 observed in Clownfish run 28840092847 after PR #101062 was refreshed.