### PR TITLE
chore(queue): refresh exact head for 98505

### DIFF
--- a/jobs/openclaw/inbox/exact-merge-wave-98505-20260707b.md
+++ b/jobs/openclaw/inbox/exact-merge-wave-98505-20260707b.md
@@ -2,7 +2,7 @@
 repo: openclaw/openclaw
 cluster_id: exact-merge-wave-98505-20260707b
 mode: autonomous
-expected_head_sha: 7c0278ea0a36cd1d4b52cb9159a24e6c781a73a4
+expected_head_sha: 50df8783d3b375bd67c019d765583cf120f90904
 allowed_actions:
   - "merge"
 blocked_actions:
@@ -31,7 +31,7 @@ allow_merge: true
 allow_post_merge_close: false
 require_fix_before_close: false
 canonical_hint: "Merge only PR #98505 after the deterministic external preflight binds validation and review to its exact live head."
-notes: "Refreshed exact head: 7c0278ea0a36cd1d4b52cb9159a24e6c781a73a4. Maintainers rebased the editable contributor branch onto OpenClaw main 82106a18b3beaaff085ca3258a6f09cd19348d03 after its GitHub test-merge ref lagged the live base. Re-fetch live state and stop if the head or merge policy changes."
+notes: "Refreshed exact head: 50df8783d3b375bd67c019d765583cf120f90904. Maintainers rebased the editable contributor branch onto OpenClaw main 08349608f291e5c8e5f4af69ff149d864da24824 after the prior head inherited unrelated baseline failures. All 101 live checks completed without failures. Maintainer decision: https://github.com/openclaw/openclaw/pull/98505#issuecomment-4899396688. Exact maintainer evidence: https://github.com/openclaw/openclaw/pull/98505#issuecomment-4900070065. Re-fetch live state and stop if the head or merge policy changes."
 ---
 
 # Exact Merge Wave: #98505


### PR DESCRIPTION
## Summary

- refresh the queued exact-merge job to PR #98505 head `50df8783d3b375bd67c019d765583cf120f90904`
- record the clean post-rebase checks and current maintainer evidence
- preserve merge-only scope

## Validation

- `npm run validate:job -- jobs/openclaw/inbox/exact-merge-wave-98505-20260707b.md`
- `npm run validate` (6,656 jobs)
- live OpenClaw checks: 101 complete, zero failures