### PR TITLE
fix(merge): accept indicated ready reviews

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -2573,7 +2573,7 @@ function hasClawSweeperReadyReviewSignal(body) {
   return (
     isClawSweeperMaintainerReviewHeader(firstLine) &&
     /result:\s*ready for maintainer review\./.test(body) &&
-    /(review metrics:\*\*\s*none identified|review metrics:\s*none identified|no (?:clawsweeper |automated )?repair(?: job| lane)? is needed|no concrete (?:code finding|contributor-facing blocker left)|remaining action is normal maintainer review)/.test(
+    /(review metrics:\*\*\s*none identified|review metrics:\s*none identified|no (?:clawsweeper |automated )?repair(?: job| lane)? is (?:needed|indicated)|no concrete (?:code finding|contributor-facing blocker left)|remaining action is normal maintainer review)/.test(
       body,
     )
   );
@@ -3047,7 +3047,8 @@ function isAuthorObjectionComment(body) {
     .filter((line) => !/^\s*\*\*before this fix\*\*:/.test(line))
     .join("\n");
   return hasOpenIssueStatement(currentClaims) || hasInvertedProofEvidence(currentClaims) || [
-    /\b(?:pause|wait|hold)(?:\s+off)?\b/,
+    /(?:^|[.!?;]\s+|\n)\s*(?:please\s+)?(?:pause|wait|hold)(?:\s+off)?\b/,
+    /\b(?:let'?s|could we|can we|we should|we need to|i(?: would|'d) prefer to)\s+(?:pause|wait|hold)(?:\s+off)?\b/,
     /\b(?:not|isn't|aren't)\s+(?:ready|complete|fixed|resolved)\b/,
     /\b(?:incomplete|unfinished|still investigating|need more time|one more thought|worried|concerns?|unclear)\b/,
     /\b(?:haven't|hasn't|nothing was)\s+fixed\b/,
@@ -3099,12 +3100,16 @@ function hasInvertedProofEvidence(body) {
       ) {
         return false;
       }
+      const unresolvedClaims = line.replace(
+        /\b(?:invalid|malformed|unsupported)\b.{0,80}?\b(?:is|are|was|were)\s+(?:correctly\s+)?(?:dropped|ignored|rejected|skipped)\b/g,
+        "",
+      );
       return [
         /\b(?:expected|supported|valid)\b.{0,80}\b(?:disappears?|dropped|fails?|ignored|lost|missing|rejected|skipped)\b/,
         /\b(?:disappears?|drops?|ignores?|loses?|rejects?|skips?)\b.{0,80}\b(?:expected|supported|valid)\b/,
         /\b(?:invalid|malformed|unsupported)\b.{0,80}\b(?:accepted|allowed|creates?|processed|preserved|produces?)\b/,
         /\b(?:accepts?|allows?|creates?|processes?|preserves?|produces?)\b.{0,80}\b(?:invalid|malformed|unsupported)\b/,
-      ].some((pattern) => pattern.test(line));
+      ].some((pattern) => pattern.test(unresolvedClaims));
     });
 }
 

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -1335,7 +1335,9 @@ for (const [kind, body] of [
   });
 }
 
-function trustedReadyReviewComment() {
+function trustedReadyReviewComment({
+  nextStep = "No automated repair is needed; the remaining action is normal maintainer review.",
+} = {}) {
   return {
     author: { login: "clawsweeper[bot]" },
     authorAssociation: "CONTRIBUTOR",
@@ -1349,7 +1351,7 @@ function trustedReadyReviewComment() {
       "Result: ready for maintainer review.",
       "",
       "**Next step before merge**",
-      "- No automated repair is needed; the remaining action is normal maintainer review.",
+      `- ${nextStep}`,
       "",
       `<!-- clawsweeper-verdict:needs-human item=123 sha=${"a".repeat(40)} confidence=high -->`,
       "<!-- clawsweeper-review item=123 -->",
@@ -1372,6 +1374,31 @@ test("external merge preflight accepts an explicit maintainer decision with an e
           "This is intentional hardening; the pnpm and npm user paths remain present, and Clownfish must still verify the current-main effective diff through the exact merge gate before landing.",
         ].join(" "),
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-maintainer-decision",
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+  assert.equal(report.status, "passed", report.reason);
+});
+
+test("external merge preflight accepts indicated-no-repair wording with a maintainer decision", () => {
+  const fixture = makeFixture({
+    issueComments: [
+      trustedReadyReviewComment({
+        nextStep:
+          "No automated repair is indicated; maintainers should do normal review and exact-merge validation for the behind-but-mergeable head.",
+      }),
+      {
+        author: { login: "vincentkoc" },
+        authorAssociation: "MEMBER",
+        isMinimized: false,
+        createdAt: "2026-07-07T02:02:09Z",
+        body: [
+          "Maintainer decision: accept the fail-closed port ownership behavior.",
+          "Malformed PID output is rejected, the fuser fallback preserves recovery where possible, and the stale-port wait remains bounded.",
+          "The compatibility and availability risk labels were false positives; no code repair is needed.",
+        ].join(" "),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-maintainer-decision-indicated",
       },
     ],
   });


### PR DESCRIPTION
## Summary
- accept ClawSweeper exact-head reviews that say no repair is indicated
- avoid treating resolved malformed-input proof or bounded wait nouns as objections
- cover the exact #98505 review and maintainer-decision wording

## Validation
- `node --test test/preflight-external-pr-merge.test.mjs` (134 passed)
- `npm run validate` (6,657 jobs)
- `node --check scripts/preflight-external-pr-merge.mjs`
- `git diff --check`