### PR TITLE
chore(queue): refresh exact head for 98505

### DIFF
--- a/jobs/openclaw/outbox/finalized/exact-merge-wave-98505-20260707b.md
+++ b/jobs/openclaw/outbox/finalized/exact-merge-wave-98505-20260707b.md
@@ -2,7 +2,7 @@
 repo: openclaw/openclaw
 cluster_id: exact-merge-wave-98505-20260707b
 mode: autonomous
-expected_head_sha: 50df8783d3b375bd67c019d765583cf120f90904
+expected_head_sha: e29e65f4f309529622f262fd7ec993b4a91fecdb
 allowed_actions:
   - "merge"
 blocked_actions:
@@ -32,7 +32,7 @@ require_external_merge_preflight: true
 allow_post_merge_close: false
 require_fix_before_close: false
 canonical_hint: "Merge only PR #98505 after the deterministic external preflight binds validation and review to its exact live head."
-notes: "Refreshed exact head: 50df8783d3b375bd67c019d765583cf120f90904. Maintainers rebased the editable contributor branch onto OpenClaw main 08349608f291e5c8e5f4af69ff149d864da24824 after the prior head inherited unrelated baseline failures. All 101 live checks completed without failures. Maintainer decision: https://github.com/openclaw/openclaw/pull/98505#issuecomment-4899396688. Exact maintainer evidence: https://github.com/openclaw/openclaw/pull/98505#issuecomment-4900070065. Re-fetch live state and stop if the head or merge policy changes."
+notes: "Refreshed exact head: e29e65f4f309529622f262fd7ec993b4a91fecdb. During the prior exact authorization, Clownfish merged OpenClaw main 3175d8e7423de21235cc34c49080c9df83c3af2b into the editable contributor branch and correctly revoked the stale authorization after the head changed. The refreshed head preserves effective diff SHA-256 4f360bb04e9d6b2196daf69fcca6065f0f5c5d1d6245ee5d6209968b2c6234fa across the same six files. Maintainer decision: https://github.com/openclaw/openclaw/pull/98505#issuecomment-4899396688. Require refreshed checks and current-head review, re-fetch live state, and stop if the head or merge policy changes."
 ---
 
 # Exact Merge Wave: #98505


### PR DESCRIPTION
## Summary
- pin the queue job to refreshed OpenClaw head `e29e65f4f309529622f262fd7ec993b4a91fecdb`
- record the adopted `main` SHA and preserved effective diff hash
- require refreshed checks and current-head review before replay

## Validation
- `npm run render -- jobs/openclaw/outbox/finalized/exact-merge-wave-98505-20260707b.md --mode plan`
- `git diff --check`