### PR TITLE
chore(queue): add explicit rebase repair jobs

### DIFF
--- a/jobs/openclaw/inbox/pr-rebase-87799-20260711.md
+++ b/jobs/openclaw/inbox/pr-rebase-87799-20260711.md
@@ -1,0 +1,50 @@
+---
+repo: openclaw/openclaw
+cluster_id: pr-rebase-87799-20260711
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - comment
+  - label
+  - close
+  - merge
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - unresolved_review_threads
+  - broad_code_delta
+maintainer_calibration:
+  - "Rebase the current maintainer-editable contributor branch onto current main, validate it, and run Codex /review. Preserve the existing two-file installer fix and do not broaden the PR."
+canonical:
+  - "#87799"
+candidates:
+  - "#87799"
+cluster_refs:
+  - "#87799"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+rebase_only: true
+security_policy: central_security_only
+security_sensitive: false
+canonical_hint: "#87799 is the sole canonical PR. Repair its stale conflicting branch against current main before any separate merge finalization."
+notes: "Bounded rebase-only repair for the maintainer-editable #87799 contributor branch. Do not merge, close, label, comment, create a replacement PR, or expand the installer change."
+---
+
+# Rebase-only repair: #87799
+
+Re-hydrate #87799 and emit `fix_needed` plus a complete `build_fix_artifact`
+using `repair_strategy: repair_contributor_branch`.
+
+Rebase the existing maintainer-editable branch onto current main. Preserve the
+narrow `scripts/install.sh` and installer-test intent, resolve only current-main
+compatibility conflicts, run changed-surface validation and Codex `/review`,
+then push the repaired contributor branch.
+
+Do not merge, close, label, comment, create a replacement PR, or broaden the PR.

--- a/jobs/openclaw/inbox/pr-rebase-90942-20260711.md
+++ b/jobs/openclaw/inbox/pr-rebase-90942-20260711.md
@@ -1,0 +1,52 @@
+---
+repo: openclaw/openclaw
+cluster_id: pr-rebase-90942-20260711
+mode: autonomous
+allowed_actions:
+  - fix
+  - raise_pr
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - comment
+  - label
+  - close
+  - merge
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - unresolved_review_threads
+  - broad_code_delta
+maintainer_calibration:
+  - "Rebase the current maintainer-editable contributor branch onto current main, validate it, and run Codex /review. Preserve the existing symlinked-launcher fix and do not broaden the PR."
+canonical:
+  - "#90942"
+candidates:
+  - "#90942"
+cluster_refs:
+  - "#90942"
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_post_merge_close: false
+require_fix_before_close: false
+rebase_only: true
+security_policy: central_security_only
+security_sensitive: false
+canonical_hint: "#90942 is the sole canonical PR. Refresh its stale branch against current main before any separate exact-head merge finalization."
+notes: "Bounded rebase-only repair for the maintainer-editable #90942 contributor branch. Current review found no implementation change required beyond branch refresh; do not merge, close, label, comment, create a replacement PR, or expand scope."
+---
+
+# Rebase-only repair: #90942
+
+Re-hydrate #90942 and emit `fix_needed` plus a complete
+`build_fix_artifact` using `repair_strategy: repair_contributor_branch`.
+
+Rebase the existing maintainer-editable branch onto current main. Preserve the
+narrow symlinked-launcher and package-root lookup fix. Current main already
+uses the intended package-root precedence, so do not invent implementation
+changes merely to make progress. Resolve only rebase conflicts, run
+changed-surface validation and Codex `/review`, then push the repaired
+contributor branch.
+
+Do not merge, close, label, comment, create a replacement PR, or broaden the PR.


### PR DESCRIPTION
## Summary

- add bounded `rebase_only` repair jobs for openclaw/openclaw PRs #87799 and #90942
- require repair of the existing maintainer-editable contributor branches
- block merge, close, labels, comments, replacement PRs, and scope expansion

## Why

Generic merge-risk remediation correctly classified #87799 but produced no mutation because it requires a code patch. These jobs use the executor's explicit `rebase_only` path so stale/conflicting branches can actually be refreshed and validated.

## Validation

- `npm run validate` (6,661 jobs)
- `npm run render -- <job> --mode autonomous` for both jobs
- `npm run worker -- <job> --mode autonomous --dry-run` for both jobs
- `git diff --check`