### PR TITLE
feat(intake): add guarded conflicting branch repair lane

### DIFF
--- a/.github/workflows/checks-success-preflight-intake.yml
+++ b/.github/workflows/checks-success-preflight-intake.yml
@@ -27,6 +27,16 @@ on:
         required: true
         default: ubuntu-latest
         type: string
+      repair_runner:
+        description: "Runner for conflicting branch planning and review"
+        required: true
+        default: blacksmith-4vcpu-ubuntu-2404
+        type: string
+      execution_runner:
+        description: "Runner for conflicting branch fix execution"
+        required: true
+        default: blacksmith-16vcpu-ubuntu-2404
+        type: string
       apply:
         description: "Dispatch guarded apply after preflight passes"
         required: true
@@ -82,9 +92,12 @@ jobs:
           TARGET_REPO: ${{ github.event_name == 'workflow_dispatch' && inputs.target_repo || vars.CLOWNFISH_TARGET_REPO || 'openclaw/openclaw' }}
           LIMIT: ${{ github.event_name == 'workflow_dispatch' && inputs.limit || vars.CLOWNFISH_CHECKS_SUCCESS_LIMIT || '30' }}
           BATCH_SIZE: ${{ github.event_name == 'workflow_dispatch' && inputs.batch_size || vars.CLOWNFISH_CHECKS_SUCCESS_BATCH_SIZE || '2' }}
+          CONFLICT_REPAIR_LIMIT: ${{ vars.CLOWNFISH_CONFLICTING_BRANCH_REPAIR_LIMIT || '5' }}
           IMPORT_JSON: ${{ runner.temp }}/checks-success-import.json
+          CONFLICT_IMPORT_JSON: ${{ runner.temp }}/conflicting-branch-repair-import.json
           GENERATED_PATHS: ${{ runner.temp }}/checks-success-generated-paths.txt
           DISPATCH_TSV: ${{ runner.temp }}/checks-success-dispatch.tsv
+          CONFLICT_DISPATCH_PATHS: ${{ runner.temp }}/conflicting-branch-repair-dispatch-paths.txt
         run: |
           set -euo pipefail
           node scripts/import-github-pr-inventory.mjs \
@@ -98,12 +111,26 @@ jobs:
             --batch-size "$BATCH_SIZE" \
             --json > "$IMPORT_JSON"
 
+          node scripts/import-github-pr-inventory.mjs \
+            --repo "$TARGET_REPO" \
+            --mode autonomous \
+            --strategy remediation \
+            --bucket conflicting_branch_repair \
+            --sort stale \
+            --skip-existing false \
+            --search-limit 100 \
+            --limit "$CONFLICT_REPAIR_LIMIT" \
+            --batch-size 1 \
+            --json > "$CONFLICT_IMPORT_JSON"
+
           node --input-type=module <<'EOF'
           import fs from "node:fs";
 
           const payload = JSON.parse(fs.readFileSync(process.env.IMPORT_JSON, "utf8"));
+          const conflictPayload = JSON.parse(fs.readFileSync(process.env.CONFLICT_IMPORT_JSON, "utf8"));
           const generated = Array.isArray(payload.generated) ? payload.generated : [];
-          const paths = generated.map((item) => String(item.path ?? "")).filter(Boolean);
+          const conflictGenerated = Array.isArray(conflictPayload.generated) ? conflictPayload.generated : [];
+          const paths = [...generated, ...conflictGenerated].map((item) => String(item.path ?? "")).filter(Boolean);
           const rows = [];
           for (const item of generated) {
             const sourceJob = String(item.path ?? "");
@@ -116,14 +143,22 @@ jobs:
 
           fs.writeFileSync(process.env.GENERATED_PATHS, paths.join("\n") + (paths.length ? "\n" : ""));
           fs.writeFileSync(process.env.DISPATCH_TSV, rows.join("\n") + (rows.length ? "\n" : ""));
+          const conflictPaths = conflictGenerated.map((item) => String(item.path ?? "")).filter(Boolean);
+          fs.writeFileSync(
+            process.env.CONFLICT_DISPATCH_PATHS,
+            conflictPaths.join("\n") + (conflictPaths.length ? "\n" : ""),
+          );
 
           const output = [
             ["generated_count", String(paths.length)],
             ["candidate_count", String(payload?.totals?.candidates ?? rows.length)],
             ["dispatch_count", String(rows.length)],
+            ["conflict_generated_count", String(conflictPaths.length)],
           ];
           fs.appendFileSync(process.env.GITHUB_OUTPUT, output.map(([key, value]) => `${key}=${value}`).join("\n") + "\n");
-          console.log(`generated ${paths.length} source shard(s), ${rows.length} external preflight dispatch(es)`);
+          console.log(
+            `generated ${paths.length} source shard(s), ${rows.length} external preflight dispatch(es), ${conflictPaths.length} conflicting branch repair dispatch(es)`,
+          );
           EOF
 
       - name: Commit generated source shards
@@ -182,3 +217,44 @@ jobs:
               -f "apply=${apply}"
             sleep "$DISPATCH_DELAY_SECONDS"
           done < "${{ runner.temp }}/checks-success-dispatch.tsv"
+
+      - name: Dispatch conflicting branch repairs
+        if: ${{ steps.intake.outputs.conflict_generated_count != '0' }}
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token || github.token }}
+          REPAIR_RUNNER: ${{ github.event_name == 'workflow_dispatch' && inputs.repair_runner || vars.CLOWNFISH_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+          REPAIR_EXECUTION_RUNNER: ${{ github.event_name == 'workflow_dispatch' && inputs.execution_runner || vars.CLOWNFISH_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
+          DISPATCH_DELAY_SECONDS: ${{ vars.CLOWNFISH_CONFLICTING_BRANCH_REPAIR_DISPATCH_DELAY_SECONDS || '5' }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            apply="${{ inputs.apply }}"
+          else
+            apply="${{ vars.CLOWNFISH_CHECKS_SUCCESS_APPLY || 'true' }}"
+          fi
+          if [ "$apply" != "true" ]; then
+            echo "Guarded apply is disabled; skipping conflicting branch repair dispatches"
+            exit 0
+          fi
+
+          dispatch_failed=0
+          while IFS= read -r source_job; do
+            if [ -z "$source_job" ]; then
+              continue
+            fi
+            echo "Dispatching conflicting branch repair for ${source_job}"
+            if ! gh workflow run cluster-worker.yml \
+              --repo "$GITHUB_REPOSITORY" \
+              --ref main \
+              -f "job=${source_job}" \
+              -f "mode=autonomous" \
+              -f "runner=${REPAIR_RUNNER}" \
+              -f "execution_runner=${REPAIR_EXECUTION_RUNNER}" \
+              -f "dry_run=false"; then
+              echo "::error::Failed to dispatch conflicting branch repair for ${source_job}"
+              dispatch_failed=1
+              continue
+            fi
+            sleep "$DISPATCH_DELAY_SECONDS"
+          done < "${{ runner.temp }}/conflicting-branch-repair-dispatch-paths.txt"
+          exit "$dispatch_failed"

--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -223,6 +223,19 @@ if (NON_EXECUTABLE_REPAIR_STRATEGIES.has(repairStrategy)) {
 
 const fixArtifact = validateFixArtifact(executableFixArtifact);
 installEmergencyFixReportHandlers({ report, resultPath, fixArtifact });
+const requiredRepairStrategy = String(job.frontmatter.repair_strategy ?? "");
+if (requiredRepairStrategy && fixArtifact.repair_strategy !== requiredRepairStrategy) {
+  report.status = "blocked";
+  report.reason = `source job requires repair_strategy=${requiredRepairStrategy}, received ${fixArtifact.repair_strategy}`;
+  report.actions.push({
+    action: "execute_fix",
+    status: "blocked",
+    repair_strategy: fixArtifact.repair_strategy,
+    reason: report.reason,
+  });
+  writeReport(report, resultPath);
+  process.exit(0);
+}
 const securityBlock = validateFixSecurityScope({ job, resultPath, fixArtifact, plannedFixActions });
 if (securityBlock) {
   report.status = "skipped";
@@ -369,8 +382,10 @@ try {
         ensureCodexWritePreflight,
       });
     } catch (error) {
-      if (rebaseOnlyRepair) {
-        const reason = `rebase-only repair stopped: ${error.message}`;
+      if (rebaseOnlyRepair || requiredRepairStrategy === "repair_contributor_branch") {
+        const reason = rebaseOnlyRepair
+          ? `rebase-only repair stopped: ${error.message}`
+          : `required contributor-branch repair stopped: ${error.message}`;
         outcome = {
           ...blockedFixOutcome(error, fixArtifact),
           action: "repair_contributor_branch",
@@ -2558,18 +2573,54 @@ function mutableFixSourceRefs(fixArtifact) {
 }
 
 function validateLiveAutonomousTargetPolicy({ job, fixArtifact }) {
-  if (job.frontmatter.mode !== "autonomous") return null;
   const adoptedAutomergeTarget = adoptedAutomergeRepairTarget(job);
 
   const sources =
     fixArtifact.repair_strategy === "repair_contributor_branch"
-      ? [firstSourcePullRequest(fixArtifact)]
+      ? (fixArtifact.source_prs ?? []).map(parsePullRequestUrl).filter((source) => source?.repo === result.repo)
       : fixArtifact.repair_strategy === "replace_uneditable_branch"
         ? supersededReplacementSources(fixArtifact).map(parsePullRequestUrl).filter(Boolean)
         : [];
+  const canonicalRefs = new Set((job.frontmatter.canonical ?? []).map(normalizeLocalRef).filter(Boolean));
+  const hasPinnedHeads =
+    (job.frontmatter.expected_head_shas ?? []).length > 0 ||
+    /^[0-9a-f]{40}$/i.test(job.frontmatter.expected_head_sha ?? "");
+
+  if (
+    job.frontmatter.repair_strategy === "repair_contributor_branch" &&
+    canonicalRefs.size === 1 &&
+    (sources.length !== 1 || !canonicalRefs.has(`#${sources[0]?.number}`))
+  ) {
+    const expectedRef = [...canonicalRefs][0];
+    const actualRefs = sources.map((source) => `#${source.number}`).join(", ") || "none";
+    return {
+      code: "repair_source_mismatch",
+      reason: `repair_contributor_branch source must be canonical ${expectedRef}; received ${actualRefs}`,
+      evidence: [`canonical=${expectedRef}`, `source_prs=${actualRefs}`],
+    };
+  }
 
   for (const source of sources) {
+    const expectedHeadSha = expectedHeadShaForSource(job, source.number);
+    if (hasPinnedHeads && !expectedHeadSha) {
+      return {
+        code: "expected_head_missing",
+        reason: `source PR #${source.number} is not pinned by the source job expected head policy`,
+        evidence: [`source_pr=#${source.number}`],
+      };
+    }
     const pull = fetchPullRequest(source.number);
+    if (expectedHeadSha) {
+      const liveHeadSha = String(pull.head?.sha ?? "").toLowerCase();
+      if (liveHeadSha !== expectedHeadSha) {
+        return {
+          code: "expected_head_mismatch",
+          reason: `source PR #${source.number} head changed after intake: expected ${expectedHeadSha}, found ${liveHeadSha || "missing"}`,
+          evidence: [`expected_head_sha=${expectedHeadSha}`, `live_head_sha=${liveHeadSha || "missing"}`],
+        };
+      }
+    }
+    if (job.frontmatter.mode !== "autonomous") continue;
     const labels = (pull.labels ?? []).map((label) => String(label?.name ?? label)).filter(Boolean);
     const normalizedLabels = labels.map((label) => label.toLowerCase());
     const isAdoptedAutomergeTarget = source.number === adoptedAutomergeTarget;
@@ -2592,6 +2643,19 @@ function validateLiveAutonomousTargetPolicy({ job, fixArtifact }) {
   }
 
   return null;
+}
+
+function expectedHeadShaForSource(job, number) {
+  const ref = `#${number}`;
+  for (const entry of job.frontmatter.expected_head_shas ?? []) {
+    const match = String(entry).match(/^(#[0-9]+)=([0-9a-f]{40})$/i);
+    if (match?.[1] === ref) return match[2].toLowerCase();
+  }
+  const candidates = (job.frontmatter.candidates ?? []).map((candidate) => normalizeLocalRef(candidate));
+  if (candidates.length === 1 && candidates[0] === ref && /^[0-9a-f]{40}$/i.test(job.frontmatter.expected_head_sha ?? "")) {
+    return String(job.frontmatter.expected_head_sha).toLowerCase();
+  }
+  return "";
 }
 
 function isRepairOnlyMergeRiskRemediationJob(job) {

--- a/scripts/import-github-pr-inventory.mjs
+++ b/scripts/import-github-pr-inventory.mjs
@@ -70,7 +70,9 @@ const includeSecurity = Boolean(args["include-security-candidates"]);
 const includeMergeRisk = Boolean(args["include-merge-risk-candidates"] ?? args.include_merge_risk_candidates);
 const repairOnlyMergeRiskInventory =
   strategy === "remediation" && includeMergeRisk && bucketFilter === "merge_risk_remediation";
-const batchSize = repairOnlyMergeRiskInventory ? 1 : requestedBatchSize;
+const conflictingBranchRepairInventory =
+  strategy === "remediation" && bucketFilter === "conflicting_branch_repair";
+const batchSize = repairOnlyMergeRiskInventory || conflictingBranchRepairInventory ? 1 : requestedBatchSize;
 const includeRefs = optionalRefsFile(args["include-refs-file"] ?? args.include_refs_file);
 const hydrateIncludeRefs = Boolean(args["hydrate-include-refs"] ?? args.hydrate_include_refs);
 const minScore = numberArg("min-score", 2);
@@ -117,6 +119,14 @@ if (!["all", "terminal"].includes(existingResultsActionPolicy)) die("--existing-
 
 const existingRefs = skipExisting ? existingRefsForStrategy() : new Set();
 if (skipExisting) mergeRefs(existingRefs, existingPublishedResultRefs(existingResultsDir, repo, existingResultsActionPolicy));
+const existingConflictingRepairJobs =
+  conflictingBranchRepairInventory && !dryRun
+    ? conflictingRepairJobs([path.join(repoRoot(), "jobs", owner), outDir])
+    : new Map();
+const publishedConflictingRepairClusterIds =
+  conflictingBranchRepairInventory && !dryRun
+    ? publishedResultClusterIds(existingResultsDir, repo, "conflicting-branch-repair-")
+    : new Set();
 const checksSuccessAttempts =
   skipExisting && checksSuccessPreflight ? existingChecksSuccessAttempts(existingDir) : new Map();
 if (checksSuccessPreflight) checksSuccessMainSha = fetchChecksSuccessMainSha();
@@ -138,7 +148,7 @@ for (let index = 0; index < limitedCandidates.length; index += batchSize) {
 }
 
 if (!dryRun) fs.mkdirSync(outDir, { recursive: true });
-const generated = batches.map((batch, index) => writeJob(batch, index + 1));
+const generated = batches.map((batch, index) => writeJob(batch, index + 1)).filter(Boolean);
 
 const payload = sanitizeJsonValue({
   generated,
@@ -278,6 +288,8 @@ function fetchOpenPullRequestsFromSearch() {
   ];
   if (checksSuccessPreflight) {
     ghArgs.push("--base", "main", "--checks", "success");
+  } else if (conflictingBranchRepairInventory) {
+    ghArgs.push("--base", "main");
   } else if (strategy === "remediation") {
     ghArgs.push("--label", "status: 👀 ready for maintainer look", "--label", "proof: sufficient");
   }
@@ -562,28 +574,32 @@ function fetchOpenPullRequestsFromPrList() {
       remediationPrListSearchQuery(),
   );
   let pulls;
-  try {
-    pulls = ghJsonWithRetry(
-      [
-        "pr",
-        "list",
-        "--repo",
-        repo,
-        "--state",
-        "open",
-        "--search",
-        search,
-        "--limit",
-        String(searchLimit),
-        "--json",
-        prListFields(),
-      ],
-      { operation: "list open pull request inventory" },
-    );
-  } catch (error) {
-    if (!isRetryableGhError(error)) throw error;
-    console.error("list open pull request inventory failed after retries; falling back to search plus per-PR hydration");
+  if (conflictingBranchRepairInventory) {
     pulls = fetchOpenPullRequestsFromPrListFallback();
+  } else {
+    try {
+      pulls = ghJsonWithRetry(
+        [
+          "pr",
+          "list",
+          "--repo",
+          repo,
+          "--state",
+          "open",
+          "--search",
+          search,
+          "--limit",
+          String(searchLimit),
+          "--json",
+          prListFields(),
+        ],
+        { operation: "list open pull request inventory" },
+      );
+    } catch (error) {
+      if (!isRetryableGhError(error)) throw error;
+      console.error("list open pull request inventory failed after retries; falling back to search plus per-PR hydration");
+      pulls = fetchOpenPullRequestsFromPrListFallback();
+    }
   }
   if (!Array.isArray(pulls)) throw new Error("GitHub PR list returned a non-array payload");
   const normalized = pulls.map(normalizePrListPullRequest);
@@ -592,6 +608,7 @@ function fetchOpenPullRequestsFromPrList() {
       .filter((pull) => shouldRetryChecksSuccessPullRequest(pull))
       .filter(acceptHydratedChecksSuccessPullRequest);
   }
+  if (conflictingBranchRepairInventory) return normalized;
   return normalized.filter((pull) => !prListMergeBlocker(pull));
 }
 
@@ -608,7 +625,7 @@ function fetchOpenPullRequestsFromIncludedRefs() {
     }
     if (!hydrated) continue;
     const normalized = normalizePrListPullRequest(hydrated);
-    if (!checksSuccessPreflight && prListMergeBlocker(normalized)) continue;
+    if (!checksSuccessPreflight && !conflictingBranchRepairInventory && prListMergeBlocker(normalized)) continue;
     pulls.push(normalized);
     if (limit !== "all" && pulls.length >= limitForHydration) break;
   }
@@ -638,7 +655,8 @@ function fetchOpenPullRequestsFromPrListFallback() {
     }
     if (!hydrated) continue;
     const normalized = normalizePrListPullRequest(hydrated);
-    if (prListMergeBlocker(normalized)) continue;
+    if (!conflictingBranchRepairInventory && prListMergeBlocker(normalized)) continue;
+    if (conflictingBranchRepairInventory && !conflictingBranchRepairProfile(normalized)) continue;
     pulls.push(hydrated);
     if (limit !== "all" && pulls.length >= limitForHydration) break;
   }
@@ -692,6 +710,7 @@ function prListFields() {
 
 function remediationPrListSearchQuery() {
   if (strategy !== "remediation") return "state:open";
+  if (conflictingBranchRepairInventory) return "state:open base:main sort:updated-asc";
   if (checksSuccessPreflight) {
     return [
       "state:open",
@@ -764,8 +783,31 @@ function normalizePrListPullRequest(raw) {
     body: raw.body,
     labels: { nodes: arrayNodes(raw.labels, "name") },
     assignees: { nodes: arrayNodes(raw.assignees, "login") },
-    comments: { totalCount: commentCount(raw) },
+    comments: normalizeComments(raw.comments, raw.commentsCount),
     reviews: { totalCount: Number(raw.reviewsCount ?? raw.reviews?.totalCount ?? 0) },
+  };
+}
+
+function normalizeComments(value, explicitCount = null) {
+  const source = Array.isArray(value) ? value : Array.isArray(value?.nodes) ? value.nodes : [];
+  const nodes = source
+    .map((comment) => {
+      if (!comment || typeof comment !== "object") return null;
+      return {
+        author: {
+          login: asciiString(comment.author?.login ?? comment.user?.login ?? ""),
+        },
+        body: asciiString(comment.body ?? ""),
+        createdAt: nullableAscii(comment.createdAt ?? comment.created_at),
+        updatedAt: nullableAscii(comment.updatedAt ?? comment.updated_at),
+        url: nullableAscii(comment.url ?? comment.html_url),
+      };
+    })
+    .filter(Boolean);
+  const totalCount = Number(explicitCount ?? value?.totalCount ?? nodes.length);
+  return {
+    totalCount: Number.isFinite(totalCount) ? totalCount : nodes.length,
+    nodes,
   };
 }
 
@@ -857,7 +899,10 @@ function classifyCandidate(raw) {
   const authorAssociation = asciiString(raw.authorAssociation ?? "");
   const body = asciiString(raw.body ?? "");
   const files = Array.isArray(raw.files) ? raw.files.map(asciiString).filter(Boolean) : [];
-  const bucket = chooseBucket({ raw, title, labels, assignees, authorAssociation });
+  const repairProfile = conflictingBranchRepairInventory ? conflictingBranchRepairProfile(raw) : null;
+  const bucket = repairProfile
+    ? "conflicting_branch_repair"
+    : chooseBucket({ raw, title, labels, assignees, authorAssociation });
   const base = {
     number: Number(raw.number),
     ref: `#${raw.number}`,
@@ -880,8 +925,128 @@ function classifyCandidate(raw) {
     additions: Number(raw.additions ?? 0),
     deletions: Number(raw.deletions ?? 0),
     bucket,
+    repair_profile: repairProfile,
   };
   return strategy === "low-signal" ? classifyLowSignalCandidate(base, { raw, body }) : base;
+}
+
+function conflictingBranchRepairProfile(raw) {
+  const labels = labelNames(raw.labels);
+  if (raw.baseRefName !== "main") return null;
+  if (Boolean(raw.isDraft)) return null;
+  if (raw.maintainerCanModify !== true) return null;
+  if (hasExactSecuritySignal({ title: asciiString(raw.title ?? ""), labels })) return null;
+
+  const mergeable = String(raw.mergeable ?? "").toUpperCase();
+  const mergeStateStatus = String(raw.mergeStateStatus ?? "").toUpperCase();
+  if (mergeable !== "CONFLICTING" && mergeStateStatus !== "DIRTY") return null;
+
+  const headSha = normalizedGitSha(raw.headRefOid);
+  if (!headSha) return null;
+
+  const decisions = [];
+  for (const [index, comment] of (raw.comments?.nodes ?? []).entries()) {
+    const author = String(comment?.author?.login ?? comment?.user?.login ?? "").toLowerCase();
+    if (!["clawsweeper", "clawsweeper[bot]"].includes(author)) continue;
+    const body = String(comment?.body ?? "");
+    const markers = parseClawSweeperDecisionMarkers(body);
+    if (!markers) continue;
+    let profile = null;
+    if (
+      markers.some(
+        (marker) =>
+          markerMatchesPull(marker, raw, headSha) &&
+          ((marker.kind === "action" &&
+            ["fix-required", "repair-required", "address-review", "fix-ci"].includes(marker.action)) ||
+            (marker.kind === "verdict" &&
+              ["needs-changes", "changes-requested", "fix-required", "repair-required"].includes(marker.action))),
+      )
+    ) {
+      profile = "review_fix";
+    } else if (isExactHeadReadyReview({ body, markers, raw, headSha })) {
+      profile = "rebase_only";
+    }
+    if (!profile) continue;
+    const timestamp = Date.parse(comment?.updatedAt ?? comment?.updated_at ?? comment?.createdAt ?? comment?.created_at ?? "");
+    decisions.push({
+      profile,
+      timestamp: Number.isFinite(timestamp) ? timestamp : Number.NEGATIVE_INFINITY,
+      index,
+    });
+  }
+  decisions.sort((left, right) => left.timestamp - right.timestamp || left.index - right.index);
+  return decisions.at(-1)?.profile ?? null;
+}
+
+function parseClawSweeperDecisionMarkers(body) {
+  const text = String(body ?? "");
+  const openers = text.match(/<!--\s*clawsweeper-(?:action|verdict):/gi) ?? [];
+  const matches = [
+    ...text.matchAll(/<!--\s*clawsweeper-(action|verdict):\s*([a-z0-9_-]+)\s+([^>]*)-->/gi),
+  ];
+  if (openers.length !== matches.length) return null;
+
+  const markers = [];
+  for (const match of matches) {
+    const attrs = parseStrictMarkerAttributes(match[3]);
+    if (!attrs) return null;
+    markers.push({
+      kind: match[1].toLowerCase(),
+      action: match[2].toLowerCase(),
+      attrs,
+    });
+  }
+  return markers;
+}
+
+function parseStrictMarkerAttributes(input) {
+  const attrs = {};
+  const tokens = String(input ?? "").trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return null;
+  for (const token of tokens) {
+    const match = token.match(/^([a-z0-9_-]+)=([^\s=]+)$/i);
+    if (!match) return null;
+    const key = match[1].toLowerCase();
+    if (Object.hasOwn(attrs, key)) return null;
+    attrs[key] = match[2];
+  }
+  return attrs;
+}
+
+function markerMatchesPull(marker, raw, headSha) {
+  return (
+    marker.attrs.item === String(raw.number) &&
+    marker.attrs.sha?.toLowerCase() === headSha &&
+    marker.attrs.confidence === "high"
+  );
+}
+
+function isExactHeadReadyReview({ body, markers, raw, headSha }) {
+  if (markers.some((marker) => marker.kind === "action")) return false;
+  const verdicts = markers.filter((marker) => marker.kind === "verdict");
+  if (
+    verdicts.length !== 1 ||
+    verdicts[0].action !== "needs-human" ||
+    !markerMatchesPull(verdicts[0], raw, headSha)
+  ) {
+    return false;
+  }
+
+  const reviewOpeners = String(body).match(/<!--\s*clawsweeper-review(?=\s)/gi) ?? [];
+  const reviews = [...String(body).matchAll(/<!--\s*clawsweeper-review\s+([^>]*)-->/gi)];
+  if (reviewOpeners.length !== 1 || reviews.length !== 1) return false;
+  const reviewAttrs = parseStrictMarkerAttributes(reviews[0][1]);
+  if (!reviewAttrs || reviewAttrs.item !== String(raw.number)) return false;
+
+  const normalized = String(body).trim().toLowerCase();
+  const firstLine = normalized.split(/\r?\n/, 1)[0].trim();
+  return (
+    /^codex review:\s*needs maintainer review before merge\./.test(firstLine) &&
+    /result:\s*ready for maintainer review\./.test(normalized) &&
+    /(review metrics:\*\*\s*none identified|review metrics:\s*none identified|no (?:clawsweeper |automated )?repair(?: job| lane)? is (?:needed|indicated)|no concrete (?:code finding|contributor-facing blocker left)|remaining action is normal maintainer review)/.test(
+      normalized,
+    )
+  );
 }
 
 function dedupeCandidates(candidates) {
@@ -1042,6 +1207,7 @@ function chooseBucket({ raw, title, labels, assignees, authorAssociation }) {
 }
 
 function writeJob(batch, index) {
+  if (conflictingBranchRepairInventory) return writeConflictingBranchRepairJob(batch, index);
   const now = new Date();
   const stamp = now.toISOString().replace(/[-:.]/g, "").slice(0, 15);
   const bucket = batch.every((item) => item.bucket === batch[0].bucket) ? batch[0].bucket : "mixed";
@@ -1182,6 +1348,95 @@ function writeJob(batch, index) {
   };
 }
 
+function writeConflictingBranchRepairJob(batch, index) {
+  if (batch.length !== 1) throw new Error("conflicting branch repair jobs must be singleton");
+  const candidate = batch[0];
+  const clusterId = `conflicting-branch-repair-${candidate.number}-${candidate.head_sha}`;
+  const existingJobPath = existingConflictingRepairJobs.get(clusterId);
+  if (!dryRun && existingJobPath) {
+    if (publishedConflictingRepairClusterIds.has(clusterId)) return null;
+    return {
+      path: path.relative(repoRoot(), existingJobPath),
+      cluster_id: clusterId,
+      bucket: "conflicting_branch_repair",
+      candidates: [candidate.ref],
+      retry: true,
+      dry_run: false,
+    };
+  }
+  const filePath = path.join(outDir, `${clusterId}.md`);
+  const rebaseOnly = candidate.repair_profile === "rebase_only";
+  const calibration = rebaseOnly
+    ? "Rebase the current maintainer-editable contributor branch onto current main, validate it, and run Codex /review. Preserve the existing contributor change and do not broaden the PR."
+    : "Repair the exact-current-head actionable ClawSweeper finding on the maintainer-editable contributor branch, rebase it onto current main, validate it, and run Codex /review without broadening the PR.";
+  const goal = rebaseOnly
+    ? "Rebase the existing maintainer-editable contributor branch onto current main. Preserve the current implementation, resolve only rebase conflicts, run changed-surface validation and Codex `/review`, then push the repaired contributor branch."
+    : "Address the exact-current-head actionable ClawSweeper finding on the existing maintainer-editable contributor branch. Keep the repair bounded to that finding, rebase onto current main, run changed-surface validation and Codex `/review`, then push the repaired contributor branch.";
+  const markdown = [
+    "---",
+    `repo: ${repo}`,
+    `cluster_id: ${clusterId}`,
+    `mode: ${mode}`,
+    "allowed_actions:",
+    ...yamlList(["fix", "raise_pr"]),
+    "blocked_actions:",
+    ...yamlList(["force_push", "bypass_checks", "comment", "label", "close", "merge"]),
+    "require_human_for:",
+    ...yamlList(["security_sensitive", "failing_checks", "unresolved_review_threads", "broad_code_delta"]),
+    "maintainer_calibration:",
+    ...yamlList([calibration]),
+    "canonical:",
+    ...yamlList([candidate.ref]),
+    "candidates:",
+    ...yamlList([candidate.ref]),
+    "cluster_refs:",
+    ...yamlList([candidate.ref]),
+    "expected_head_shas:",
+    ...yamlList([`${candidate.ref}=${candidate.head_sha}`]),
+    "allow_instant_close: false",
+    "allow_fix_pr: true",
+    "allow_merge: false",
+    "allow_post_merge_close: false",
+    "require_fix_before_close: false",
+    "repair_strategy: repair_contributor_branch",
+    ...(rebaseOnly ? ["rebase_only: true"] : []),
+    "security_policy: central_security_only",
+    "security_sensitive: false",
+    `canonical_hint: ${quoteYaml(
+      `${candidate.ref} is the sole canonical PR. Repair its maintainer-editable contributor branch against current main before any separate exact-head merge finalization.`,
+    )}`,
+    `notes: ${quoteYaml(
+      `Generated from live GitHub conflicting branch repair intake; profile=${candidate.repair_profile}; exact reviewed head=${candidate.head_sha}. Do not merge, close, label, comment, create a replacement PR, or expand scope.`,
+    )}`,
+    "---",
+    "",
+    `# Conflicting branch repair: ${candidate.ref}`,
+    "",
+    `Re-hydrate ${candidate.ref} and emit \`fix_needed\` plus a complete \`build_fix_artifact\` using \`repair_strategy: repair_contributor_branch\`.`,
+    "",
+    goal,
+    "",
+    "Do not merge, close, label, comment, create a replacement PR, or broaden the PR.",
+    "",
+    "## Inventory",
+    "",
+    ...candidateBlock(candidate),
+    "",
+  ].join("\n");
+
+  if (!dryRun) {
+    fs.writeFileSync(filePath, cleanGeneratedMarkdown(markdown));
+    existingConflictingRepairJobs.set(clusterId, filePath);
+  }
+  return {
+    path: path.relative(repoRoot(), filePath),
+    cluster_id: clusterId,
+    bucket: "conflicting_branch_repair",
+    candidates: [candidate.ref],
+    dry_run: dryRun,
+  };
+}
+
 function defaultBucketFor({ mode, strategy }) {
   if (checksSuccessPreflight) return "all";
   if (strategy === "remediation") return "ready_for_maintainer";
@@ -1194,6 +1449,7 @@ function candidateBlock(candidate) {
     `### ${candidate.ref} ${candidate.title}`,
     "",
     `- bucket: ${candidate.bucket}`,
+    ...(candidate.repair_profile ? [`- repair profile: ${candidate.repair_profile}`] : []),
     `- author: ${candidate.author || "unknown"}`,
     `- author association: ${candidate.author_association || "unknown"}`,
     `- draft: ${candidate.is_draft ? "yes" : "no"}`,
@@ -1214,6 +1470,41 @@ function existingMentionedRefs(roots) {
     for (const file of markdownJobFiles(root)) addStructuredJobRefs(refs, file);
   }
   return refs;
+}
+
+function conflictingRepairJobs(roots) {
+  const jobs = new Map();
+  const visited = new Set();
+  for (const root of roots) {
+    if (!fs.existsSync(root) || visited.has(root)) continue;
+    visited.add(root);
+    for (const file of markdownJobFiles(root)) {
+      try {
+        const clusterId = String(parseJob(file).frontmatter.cluster_id ?? "");
+        if (clusterId.startsWith("conflicting-branch-repair-") && !jobs.has(clusterId)) jobs.set(clusterId, file);
+      } catch {
+        // Non-job markdown does not participate in conflicting repair deduplication.
+      }
+    }
+  }
+  return jobs;
+}
+
+function publishedResultClusterIds(root, targetRepo, prefix) {
+  const clusterIds = new Set();
+  if (!fs.existsSync(root)) return clusterIds;
+  for (const entry of fs.readdirSync(root, { recursive: true })) {
+    const file = path.join(root, String(entry));
+    if (!file.endsWith(".md") || !fs.statSync(file).isFile()) continue;
+    const raw = fs.readFileSync(file, "utf8");
+    const frontmatter = raw.match(/^---\n([\s\S]*?)\n---\n?/);
+    if (!frontmatter) continue;
+    const parsed = parsePublishedResultFrontmatter(frontmatter[1]);
+    if (String(parsed.repo ?? "") !== targetRepo) continue;
+    const clusterId = String(parsed.cluster_id ?? "");
+    if (clusterId.startsWith(prefix)) clusterIds.add(clusterId);
+  }
+  return clusterIds;
 }
 
 function existingRefsForStrategy() {

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -439,6 +439,7 @@ export function validateJob(job) {
     "source",
     "commit_sha",
     "expected_head_sha",
+    "repair_strategy",
     "clawsweeper_report_repo",
     "clawsweeper_report_path",
   ]) {
@@ -451,6 +452,12 @@ export function validateJob(job) {
   }
   if (fm.expected_head_sha !== undefined && !/^[0-9a-f]{40}$/i.test(fm.expected_head_sha)) {
     errors.push("expected_head_sha must be a 40-character Git SHA");
+  }
+  if (
+    fm.repair_strategy !== undefined &&
+    !["repair_contributor_branch", "replace_uneditable_branch", "new_fix_pr"].includes(fm.repair_strategy)
+  ) {
+    errors.push("repair_strategy must be repair_contributor_branch, replace_uneditable_branch, or new_fix_pr");
   }
   if (
     fm.require_external_merge_preflight === true &&

--- a/scripts/plan-cluster.mjs
+++ b/scripts/plan-cluster.mjs
@@ -115,6 +115,7 @@ while (pending.length > 0) {
 }
 
 const itemList = [...items.values()].sort((left, right) => left.number - right.number);
+assertExpectedHeadPins(job, itemList);
 const securitySensitiveItems = itemList.filter((item) => itemSecuritySensitive(item, job));
 const plan = {
   repo: job.frontmatter.repo,
@@ -456,7 +457,9 @@ function buildFixArtifact(plan, job) {
           : "Disabled by job frontmatter.",
       canonical_fix:
         job.frontmatter.allow_fix_pr === true
-          ? "If no viable canonical PR exists, first repair a useful contributor PR when maintainer_can_modify is true. If it is false, draft/unmergeable, stale, unsafe, or too broad, replace it with fix_needed plus build_fix_artifact/open_fix_pr using repair_strategy=replace_uneditable_branch, narrow files, tests, changelog, branch_update_blockers, and source PR credit. Do not ask whether to wait when fix PRs are allowed."
+          ? job.frontmatter.repair_strategy
+            ? `Worker must use repair_strategy=${job.frontmatter.repair_strategy}. Do not substitute a replacement or new-fix strategy, even when the requested repair is blocked.`
+            : "If no viable canonical PR exists, first repair a useful contributor PR when maintainer_can_modify is true. If it is false, draft/unmergeable, stale, unsafe, or too broad, replace it with fix_needed plus build_fix_artifact/open_fix_pr using repair_strategy=replace_uneditable_branch, narrow files, tests, changelog, branch_update_blockers, and source PR credit. Do not ask whether to wait when fix PRs are allowed."
           : "Worker may identify canonical fixes but must not plan a fix PR.",
       merge:
         job.frontmatter.allow_merge === true
@@ -505,10 +508,33 @@ function snapshotSourceJobPolicy(job) {
     allow_fix_pr: job.frontmatter.allow_fix_pr === true,
     allow_merge: job.frontmatter.allow_merge === true,
     require_external_merge_preflight: job.frontmatter.require_external_merge_preflight === true,
+    repair_strategy: job.frontmatter.repair_strategy ?? null,
+    rebase_only: job.frontmatter.rebase_only === true,
+    expected_head_shas: [...(job.frontmatter.expected_head_shas ?? [])],
     maintainer_calibration: Array.isArray(job.frontmatter.maintainer_calibration)
       ? [...job.frontmatter.maintainer_calibration]
       : [],
   };
+}
+
+function assertExpectedHeadPins(job, items) {
+  const expected = new Map();
+  for (const entry of job.frontmatter.expected_head_shas ?? []) {
+    const match = String(entry).match(/^(#[0-9]+)=([0-9a-f]{40})$/i);
+    if (match) expected.set(match[1], match[2].toLowerCase());
+  }
+  if (expected.size === 0) return;
+
+  const byRef = new Map(items.map((item) => [item.ref, item]));
+  for (const [ref, expectedSha] of expected) {
+    const actualSha = String(byRef.get(ref)?.pull_request?.head_sha ?? "").toLowerCase();
+    if (!actualSha) {
+      throw new Error(`${ref} expected head ${expectedSha} could not be verified during live hydration`);
+    }
+    if (actualSha !== expectedSha) {
+      throw new Error(`${ref} head changed after intake: expected ${expectedSha}, found ${actualSha}`);
+    }
+  }
 }
 
 function canonicalCandidates(items, job) {

--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -318,6 +318,7 @@ function reviewResult(resultPath) {
     }
     validateFixActionPermissions(sourceJobPolicy, fixActions, failures);
     validateFixArtifact(result.fix_artifact, failures);
+    validatePinnedFixPolicy(sourceJobPolicy, result.fix_artifact, failures);
     validateExecutableFixTargetLabels({
       fixActions,
       fixArtifact: result.fix_artifact,
@@ -786,6 +787,42 @@ function validateFixArtifact(fixArtifact, failures) {
   }
 }
 
+function validatePinnedFixPolicy(sourceJobPolicy, fixArtifact, failures) {
+  const requiredStrategy = String(sourceJobPolicy?.repair_strategy ?? "");
+  if (requiredStrategy && fixArtifact?.repair_strategy !== requiredStrategy) {
+    failures.push(
+      `fix_artifact.repair_strategy must match source job policy: expected ${requiredStrategy}, found ${String(fixArtifact?.repair_strategy ?? "missing")}`,
+    );
+  }
+  if (sourceJobPolicy?.rebase_only === true && fixArtifact?.repair_strategy !== "repair_contributor_branch") {
+    failures.push("rebase-only source jobs require fix_artifact.repair_strategy=repair_contributor_branch");
+  }
+  if (requiredStrategy !== "repair_contributor_branch") return;
+
+  const sourceRefs = [...new Set((fixArtifact?.source_prs ?? []).map(normalizeRef).filter(Boolean))];
+  const canonicalRefs = [...new Set((sourceJobPolicy?.canonical ?? []).map(normalizeRef).filter(Boolean))];
+  const pinnedRefs = [
+    ...new Set(
+      (sourceJobPolicy?.expected_head_shas ?? [])
+        .map((entry) => String(entry).match(/^(#[0-9]+)=([0-9a-f]{40})$/i)?.[1] ?? "")
+        .filter(Boolean),
+    ),
+  ];
+  if (canonicalRefs.length === 1 && (sourceRefs.length !== 1 || sourceRefs[0] !== canonicalRefs[0])) {
+    failures.push(
+      `repair_contributor_branch source_prs must contain only the canonical PR ${canonicalRefs[0]}`,
+    );
+  }
+  if (
+    pinnedRefs.length > 0 &&
+    (sourceRefs.length !== pinnedRefs.length || pinnedRefs.some((ref) => !sourceRefs.includes(ref)))
+  ) {
+    failures.push(
+      `repair_contributor_branch source_prs must exactly match expected_head_shas refs: ${pinnedRefs.join(", ")}`,
+    );
+  }
+}
+
 function validateExecutableFixTargetLabels({ fixActions, fixArtifact, itemByRef, sourceJobPolicy, failures }) {
   if (!EXECUTABLE_FIX_REPAIR_STRATEGIES.has(fixArtifact?.repair_strategy)) return;
 
@@ -920,6 +957,13 @@ function readSourceJobPolicySnapshot(plan) {
     typeof permissions.allow_merge !== "boolean" ||
     (permissions.require_external_merge_preflight !== undefined &&
       typeof permissions.require_external_merge_preflight !== "boolean") ||
+    (permissions.repair_strategy !== undefined &&
+      permissions.repair_strategy !== null &&
+      typeof permissions.repair_strategy !== "string") ||
+    (permissions.rebase_only !== undefined && typeof permissions.rebase_only !== "boolean") ||
+    (permissions.expected_head_shas !== undefined &&
+      (!Array.isArray(permissions.expected_head_shas) ||
+        !permissions.expected_head_shas.every((entry) => typeof entry === "string"))) ||
     !Array.isArray(permissions.maintainer_calibration) ||
     !permissions.maintainer_calibration.every((entry) => typeof entry === "string") ||
     (permissions.source !== undefined && permissions.source !== null && typeof permissions.source !== "string") ||

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -269,6 +269,119 @@ test("execute-fix-artifact permits ClawSweeper automerge labels only for the ado
   );
 });
 
+test("execute-fix-artifact blocks a contributor repair when the pinned head changed", () => {
+  const fixture = makeFixture();
+  const clusterId = "pinned-head-drift";
+  const expected = "a".repeat(40);
+  const live = "b".repeat(40);
+  const resultPath = path.join(fixture.runDir, "result.json");
+  const reportPath = path.join(fixture.runDir, "fix-execution-report.json");
+  const ghLog = path.join(fixture.root, "gh.log");
+
+  fs.writeFileSync(
+    fixture.jobPath,
+    jobFile(clusterId).replace(
+      "security_sensitive: false",
+      `security_sensitive: false\nrepair_strategy: repair_contributor_branch\nexpected_head_shas:\n  - "#1=${expected}"`,
+    ),
+  );
+  const result = resultFile(clusterId);
+  result.actions = [{ action: "fix_needed", status: "planned", target: "#1" }];
+  result.fix_artifact.repair_strategy = "repair_contributor_branch";
+  result.fix_artifact.source_prs = ["https://github.com/openclaw/openclaw/pull/1"];
+  fs.writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`);
+  writeLiveTargetPolicyGhStub({ binDir: fixture.binDir, ghLog, labels: [], headSha: live });
+
+  const child = spawnSync(
+    process.execPath,
+    [
+      "scripts/execute-fix-artifact.mjs",
+      fixture.jobPath,
+      resultPath,
+      "--target-dir",
+      fixture.targetDir,
+      "--work-dir",
+      fixture.workDir,
+      "--report",
+      reportPath,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+        CLOWNFISH_ALLOW_EXECUTE: "1",
+        CLOWNFISH_ALLOW_FIX_PR: "1",
+      },
+    },
+  );
+
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.equal(report.no_target_mutations, true);
+  assert.equal(report.actions[0].code, "expected_head_mismatch");
+  assert.match(report.reason, new RegExp(`expected ${expected}, found ${live}`));
+});
+
+test("execute-fix-artifact blocks a pinned contributor repair targeting another PR", () => {
+  const fixture = makeFixture();
+  const clusterId = "pinned-source-mismatch";
+  const expected = "a".repeat(40);
+  const resultPath = path.join(fixture.runDir, "result.json");
+  const reportPath = path.join(fixture.runDir, "fix-execution-report.json");
+
+  fs.writeFileSync(
+    fixture.jobPath,
+    jobFile(clusterId)
+      .replace("canonical: []", 'canonical:\n  - "#1"')
+      .replace(
+        "security_sensitive: false",
+        `security_sensitive: false\nrepair_strategy: repair_contributor_branch\nexpected_head_shas:\n  - "#1=${expected}"`,
+      ),
+  );
+  const result = resultFile(clusterId);
+  result.actions = [{ action: "fix_needed", status: "planned", target: "#1" }];
+  result.fix_artifact.repair_strategy = "repair_contributor_branch";
+  result.fix_artifact.source_prs = ["https://github.com/openclaw/openclaw/pull/2"];
+  fs.writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`);
+
+  const child = spawnSync(
+    process.execPath,
+    [
+      "scripts/execute-fix-artifact.mjs",
+      fixture.jobPath,
+      resultPath,
+      "--target-dir",
+      fixture.targetDir,
+      "--work-dir",
+      fixture.workDir,
+      "--report",
+      reportPath,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+        CLOWNFISH_ALLOWED_OWNER: "openclaw",
+        CLOWNFISH_ALLOW_EXECUTE: "1",
+        CLOWNFISH_ALLOW_FIX_PR: "1",
+      },
+    },
+  );
+
+  assert.equal(child.status, 0, child.stderr || child.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.status, "blocked");
+  assert.equal(report.no_target_mutations, true);
+  assert.equal(report.actions[0].code, "repair_source_mismatch");
+  assert.match(report.reason, /source must be canonical #1; received #2/);
+});
+
 test("execute-fix-artifact permits non-security merge-risk labels for the adopted automerge repair target", () => {
   const fixture = makeFixture();
   const clusterId = "live-target-policy-adopted-risk";
@@ -650,7 +763,7 @@ test("execute-fix-artifact makes rebase-only repair a no-generated-edit path", (
   assert.match(source, /if \(!allowReviewFixes \|\| reviewAttempts === maxReviewAttempts\) break;/);
   assert.match(
     source,
-    /if \(rebaseOnlyRepair\) \{\s*const reason = `rebase-only repair stopped: \$\{error\.message\}`;[\s\S]*?outcome = \{\s*\.{3}blockedFixOutcome\(error, fixArtifact\),\s*action: "repair_contributor_branch",/,
+    /if \(rebaseOnlyRepair \|\| requiredRepairStrategy === "repair_contributor_branch"\) \{[\s\S]*?`rebase-only repair stopped: \$\{error\.message\}`[\s\S]*?outcome = \{\s*\.{3}blockedFixOutcome\(error, fixArtifact\),\s*action: "repair_contributor_branch",/,
   );
   assert.match(source, /rebase-only repair does not resolve review threads/);
   assert.match(source, /if \(!rebaseOnly\) \{\s*const comment = repairContributorBranchComment/);
@@ -1792,7 +1905,7 @@ process.exit(child.status ?? 1);
   );
 }
 
-function writeLiveTargetPolicyGhStub({ binDir, ghLog, labels }) {
+function writeLiveTargetPolicyGhStub({ binDir, ghLog, labels, headSha = null }) {
   writeExecutable(
     path.join(binDir, "gh"),
     `#!/usr/bin/env node
@@ -1800,7 +1913,10 @@ const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(ghLog)}, args.join(" ") + "\\n");
 if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/pulls/1") {
-  console.log(JSON.stringify({ labels: ${JSON.stringify(labels)}.map((name) => ({ name })) }));
+  console.log(JSON.stringify({
+    labels: ${JSON.stringify(labels)}.map((name) => ({ name })),
+    head: ${JSON.stringify(headSha)} ? { sha: ${JSON.stringify(headSha)} } : undefined
+  }));
   process.exit(0);
 }
 console.error("unexpected gh call: " + args.join(" "));

--- a/test/import-github-pr-inventory.test.mjs
+++ b/test/import-github-pr-inventory.test.mjs
@@ -298,6 +298,113 @@ test("remediation inventory routes opted-in merge-risk candidates to repair-only
   assert.match(job, /Do not emit `merge_candidate`/);
 });
 
+test("remediation inventory emits exact-head singleton conflicting branch repair jobs", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.gh, { includeConflictingBranchRepairPrList: true });
+
+  const result = runImport(
+    fixture,
+    "--write",
+    "--strategy",
+    "remediation",
+    "--inventory-source",
+    "pr-list",
+    "--bucket",
+    "conflicting_branch_repair",
+    "--batch-size",
+    "5",
+    "--skip-existing",
+    "false",
+    "--limit",
+    "all",
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const payload = JSON.parse(result.stdout);
+
+  assert.deepEqual(
+    payload.candidates.map((candidate) => [candidate.ref, candidate.repair_profile]),
+    [
+      ["#130", "rebase_only"],
+      ["#131", "review_fix"],
+      ["#132", "review_fix"],
+      ["#138", "rebase_only"],
+    ],
+  );
+  assert.equal(payload.options.batch_size, 1);
+  assert.equal(payload.generated.length, 4);
+  assert.equal(payload.generated.every((item) => item.candidates.length === 1), true);
+
+  const rebaseJob = fs.readFileSync(path.join(fixture.out, path.basename(payload.generated[0].path)), "utf8");
+  assert.match(rebaseJob, /canonical:\n  - "#130"/);
+  assert.match(rebaseJob, /expected_head_shas:\n  - "#130=[0-9a-f]{40}"/);
+  assert.match(rebaseJob, /repair_strategy: repair_contributor_branch/);
+  assert.match(rebaseJob, /rebase_only: true/);
+  assert.match(rebaseJob, /maintainer_calibration:/);
+  assert.match(rebaseJob, /profile=rebase_only/);
+
+  const reviewFixJob = fs.readFileSync(path.join(fixture.out, path.basename(payload.generated[2].path)), "utf8");
+  assert.match(reviewFixJob, /canonical:\n  - "#132"/);
+  assert.doesNotMatch(reviewFixJob, /rebase_only: true/);
+  assert.match(reviewFixJob, /exact-current-head actionable ClawSweeper finding/);
+  assert.match(reviewFixJob, /profile=review_fix/);
+
+  const refs = new Set(payload.candidates.map((candidate) => candidate.ref));
+  for (const skipped of ["#133", "#134", "#135", "#136", "#137"]) {
+    assert.equal(refs.has(skipped), false, skipped);
+  }
+
+  const rerun = runImport(
+    fixture,
+    "--write",
+    "--strategy",
+    "remediation",
+    "--inventory-source",
+    "pr-list",
+    "--bucket",
+    "conflicting_branch_repair",
+    "--batch-size",
+    "5",
+    "--skip-existing",
+    "false",
+    "--limit",
+    "all",
+  );
+  assert.equal(rerun.status, 0, rerun.stderr || rerun.stdout);
+  const retryPayload = JSON.parse(rerun.stdout);
+  assert.equal(retryPayload.generated.length, 4);
+  assert.equal(retryPayload.generated.every((item) => item.retry === true), true);
+
+  for (const item of payload.generated) {
+    fs.writeFileSync(
+      path.join(fixture.results, `${item.cluster_id}.md`),
+      `---
+repo: "openclaw/openclaw"
+cluster_id: "${item.cluster_id}"
+mode: "autonomous"
+---
+`,
+    );
+  }
+  const completedRerun = runImport(
+    fixture,
+    "--write",
+    "--strategy",
+    "remediation",
+    "--inventory-source",
+    "pr-list",
+    "--bucket",
+    "conflicting_branch_repair",
+    "--batch-size",
+    "5",
+    "--skip-existing",
+    "false",
+    "--limit",
+    "all",
+  );
+  assert.equal(completedRerun.status, 0, completedRerun.stderr || completedRerun.stdout);
+  assert.equal(JSON.parse(completedRerun.stdout).generated.length, 0);
+});
+
 test("remediation inventory can hydrate only included refs", () => {
   const fixture = makeFixture();
   writeFakeGh(fixture.gh, { failPrList: true, includeRiskPrList: true });
@@ -1098,6 +1205,19 @@ function writeFakeGh(filePath, options = {}) {
     mergeable: "CONFLICTING",
     mergeStateStatus: "DIRTY",
   };
+  const conflictingRepairPulls = options.includeConflictingBranchRepairPrList
+    ? makeConflictingBranchRepairPulls(cleanPrListPull)
+    : [];
+  if (conflictingRepairPulls.length > 0) {
+    searchPulls.push(
+      ...conflictingRepairPulls.map((pull) => ({
+        ...pull,
+        labels: pull.labels,
+        assignees: pull.assignees,
+        commentsCount: pull.commentsCount,
+      })),
+    );
+  }
   if (options.includeChecksSuccessPreflight) {
     searchPulls.push(
       ...[
@@ -1132,6 +1252,7 @@ function writeFakeGh(filePath, options = {}) {
           conflictingChecksSuccessPull,
         ]
       : []),
+    ...conflictingRepairPulls,
     cleanPrListPull,
   ];
   fs.writeFileSync(
@@ -1219,6 +1340,110 @@ console.log(JSON.stringify(payload));
 `,
     { mode: 0o755 },
   );
+}
+
+function makeConflictingBranchRepairPulls(base) {
+  const pull = (number, overrides = {}) => {
+    const headSha = String.fromCharCode(97 + (number % 6)).repeat(40);
+    return {
+      ...base,
+      id: `PR_${number}`,
+      number,
+      title: `conflicting repair candidate ${number}`,
+      url: `https://github.com/openclaw/openclaw/pull/${number}`,
+      updatedAt: `2026-02-${String(number - 120).padStart(2, "0")}T00:00:00Z`,
+      headRefOid: headSha,
+      mergeable: "CONFLICTING",
+      mergeStateStatus: "DIRTY",
+      maintainerCanModify: true,
+      labels: [{ name: "proof: sufficient" }, { name: "status: ready for maintainer look" }],
+      comments: [],
+      commentsCount: 0,
+      ...overrides,
+    };
+  };
+  const readyComment = (number, headSha) => ({
+    author: { login: "clawsweeper[bot]" },
+    body: [
+      "Codex review: needs maintainer review before merge.",
+      "",
+      "**Review metrics:** none identified.",
+      "Result: ready for maintainer review.",
+      "No ClawSweeper repair lane is needed; the remaining action is normal maintainer review.",
+      "",
+      `<!-- clawsweeper-verdict:needs-human item=${number} sha=${headSha} confidence=high -->`,
+      `<!-- clawsweeper-review item=${number} -->`,
+    ].join("\n"),
+  });
+  const fixComment = (number, headSha) => ({
+    author: { login: "clawsweeper[bot]" },
+    body: [
+      "Codex review: changes required before merge.",
+      `<!-- clawsweeper-verdict:needs-changes item=${number} sha=${headSha} confidence=high -->`,
+      `<!-- clawsweeper-action:fix-required item=${number} sha=${headSha} confidence=high finding=review-feedback -->`,
+      `<!-- clawsweeper-review item=${number} -->`,
+    ].join("\n"),
+  });
+
+  const ready = pull(130);
+  ready.comments = [readyComment(ready.number, ready.headRefOid)];
+  ready.commentsCount = ready.comments.length;
+
+  const actionable = pull(131);
+  actionable.comments = [fixComment(actionable.number, actionable.headRefOid)];
+  actionable.commentsCount = actionable.comments.length;
+
+  const both = pull(132);
+  both.comments = [
+    readyComment(both.number, both.headRefOid),
+    fixComment(both.number, both.headRefOid),
+  ];
+  both.commentsCount = both.comments.length;
+
+  const stale = pull(133);
+  stale.comments = [fixComment(stale.number, "f".repeat(40))];
+  stale.commentsCount = stale.comments.length;
+
+  const malformed = pull(134);
+  malformed.comments = [
+    {
+      author: { login: "clawsweeper[bot]" },
+      body: `<!-- clawsweeper-action:fix-required item=134 sha=${malformed.headRefOid} confidence=high confidence=low -->`,
+    },
+  ];
+  malformed.commentsCount = malformed.comments.length;
+
+  const unwritable = pull(135, { maintainerCanModify: false });
+  unwritable.comments = [readyComment(unwritable.number, unwritable.headRefOid)];
+  unwritable.commentsCount = unwritable.comments.length;
+
+  const needsHumanOnly = pull(136);
+  needsHumanOnly.comments = [
+    {
+      author: { login: "clawsweeper[bot]" },
+      body: `<!-- clawsweeper-verdict:needs-human item=136 sha=${needsHumanOnly.headRefOid} confidence=high -->`,
+    },
+  ];
+  needsHumanOnly.commentsCount = needsHumanOnly.comments.length;
+
+  const security = pull(137, { labels: [{ name: "security" }] });
+  security.comments = [fixComment(security.number, security.headRefOid)];
+  security.commentsCount = security.comments.length;
+
+  const supersededFinding = pull(138);
+  supersededFinding.comments = [
+    {
+      ...fixComment(supersededFinding.number, supersededFinding.headRefOid),
+      updatedAt: "2026-02-01T00:00:00Z",
+    },
+    {
+      ...readyComment(supersededFinding.number, supersededFinding.headRefOid),
+      updatedAt: "2026-02-02T00:00:00Z",
+    },
+  ];
+  supersededFinding.commentsCount = supersededFinding.comments.length;
+
+  return [ready, actionable, both, stale, malformed, unwritable, needsHumanOnly, security, supersededFinding];
 }
 
 function readFakeGhCalls(fixture) {

--- a/test/lib.test.mjs
+++ b/test/lib.test.mjs
@@ -105,6 +105,29 @@ candidates:
   ]);
 });
 
+test("validateJob rejects an unsupported pinned repair strategy", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-job-repair-strategy-"));
+  const jobPath = path.join(tmp, "job.md");
+  fs.writeFileSync(
+    jobPath,
+    `---
+repo: openclaw/openclaw
+cluster_id: repair-strategy
+mode: autonomous
+repair_strategy: improvise
+allowed_actions:
+  - fix
+candidates:
+  - "#1"
+---
+`,
+  );
+
+  assert.deepEqual(validateJob(parseJob(jobPath)), [
+    "repair_strategy must be repair_contributor_branch, replace_uneditable_branch, or new_fix_pr",
+  ]);
+});
+
 test("validateJob requires merge permission for deterministic external preflight", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-job-external-preflight-"));
   const jobPath = path.join(tmp, "job.md");

--- a/test/plan-cluster.test.mjs
+++ b/test/plan-cluster.test.mjs
@@ -107,6 +107,9 @@ canonical:
     allow_fix_pr: false,
     allow_merge: false,
     require_external_merge_preflight: false,
+    repair_strategy: null,
+    rebase_only: false,
+    expected_head_shas: [],
     maintainer_calibration: ["Require a planned fix or merge for an open canonical PR."],
   });
   assert.equal(candidate.kind, "pull_request");
@@ -151,4 +154,81 @@ security_signal_refs:
   const contextPlan = JSON.parse(fs.readFileSync(path.join(contextRunDir, "cluster-plan.json"), "utf8"));
   assert.deepEqual(contextPlan.scope.read_only_context_refs, ["#2"]);
   assert.ok(contextPlan.items.some((item) => item.ref === "#2"));
+});
+
+test("plan-cluster rejects a PR whose live head drifted after intake", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-plan-head-pin-"));
+  const binDir = path.join(tmp, "bin");
+  const runDir = path.join(tmp, "run");
+  fs.mkdirSync(binDir, { recursive: true });
+  const expected = "a".repeat(40);
+  const live = "b".repeat(40);
+
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const apiPath = args[1];
+if (apiPath === "repos/openclaw/openclaw/branches/main") {
+  console.log(JSON.stringify({ commit: { sha: "abc123" }, _links: { html: "https://github.com/openclaw/openclaw/tree/main" } }));
+} else if (apiPath === "repos/openclaw/openclaw/issues/2") {
+  console.log(JSON.stringify({
+    state: "open",
+    title: "candidate pr",
+    html_url: "https://github.com/openclaw/openclaw/pull/2",
+    user: { login: "contributor" },
+    labels: [],
+    body: "candidate body",
+    comments: 0,
+    pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/2" }
+  }));
+} else if (apiPath === "repos/openclaw/openclaw/pulls/2") {
+  console.log(JSON.stringify({
+    state: "open",
+    draft: false,
+    merged: false,
+    base: { ref: "main" },
+    head: { ref: "fix", sha: ${JSON.stringify(live)}, repo: { full_name: "contributor/openclaw", owner: { login: "contributor" } } },
+    user: { login: "contributor" },
+    labels: [],
+    requested_reviewers: [],
+    requested_teams: []
+  }));
+} else {
+  console.log("[]");
+}
+`,
+  );
+  fs.chmodSync(ghPath, 0o755);
+
+  const jobPath = path.join(tmp, "job.md");
+  fs.writeFileSync(
+    jobPath,
+    `---
+repo: openclaw/openclaw
+cluster_id: pinned-head
+mode: autonomous
+allowed_actions:
+  - fix
+candidates:
+  - "#2"
+expected_head_shas:
+  - "#2=${expected}"
+---
+`,
+  );
+
+  const result = spawnSync("node", ["scripts/plan-cluster.mjs", jobPath, "--run-dir", runDir], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      CLOWNFISH_HYDRATE_COMMENTS: "0",
+    },
+    encoding: "utf8",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, new RegExp(`#2 head changed after intake: expected ${expected}, found ${live}`));
 });

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -250,6 +250,30 @@ test("daily checks-success intake feeds guarded external merge preflights", () =
   assert.match(intakeWorkflow, /git commit -m "chore: add daily checks-success preflight jobs"/);
   assert.match(intakeWorkflow, /gh workflow run external-merge-preflight\.yml/);
   assert.match(intakeWorkflow, /-f "apply=\$\{apply\}"/);
+  assert.match(intakeWorkflow, /--bucket conflicting_branch_repair/);
+  assert.match(intakeWorkflow, /CLOWNFISH_CONFLICTING_BRANCH_REPAIR_LIMIT \|\| '5'/);
+  assert.match(intakeWorkflow, /--skip-existing false/);
+  assert.match(intakeWorkflow, /--search-limit 100/);
+  assert.match(intakeWorkflow, /--batch-size 1/);
+  assert.match(intakeWorkflow, /gh workflow run cluster-worker\.yml/);
+  assert.match(intakeWorkflow, /-f "mode=autonomous"/);
+  assert.match(intakeWorkflow, /-f "execution_runner=\$\{REPAIR_EXECUTION_RUNNER\}"/);
+  assert.match(intakeWorkflow, /repair_runner:[\s\S]*?default: blacksmith-4vcpu-ubuntu-2404/);
+  assert.match(intakeWorkflow, /execution_runner:[\s\S]*?default: blacksmith-16vcpu-ubuntu-2404/);
+  assert.match(
+    intakeWorkflow,
+    /REPAIR_RUNNER: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.repair_runner \|\| vars\.CLOWNFISH_WORKER_RUNNER \|\| 'blacksmith-4vcpu-ubuntu-2404' \}\}/,
+  );
+  assert.match(
+    intakeWorkflow,
+    /REPAIR_EXECUTION_RUNNER: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.execution_runner \|\| vars\.CLOWNFISH_EXECUTION_RUNNER \|\| 'blacksmith-16vcpu-ubuntu-2404' \}\}/,
+  );
+  assert.match(
+    intakeWorkflow,
+    /if \[ "\$\{\{ github\.event_name \}\}" = "workflow_dispatch" \]; then\s+apply="\$\{\{ inputs\.apply \}\}"/,
+  );
+  assert.doesNotMatch(intakeWorkflow, /APPLY: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.apply \|\|/);
+  assert.match(intakeWorkflow, /dispatch_failed=0[\s\S]*?if ! gh workflow run cluster-worker\.yml[\s\S]*?dispatch_failed=1[\s\S]*?exit "\$dispatch_failed"/);
 });
 
 test("external merge preflight emits an applicator-valid exact-head merge artifact", () => {

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -2115,6 +2115,67 @@ test("review-results rejects incomplete permission snapshots after source job re
   assert.match(result.stdout, /fix actions require source job permissions/);
 });
 
+test("review-results rejects a fix artifact that changes the source job repair strategy", () => {
+  const dir = makeResultDir(
+    {
+      mode: "autonomous",
+      actions: [plannedBuildFixArtifact()],
+      fix_artifact: validFixArtifact({ repair_strategy: "new_fix_pr" }),
+    },
+    {
+      job: fixEnabledJob().replace(
+        "allow_fix_pr: true",
+        "allow_fix_pr: true\nrepair_strategy: repair_contributor_branch",
+      ),
+      plan: {
+        items: [],
+      },
+    },
+  );
+
+  const result = review(dir);
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stdout,
+    /fix_artifact\.repair_strategy must match source job policy: expected repair_contributor_branch, found new_fix_pr/,
+  );
+});
+
+test("review-results rejects a pinned contributor repair targeting another PR", () => {
+  const expected = "a".repeat(40);
+  const dir = makeResultDir(
+    {
+      mode: "autonomous",
+      actions: [plannedBuildFixArtifact()],
+      fix_artifact: validFixArtifact({
+        repair_strategy: "repair_contributor_branch",
+        source_prs: ["https://github.com/openclaw/openclaw/pull/38830"],
+      }),
+    },
+    {
+      job: fixEnabledJob()
+        .replace(
+          "candidates:\n  - \"#38829\"",
+          `canonical:\n  - "#38829"\ncandidates:\n  - "#38829"\nexpected_head_shas:\n  - "#38829=${expected}"`,
+        )
+        .replace(
+          "allow_fix_pr: true",
+          "allow_fix_pr: true\nrepair_strategy: repair_contributor_branch",
+        ),
+      plan: {
+        items: [],
+      },
+    },
+  );
+
+  const result = review(dir);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /repair_contributor_branch source_prs must contain only the canonical PR #38829/);
+  assert.match(result.stdout, /repair_contributor_branch source_prs must exactly match expected_head_shas refs: #38829/);
+});
+
 test("review-results enforces calibrated canonical finalization after source job removal", () => {
   const dir = makeResultDir(
     {


### PR DESCRIPTION
## Summary
- add a bounded daily lane for stale maintainer-editable PRs with conflicting branches
- pin jobs to the exact PR head and require contributor-branch repair throughout planning, review, and execution
- make stable jobs safely retryable after dispatch failures and keep dispatching independent jobs
- separate external preflight, repair, and execution runner inputs

## Safety
- refuses stale heads, source-PR substitution, strategy substitution, security-risk targets, and unpinned repairs
- never falls back to a replacement PR for this lane
- serializes each PR/head through a stable job path and retains force-with-lease as the final write guard

## Validation
- 165 affected importer/planner/reviewer/executor tests passed
- 134 external preflight/workflow tests passed
- post-rebase daily intake workflow test passed
- `npm run validate` passed for 6,661 jobs
- final independent review found no blockers