### PR TITLE
chore(ops): add current-head Clownfish canaries

### DIFF
--- a/jobs/openclaw/inbox/live-pr-inventory-20260711T100648-001.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260711T100648-001.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260711T100648-001
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#103731"
+cluster_refs:
+  - "#103731"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-11T10:06:48.815Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 1
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #103731 fix(plugins): honor empty document extractor scope
+
+- bucket: ready_for_maintainer
+- author: llagy007
+- author association: unknown
+- draft: no
+- assignees: none
+- labels: size: S, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-07-11T09:53:52Z
+- live url: https://github.com/openclaw/openclaw/pull/103731

--- a/jobs/openclaw/inbox/live-pr-inventory-20260711T101300-002.md
+++ b/jobs/openclaw/inbox/live-pr-inventory-20260711T101300-002.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-inventory-20260711T101300-002
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#103728"
+cluster_refs:
+  - "#103728"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "This is a fresh PR remediation inventory shard. Classify each PR independently. A complete merge preflight is required only for a merge recommendation; a repair requires a complete executable fix artifact."
+notes: "Generated from live GitHub open PR inventory on 2026-07-11T10:13:00.000Z; bucket=ready_for_maintainer; autonomous remediation assessment. Mutations are limited to deterministic merge/fix gates."
+---
+
+# PR Remediation Inventory 2
+
+This is a high-volume autonomous remediation shard over fresh maintainer-ready pull requests.
+
+## Goal
+
+Hydrate live GitHub state for each listed PR and produce a current finalization path. Emit `merge_candidate` only with a complete merge preflight. If a PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight. Missing merge preflight alone is not a `needs_human` reason. Emit bounded `fix_needed` plus `build_fix_artifact` and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`; otherwise classify the PR `keep_related` or `keep_independent`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive PRs centrally. In autonomous mode, the deterministic applicator/executor owns the actual merge or fix PR mutation after re-fetching live state and enforcing merge preflight.
+
+## Inventory
+
+### #103728 fix(memory): skip blank search provider bootstrap
+
+- bucket: ready_for_maintainer
+- author: llagy007
+- author association: unknown
+- draft: no
+- assignees: none
+- labels: extensions: memory-core, size: S, proof: sufficient, P2, rating: diamond lobster, status: ready for maintainer look
+- live updated: 2026-07-11T09:54:36Z
+- live url: https://github.com/openclaw/openclaw/pull/103728


### PR DESCRIPTION
## Summary

- add singleton autonomous canaries for openclaw/openclaw#103731 and #103728
- keep each remediation lane isolated for artifact review before scaling

## Validation

- `npm run validate`
- `git diff --check`