### PR TITLE
fix(preflight): accept contributor proof comments

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -2790,11 +2790,15 @@ function isAuthorProofOrStatusComment(body) {
   const hasStatusLead = contentLines.some((line) =>
     [
       /^(?:rebas(?:ed|ing)|re-ran|reran|ran|verified|validated|updated|added|addressed|resolved|fixed|tested)\b/,
+      /^(?:branch|the branch|this branch)\s+(?:refreshed|rebased|updated)\b/,
+      /^(?:please\s+)?re-review current head\s+`?[0-9a-f]{7,40}`?\b/,
       /^(?:this|the (?:change|patch|pr))\s+(?:fixes|adds|updates|preserves|addresses)\b/,
     ].some((pattern) => pattern.test(line)),
   );
   const hasProofHeading = contentLines.some((line) =>
-    /^(?:real behavior proof|proof|validation|verification|test results|current status|status):?$/.test(line),
+    /^(?:real behavior proof|behavior proof follow-up(?: for the clawsweeper note)?|proof|validation|verification|test results|current status|status):?$/.test(
+      line,
+    ),
   );
   const hasRealBehaviorProofHeading = contentLines.some((line) => /^real behavior proof:?$/.test(line));
   const hasEvidenceDetail = lines.some(

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -1178,6 +1178,67 @@ test("external merge preflight accepts the objection-loop control proof", () => 
   assert.equal(report.status, "passed", report.reason);
 });
 
+test("external merge preflight accepts author behavior proof follow-up comments", () => {
+  const fixture = makeFixture({
+    pullUser: { login: "contributor" },
+    issueComments: [
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        body: [
+          "Behavior proof follow-up for the ClawSweeper note:",
+          "",
+          "- Focused command: `node scripts/run-vitest.mjs src/plugins/document-extractors.runtime.test.ts`",
+          "- Result: passed locally, 1 test file / 5 tests.",
+          "- Regression assertion: an explicit empty allowlist resolves to no extractors.",
+          "- Scope: local document extractor resolver; no live service or key required.",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "passed", report.reason);
+});
+
+test("external merge preflight accepts author exact-head re-review status comments", () => {
+  const headSha = "a".repeat(40);
+  const fixture = makeFixture({
+    headSha,
+    pullUser: { login: "contributor" },
+    issueComments: [
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        body: [
+          "@clawsweeper re-review",
+          "",
+          "Branch refreshed onto the merged CI baseline fix at upstream/main.",
+          "The review finding was addressed with shared resolver and regression proof.",
+          "",
+          `Latest head: ${headSha}`,
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
+      },
+      {
+        author: { login: "contributor" },
+        authorAssociation: "CONTRIBUTOR",
+        body: [
+          "@clawsweeper re-review",
+          "",
+          `Please re-review current head \`${headSha}\`.`,
+          "The PR evidence includes controlled proof showing the blank query returns before provider bootstrap.",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-2",
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "passed", report.reason);
+});
+
 for (const objection of [
   "Known failure: valid listeners are skipped on Alpine.",
   "- Invalid listener records are accepted.",


### PR DESCRIPTION
## Summary

- treat structured pull-author behavior proof follow-ups as non-blocking evidence
- accept exact-head ClawSweeper re-review status comments when they contain proof and no objection
- keep maintainer asks, security concerns, failures, and author objections blocking

## Regression

Reproduces the false blockers from current-head canary runs:
- https://github.com/openclaw/clownfish/actions/runs/29149137884
- https://github.com/openclaw/clownfish/actions/runs/29149141235

## Validation

- `node --test test/preflight-external-pr-merge.test.mjs` (136/136)
- `npm run validate`
- `node --check scripts/preflight-external-pr-merge.mjs`
- `git diff --check`