### PR TITLE
fix(merge): stabilize adopted branch refresh

### DIFF
--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -489,7 +489,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
     };
   }
   const liveHeadSha = String(pullRequest.head?.sha ?? "");
-  if (liveHeadSha !== expectedHeadSha) {
+  if (!mergedAt && liveHeadSha !== expectedHeadSha) {
     return {
       ...base,
       status: "blocked",
@@ -524,11 +524,28 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       expectedHeadSha,
       preflight: findMergePreflight(result, target),
     });
+    const authorizedMergeHeadSha =
+      replayBinding?.merge_head_sha ?? expectedHeadSha;
+    if (liveHeadSha.toLowerCase() !== authorizedMergeHeadSha.toLowerCase()) {
+      return {
+        ...base,
+        status: "blocked",
+        reason: "merged pull request head does not match the authorized merge head",
+        expected_head_sha: expectedHeadSha,
+        authorized_merge_head_sha: authorizedMergeHeadSha,
+        live_head_sha: liveHeadSha || null,
+        live_state: "merged",
+        live_updated_at: live.updated_at,
+        merged_at: mergedAt,
+        merge_commit_sha: pullRequest.merge_commit_sha ?? view.mergeCommit?.oid ?? null,
+      };
+    }
     const mergedProof = verifyActualMergedCommit({
       result,
       action,
       target,
       expectedHeadSha,
+      mergeHeadSha: authorizedMergeHeadSha,
       pullRequest,
       effectiveDiffBinding: replayBinding,
     });
@@ -1310,15 +1327,15 @@ function verifyExternalMergeBinding({
             ? "GitHub test merge commit is not based on the current main SHA"
             : "GitHub test merge commit is not based on the reviewed main SHA";
           if (mergeHeadSha.toLowerCase() === expectedHeadSha.toLowerCase()) {
+            staleTestMerge = {
+              merge_commit_sha: mergeCommitSha.toLowerCase(),
+              merge_base_sha: mergeBaseSha.toLowerCase(),
+              merge_head_sha: mergeHeadSha.toLowerCase(),
+            };
             if (adoptingNewerMain) {
               lastProblem = "awaiting_adopted_test_merge";
             } else {
               lastProblem = "stale_test_merge";
-              staleTestMerge = {
-                merge_commit_sha: mergeCommitSha.toLowerCase(),
-                merge_base_sha: mergeBaseSha.toLowerCase(),
-                merge_head_sha: mergeHeadSha.toLowerCase(),
-              };
             }
           } else {
             lastProblem = "ambiguous";
@@ -1408,7 +1425,11 @@ function verifyExternalMergeBinding({
     if (delayMs > 0) sleepMs(delayMs);
   }
 
-  if (lastProblem === "stale_test_merge" && staleTestMerge && allowBranchRefresh) {
+  if (
+    ["stale_test_merge", "awaiting_adopted_test_merge"].includes(lastProblem) &&
+    staleTestMerge &&
+    allowBranchRefresh
+  ) {
     return refreshStaleExternalMergeBinding({
       result,
       action,
@@ -1421,6 +1442,11 @@ function verifyExternalMergeBinding({
       pullRequest,
       view,
       staleTestMerge,
+      refreshBaseSha:
+        lastProblem === "awaiting_adopted_test_merge"
+          ? lastVerifiedMainSha
+          : reviewedBaseSha,
+      adoptingNewerMain: lastProblem === "awaiting_adopted_test_merge",
     });
   }
 
@@ -1439,6 +1465,7 @@ function runApplyTimeBaseAdoptionValidation({
   target,
   adoptedBaseSha,
   expectedHeadSha,
+  mergeHeadSha = expectedHeadSha,
   testMergeSha,
 }) {
   const tempRoot = fs.mkdtempSync(
@@ -1468,6 +1495,8 @@ function runApplyTimeBaseAdoptionValidation({
         adoptedBaseSha,
         "--expected-head-sha",
         expectedHeadSha,
+        "--merge-head-sha",
+        mergeHeadSha,
         "--test-merge-sha",
         testMergeSha,
         "--output",
@@ -1510,6 +1539,7 @@ function captureApplyTimeAdoptionState({
   target,
   adoptedBaseSha,
   expectedHeadSha,
+  mergeHeadSha = expectedHeadSha,
   testMergeSha,
 }) {
   const tempRoot = fs.mkdtempSync(
@@ -1531,6 +1561,8 @@ function captureApplyTimeAdoptionState({
         adoptedBaseSha,
         "--expected-head-sha",
         expectedHeadSha,
+        "--merge-head-sha",
+        mergeHeadSha,
         "--test-merge-sha",
         testMergeSha,
         "--output",
@@ -1577,12 +1609,15 @@ function refreshStaleExternalMergeBinding({
   pullRequest,
   view,
   staleTestMerge,
+  refreshBaseSha = reviewedBaseSha,
+  adoptingNewerMain = false,
 }) {
   const branchRefresh = {
     status: "blocked",
     method: "merge",
     expected_old_head_sha: expectedHeadSha,
     reviewed_base_sha: reviewedBaseSha,
+    refresh_base_sha: refreshBaseSha,
     stale_test_merge_sha: staleTestMerge.merge_commit_sha,
     stale_test_merge_base_sha: staleTestMerge.merge_base_sha,
   };
@@ -1591,7 +1626,7 @@ function refreshStaleExternalMergeBinding({
       reason: "stale GitHub test merge cannot be refreshed because the pull request branch is not writable",
       retry_recommended: true,
       reviewed_effective_diff_sha256: reviewedFingerprint,
-      verified_main_sha: reviewedBaseSha,
+      verified_main_sha: refreshBaseSha,
       reviewed_head_sha: expectedHeadSha,
       merge_head_sha: expectedHeadSha,
       branch_refresh: branchRefresh,
@@ -1614,14 +1649,14 @@ function refreshStaleExternalMergeBinding({
       reason: initialMetadataBlock || initialMergeBlock,
       retry_recommended: true,
       reviewed_effective_diff_sha256: reviewedFingerprint,
-      verified_main_sha: reviewedBaseSha,
+      verified_main_sha: refreshBaseSha,
       reviewed_head_sha: expectedHeadSha,
       merge_head_sha: expectedHeadSha,
       branch_refresh: branchRefresh,
     };
   }
   const mainBeforeRefresh = fetchBranchHeadSha(result.repo, "main");
-  if (mainBeforeRefresh !== reviewedBaseSha) {
+  if (mainBeforeRefresh !== refreshBaseSha) {
     return {
       reason: "main changed before stale test merge branch refresh",
       retry_recommended: true,
@@ -1651,7 +1686,7 @@ function refreshStaleExternalMergeBinding({
       reason: `could not request non-destructive branch refresh: ${compactErrorText(commandErrorText(error), 500)}`,
       retry_recommended: true,
       reviewed_effective_diff_sha256: reviewedFingerprint,
-      verified_main_sha: reviewedBaseSha,
+      verified_main_sha: refreshBaseSha,
       reviewed_head_sha: expectedHeadSha,
       merge_head_sha: expectedHeadSha,
       branch_refresh: branchRefresh,
@@ -1669,7 +1704,7 @@ function refreshStaleExternalMergeBinding({
     branchRefresh.poll_attempts = attempt;
     try {
       const currentMainSha = fetchBranchHeadSha(result.repo, "main");
-      if (currentMainSha !== reviewedBaseSha) {
+      if (currentMainSha !== refreshBaseSha) {
         return {
           reason: "main changed during stale test merge branch refresh",
           retry_recommended: true,
@@ -1708,7 +1743,7 @@ function refreshStaleExternalMergeBinding({
         if (
           refreshedHeadParents.length !== 2 ||
           refreshedHeadParents[0] !== expectedHeadSha.toLowerCase() ||
-          refreshedHeadParents[1] !== reviewedBaseSha
+          refreshedHeadParents[1] !== refreshBaseSha
         ) {
           return {
             reason: "branch refresh head is not the expected non-destructive merge of reviewed main",
@@ -1740,14 +1775,14 @@ function refreshStaleExternalMergeBinding({
           const testMergeHeadSha = String(testMergeParents[1]?.sha ?? "").toLowerCase();
           if (
             testMergeParents.length !== 2 ||
-            testMergeBaseSha !== reviewedBaseSha ||
+            testMergeBaseSha !== refreshBaseSha ||
             testMergeHeadSha !== refreshedHeadSha
           ) {
-            lastReason = "refreshed GitHub test merge is not bound to reviewed main and refreshed head";
+            lastReason = "refreshed GitHub test merge is not bound to refresh main and refreshed head";
           } else {
             const baseCommit = ghJson([
               "api",
-              `repos/${result.repo}/git/commits/${reviewedBaseSha}`,
+              `repos/${result.repo}/git/commits/${refreshBaseSha}`,
             ]);
             const baseEntries = fetchGitTreeEntries(result.repo, baseCommit.tree?.sha);
             const mergeEntries = fetchGitTreeEntries(
@@ -1782,14 +1817,28 @@ function refreshStaleExternalMergeBinding({
               };
             }
 
+            const refreshedView = fetchSettledRefreshedPullRequestView(
+              result.repo,
+              target,
+            );
+            const settledRefreshedPull = fetchPullRequest(result.repo, target);
+            if (
+              String(settledRefreshedPull.head?.sha ?? "").toLowerCase() !==
+                refreshedHeadSha ||
+              String(settledRefreshedPull.merge_commit_sha ?? "").toLowerCase() !==
+                refreshedTestMergeSha
+            ) {
+              lastReason =
+                "pull request head or GitHub test merge changed while refreshed checks settled";
+              continue;
+            }
             const refreshedLive = fetchIssue(result.repo, target);
-            const refreshedView = fetchSettledPullRequestView(result.repo, target);
             const metadataBlock = externalRefreshMetadataBlock({
               repo: result.repo,
               beforeIssue: live,
               beforePull: pullRequest,
               afterIssue: refreshedLive,
-              afterPull: refreshedPull,
+              afterPull: settledRefreshedPull,
             });
             const riskLabel = findHighRiskMergeLabel(refreshedLive.labels);
             const riskBlock = hasSecuritySignal(refreshedLive)
@@ -1797,8 +1846,11 @@ function refreshStaleExternalMergeBinding({
               : riskLabel
                 ? `target has blocked live label: ${riskLabel}`
                 : "";
+            const checkSettlementBlock = validateSettledStatusChecks(
+              refreshedView.statusCheckRollup ?? [],
+            );
             const mergeBlock = validateMergeablePullRequest({
-              pullRequest: refreshedPull,
+              pullRequest: settledRefreshedPull,
               view: refreshedView,
               allowExactMergeState: true,
             });
@@ -1809,7 +1861,7 @@ function refreshStaleExternalMergeBinding({
               expectedHeadSha,
             });
             const currentMainAfterChecks = fetchBranchHeadSha(result.repo, "main");
-            if (currentMainAfterChecks !== reviewedBaseSha) {
+            if (currentMainAfterChecks !== refreshBaseSha) {
               return {
                 reason: "main changed during stale test merge branch refresh",
                 retry_recommended: true,
@@ -1821,11 +1873,18 @@ function refreshStaleExternalMergeBinding({
                 branch_refresh: branchRefresh,
               };
             }
-            if (metadataBlock || riskBlock || mergeBlock || preflightBlock) {
+            if (
+              metadataBlock ||
+              riskBlock ||
+              checkSettlementBlock ||
+              mergeBlock ||
+              preflightBlock
+            ) {
               return {
                 reason:
                   metadataBlock ||
                   riskBlock ||
+                  checkSettlementBlock ||
                   mergeBlock ||
                   preflightBlock ||
                   "pull request state changed during branch refresh",
@@ -1838,6 +1897,32 @@ function refreshStaleExternalMergeBinding({
                 branch_refresh: branchRefresh,
               };
             }
+            let baseAdoption = null;
+            if (adoptingNewerMain) {
+              baseAdoption = runApplyTimeBaseAdoptionValidation({
+                preflight,
+                target,
+                adoptedBaseSha: refreshBaseSha,
+                expectedHeadSha,
+                mergeHeadSha: refreshedHeadSha,
+                testMergeSha: refreshedTestMergeSha,
+              });
+              if (baseAdoption.status !== "adopted") {
+                return {
+                  reason:
+                    baseAdoption.reason ||
+                    "apply-time main adoption validation failed after branch refresh",
+                  retry_recommended: true,
+                  reviewed_effective_diff_sha256: reviewedFingerprint,
+                  live_effective_diff_sha256: refreshedFingerprint.sha256,
+                  verified_main_sha: currentMainAfterChecks,
+                  reviewed_head_sha: expectedHeadSha,
+                  merge_head_sha: refreshedHeadSha,
+                  base_adoption: baseAdoption,
+                  branch_refresh: branchRefresh,
+                };
+              }
+            }
 
             return {
               reviewed_effective_diff_sha256: reviewedFingerprint,
@@ -1847,6 +1932,12 @@ function refreshStaleExternalMergeBinding({
               merge_commit_sha: refreshedTestMergeSha,
               reviewed_head_sha: expectedHeadSha,
               merge_head_sha: refreshedHeadSha,
+              ...(baseAdoption
+                ? {
+                    base_drift_proof: baseAdoption.drift_proof,
+                    base_adoption: baseAdoption,
+                  }
+                : {}),
               branch_refresh: {
                 ...branchRefresh,
                 status: "adopted",
@@ -1856,7 +1947,7 @@ function refreshStaleExternalMergeBinding({
                 effective_diff_files: refreshedFingerprint.files,
               },
               refreshed_live: refreshedLive,
-              refreshed_pull_request: refreshedPull,
+              refreshed_pull_request: settledRefreshedPull,
               refreshed_view: refreshedView,
             };
           }
@@ -1872,7 +1963,7 @@ function refreshStaleExternalMergeBinding({
     reason: lastReason,
     retry_recommended: true,
     reviewed_effective_diff_sha256: reviewedFingerprint,
-    verified_main_sha: reviewedBaseSha,
+    verified_main_sha: refreshBaseSha,
     reviewed_head_sha: expectedHeadSha,
     merge_head_sha: lastMergeHeadSha,
     branch_refresh: branchRefresh,
@@ -1992,12 +2083,17 @@ function restoreBaseAdoptionBinding({ action, target, expectedHeadSha, preflight
     const effectiveDiffSha256 = String(
       priorAction.effective_diff_sha256 ?? "",
     ).toLowerCase();
+    const mergeHeadSha = String(
+      proof.merge_head_sha ?? proof.reviewed_head_sha ?? "",
+    ).toLowerCase();
     if (
       proof.authorization_sha256 !== authorizationSha256 ||
       String(proof.reviewed_base_sha ?? "").toLowerCase() !==
         String(preflight?.reviewed_base_sha ?? "").toLowerCase() ||
       String(proof.reviewed_head_sha ?? "").toLowerCase() !==
         expectedHeadSha.toLowerCase() ||
+      mergeHeadSha !==
+        String(priorAction.merge_head_sha ?? expectedHeadSha).toLowerCase() ||
       String(proof.adopted_base_sha ?? "").toLowerCase() !== verifiedMainSha ||
       String(proof.effective_diff_sha256 ?? "").toLowerCase() !==
         String(preflight?.effective_diff_sha256 ?? "").toLowerCase() ||
@@ -2014,7 +2110,7 @@ function restoreBaseAdoptionBinding({ action, target, expectedHeadSha, preflight
       verified_main_sha: verifiedMainSha,
       merge_commit_sha: String(proof.test_merge_sha ?? "").toLowerCase(),
       reviewed_head_sha: expectedHeadSha.toLowerCase(),
-      merge_head_sha: expectedHeadSha.toLowerCase(),
+      merge_head_sha: mergeHeadSha,
       base_drift_proof: proof.drift_proof ?? null,
       base_adoption: proof,
     };
@@ -2028,6 +2124,7 @@ function baseAdoptionAuthorization(proof) {
     reviewed_base_sha: proof.reviewed_base_sha,
     adopted_base_sha: proof.adopted_base_sha,
     reviewed_head_sha: proof.reviewed_head_sha,
+    ...(proof.merge_head_sha ? { merge_head_sha: proof.merge_head_sha } : {}),
     test_merge_sha: proof.test_merge_sha,
     test_merge_tree_sha: proof.test_merge_tree_sha,
     effective_diff_files: proof.effective_diff_files,
@@ -2059,7 +2156,10 @@ function verifyExactMergeAuthorizationState({
     const currentMainSha = fetchBranchHeadSha(result.repo, "main");
     const currentIssue = fetchIssue(result.repo, target);
     const currentPull = fetchPullRequest(result.repo, target);
-    const currentView = fetchSettledPullRequestView(result.repo, target);
+    const allowedPendingCheckNames = [EXACT_MERGE_CHECK_NAME];
+    const currentView = fetchSettledPullRequestView(result.repo, target, {
+      allowedPendingCheckNames,
+    });
     const metadataBlock = externalRefreshMetadataBlock({
       repo: result.repo,
       beforeIssue,
@@ -2072,6 +2172,7 @@ function verifyExactMergeAuthorizationState({
       pullRequest: currentPull,
       view: currentView,
       allowExactMergeState: true,
+      allowedPendingCheckNames,
     });
     const preflightBlock = validateMergePreflight({
       result,
@@ -2085,6 +2186,7 @@ function verifyExactMergeAuthorizationState({
         target,
         adoptedBaseSha: effectiveDiffBinding.verified_main_sha,
         expectedHeadSha,
+        mergeHeadSha,
         testMergeSha: effectiveDiffBinding.merge_commit_sha,
       });
       if (adoptionState.status !== "clean") {
@@ -2645,7 +2747,12 @@ function validateReplacementCloseout({ result, actionName, target }) {
   return "replacement PR closeout is handled by execute-fix after the replacement branch is pushed";
 }
 
-function validateMergeablePullRequest({ pullRequest, view, allowExactMergeState = false }) {
+function validateMergeablePullRequest({
+  pullRequest,
+  view,
+  allowExactMergeState = false,
+  allowedPendingCheckNames = [],
+}) {
   if (pullRequest.state !== "open") return `pull request is ${pullRequest.state}`;
   if (pullRequest.draft || view.isDraft) return "pull request is draft";
   if (String(view.baseRefName ?? pullRequest.base?.ref ?? "") !== "main") return "pull request base is not main";
@@ -2653,9 +2760,16 @@ function validateMergeablePullRequest({ pullRequest, view, allowExactMergeState 
   if (["CHANGES_REQUESTED", "REVIEW_REQUIRED"].includes(String(view.reviewDecision ?? ""))) {
     return `review decision is ${view.reviewDecision}`;
   }
-  const checkBlock = validateStatusChecks(view.statusCheckRollup ?? []);
+  const checkBlock = validateStatusChecks(view.statusCheckRollup ?? [], {
+    allowedPendingCheckNames,
+  });
   if (checkBlock) return checkBlock;
-  if (!isAcceptableMergeState(view, { allowExactMergeState })) {
+  if (
+    !isAcceptableMergeState(view, {
+      allowExactMergeState,
+      allowedPendingCheckNames,
+    })
+  ) {
     return `merge state status is ${view.mergeStateStatus || "unknown"}`;
   }
   return "";
@@ -2688,22 +2802,40 @@ function validatePullRequestCurrentBase({ repo, pullRequest, view, allowExactMer
   return null;
 }
 
-function validateStatusChecks(checks) {
+function validateStatusChecks(checks, { allowedPendingCheckNames = [] } = {}) {
   if (!Array.isArray(checks) || checks.length === 0) return "no PR checks found";
   const blockers = [];
+  const pending = [];
+  const allowedPending = new Set(allowedPendingCheckNames);
   for (const check of latestStatusChecks(checks)) {
     const name = check.name ?? check.context ?? "unknown check";
     const status = String(check.status ?? check.state ?? "").toUpperCase();
     const conclusion = String(check.conclusion ?? "").toUpperCase();
-    if (["COMPLETED", "SUCCESS"].includes(status) && conclusion && !PASSING_CHECK_CONCLUSIONS.has(conclusion)) {
-      blockers.push(`${name}: ${conclusion}`);
+    if (status === "COMPLETED") {
+      if (!conclusion || !PASSING_CHECK_CONCLUSIONS.has(conclusion)) {
+        blockers.push(`${name}: ${conclusion || "MISSING_CONCLUSION"}`);
+      }
+    } else if (status === "SUCCESS") {
+      continue;
+    } else if (["FAILURE", "ERROR"].includes(status)) {
+      blockers.push(`${name}: ${status}`);
+    } else if (!allowedPending.has(name)) {
+      pending.push(`${name}: ${status || "PENDING"}`);
     }
   }
   if (blockers.length > 0) return `checks are not clean: ${blockers.slice(0, 5).join(", ")}`;
+  if (pending.length > 0) return `checks are pending: ${pending.slice(0, 5).join(", ")}`;
   return "";
 }
 
-function isAcceptableMergeState(view, { allowExactMergeState = false } = {}) {
+function validateSettledStatusChecks(checks) {
+  return validateStatusChecks(checks);
+}
+
+function isAcceptableMergeState(
+  view,
+  { allowExactMergeState = false, allowedPendingCheckNames = [] } = {},
+) {
   const state = String(view.mergeStateStatus ?? "");
   if (CLEAN_MERGE_STATES.has(state)) return true;
   if (
@@ -2714,7 +2846,12 @@ function isAcceptableMergeState(view, { allowExactMergeState = false } = {}) {
   }
   // Exact-bound external actions verify the synthetic merge against current
   // main before publishing authorization or attempting the one-shot merge.
-  return view.mergeable === "MERGEABLE" && !validateStatusChecks(view.statusCheckRollup ?? []);
+  return (
+    view.mergeable === "MERGEABLE" &&
+    !validateStatusChecks(view.statusCheckRollup ?? [], {
+      allowedPendingCheckNames,
+    })
+  );
 }
 
 function latestStatusChecks(checks) {
@@ -2892,13 +3029,60 @@ function fetchPullRequestView(repo, number) {
   ]);
 }
 
-function fetchSettledPullRequestView(repo, number) {
+function fetchSettledPullRequestView(
+  repo,
+  number,
+  { allowedPendingCheckNames = [] } = {},
+) {
   const attempts = positiveInteger(process.env.CLOWNFISH_APPLY_MERGEABLE_POLL_ATTEMPTS, 6);
   const delayMs = nonNegativeInteger(process.env.CLOWNFISH_APPLY_MERGEABLE_POLL_DELAY_MS, 5000);
   let latest = null;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     latest = fetchPullRequestView(repo, number);
-    if (!hasUnknownMergeability(latest)) return latest;
+    if (
+      !hasUnknownMergeability(latest) &&
+      !hasPendingStatusChecks(latest.statusCheckRollup ?? [], {
+        allowedPendingCheckNames,
+      })
+    ) {
+      return latest;
+    }
+    if (attempt < attempts && delayMs > 0) {
+      execFileSync("sleep", [String(delayMs / 1000)], { stdio: "ignore" });
+    }
+  }
+  return latest;
+}
+
+function hasPendingStatusChecks(checks, { allowedPendingCheckNames = [] } = {}) {
+  if (!Array.isArray(checks) || checks.length === 0) return true;
+  const allowedPending = new Set(allowedPendingCheckNames);
+  return latestStatusChecks(checks).some((check) => {
+    const name = check.name ?? check.context ?? "unknown check";
+    if (allowedPending.has(name)) return false;
+    const status = String(check.status ?? check.state ?? "").toUpperCase();
+    return !["COMPLETED", "SUCCESS", "FAILURE", "ERROR"].includes(status);
+  });
+}
+
+function fetchSettledRefreshedPullRequestView(repo, number) {
+  const attempts = positiveInteger(
+    process.env.CLOWNFISH_APPLY_REFRESH_CHECK_ATTEMPTS,
+    90,
+  );
+  const delayMs = nonNegativeInteger(
+    process.env.CLOWNFISH_APPLY_REFRESH_CHECK_DELAY_MS,
+    10000,
+  );
+  let latest = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    latest = fetchPullRequestView(repo, number);
+    if (
+      !hasUnknownMergeability(latest) &&
+      !hasPendingStatusChecks(latest.statusCheckRollup ?? [])
+    ) {
+      return latest;
+    }
     if (attempt < attempts && delayMs > 0) {
       execFileSync("sleep", [String(delayMs / 1000)], { stdio: "ignore" });
     }

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -71,6 +71,9 @@ if (args["adoption-state-only"]) {
       sourceJob,
       pullRequest,
       expectedHeadSha: String(args["expected-head-sha"] ?? "").toLowerCase(),
+      mergeHeadSha: String(
+        args["merge-head-sha"] ?? args["expected-head-sha"] ?? "",
+      ).toLowerCase(),
       expectedTestMergeSha: String(args["test-merge-sha"] ?? "").toLowerCase(),
       adoptedBaseSha: String(args["adopted-base-sha"] ?? "").toLowerCase(),
     });
@@ -97,6 +100,9 @@ if (adoptionManifestPath) {
       manifest: JSON.parse(fs.readFileSync(adoptionManifestPath, "utf8")),
       adoptedBaseSha: String(args["adopted-base-sha"] ?? "").toLowerCase(),
       expectedHeadSha: String(args["expected-head-sha"] ?? "").toLowerCase(),
+      mergeHeadSha: String(
+        args["merge-head-sha"] ?? args["expected-head-sha"] ?? "",
+      ).toLowerCase(),
       expectedTestMergeSha: String(args["test-merge-sha"] ?? "").toLowerCase(),
       targetDir,
       baseBranch,
@@ -1347,11 +1353,13 @@ function captureFreshAdoptionGithubState({
   sourceJob,
   pullRequest,
   expectedHeadSha,
+  mergeHeadSha = expectedHeadSha,
   expectedTestMergeSha,
   adoptedBaseSha,
 }) {
   for (const [label, value] of [
     ["expected head", expectedHeadSha],
+    ["merge head", mergeHeadSha],
     ["GitHub test merge", expectedTestMergeSha],
     ["adopted base", adoptedBaseSha],
   ]) {
@@ -1384,7 +1392,7 @@ function captureFreshAdoptionGithubState({
     pullRequest,
   });
   const blockers = [
-    ...(String(pull.head?.sha ?? "").toLowerCase() !== expectedHeadSha
+    ...(String(pull.head?.sha ?? "").toLowerCase() !== mergeHeadSha
       ? ["PR head changed during apply-time adoption validation"]
       : []),
     ...(String(pull.merge_commit_sha ?? "").toLowerCase() !== expectedTestMergeSha
@@ -1418,9 +1426,9 @@ function captureFreshAdoptionGithubState({
   if (
     testMergeParents.length !== 2 ||
     String(testMergeParents[0]?.sha ?? "").toLowerCase() !== adoptedBaseSha ||
-    String(testMergeParents[1]?.sha ?? "").toLowerCase() !== expectedHeadSha
+    String(testMergeParents[1]?.sha ?? "").toLowerCase() !== mergeHeadSha
   ) {
-    blockers.push("GitHub test merge is not bound to [adopted main, reviewed head]");
+    blockers.push("GitHub test merge is not bound to [adopted main, merge head]");
   }
   if (blockers.length > 0) {
     throw new Error(blockers.join("; "));
@@ -1542,20 +1550,42 @@ function runBaseAdoptionValidation({
   manifest,
   adoptedBaseSha,
   expectedHeadSha,
+  mergeHeadSha = expectedHeadSha,
   expectedTestMergeSha,
   targetDir,
   baseBranch,
 }) {
   assertBaseAdoptionManifest(manifest, { expectedHeadSha, adoptedBaseSha });
-  if (!/^[0-9a-f]{40}$/i.test(expectedTestMergeSha)) {
-    throw new Error("GitHub test merge SHA is missing or invalid");
+  for (const [label, value] of [
+    ["merge head", mergeHeadSha],
+    ["GitHub test merge", expectedTestMergeSha],
+  ]) {
+    if (!/^[0-9a-f]{40}$/i.test(value)) {
+      throw new Error(`${label} SHA is missing or invalid`);
+    }
   }
 
   checkoutExactPullHead({
     repo: sourceJob.frontmatter.repo,
     pullRequest,
-    expectedHeadSha,
+    expectedHeadSha: mergeHeadSha,
   });
+  if (mergeHeadSha !== expectedHeadSha) {
+    const refreshedHead = ghJson([
+      "api",
+      `repos/${sourceJob.frontmatter.repo}/git/commits/${mergeHeadSha}`,
+    ]);
+    const refreshedParents = refreshedHead.parents ?? [];
+    if (
+      refreshedParents.length !== 2 ||
+      String(refreshedParents[0]?.sha ?? "").toLowerCase() !== expectedHeadSha ||
+      String(refreshedParents[1]?.sha ?? "").toLowerCase() !== adoptedBaseSha
+    ) {
+      throw new Error(
+        "merge head is not the expected non-destructive refresh of the reviewed head",
+      );
+    }
+  }
   const fetchedMainSha = run("git", ["rev-parse", `origin/${baseBranch}`], {
     cwd: targetDir,
     env: gitIntegrityEnv(),
@@ -1670,11 +1700,12 @@ function runBaseAdoptionValidation({
     sourceJob,
     pullRequest,
     expectedHeadSha,
+    mergeHeadSha,
     expectedTestMergeSha,
     adoptedBaseSha,
   });
   if (githubState.test_merge_tree_sha !== adoptedReviewContext.mergeTreeSha) {
-    throw new Error("GitHub test merge is not the validated [adopted main, reviewed head] merge");
+    throw new Error("GitHub test merge is not the validated [adopted main, merge head] merge");
   }
   const finalMainSha = refreshTargetMain({ targetDir, baseBranch });
   if (finalMainSha !== adoptedBaseSha) {
@@ -1688,6 +1719,7 @@ function runBaseAdoptionValidation({
     reviewed_base_sha: manifest.reviewed_base_sha,
     adopted_base_sha: adoptedBaseSha,
     reviewed_head_sha: expectedHeadSha,
+    merge_head_sha: mergeHeadSha,
     test_merge_sha: expectedTestMergeSha,
     test_merge_tree_sha: adoptedReviewContext.mergeTreeSha,
     effective_diff_files: adoptedReviewContext.effectiveDiffFiles,

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -419,6 +419,33 @@ test("apply-result blocks a stale PR base when latest checks are not clean", () 
   assert.match(report.actions[0].reason, /checks are not clean/);
 });
 
+test("apply-result blocks failing legacy status contexts", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeStaleMergeGhStub(binDir, {
+    statusCheckRollup: [{ context: "legacy-ci", state: "FAILURE" }],
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    env: {
+      CLOWNFISH_APPLY_MERGEABLE_POLL_ATTEMPTS: "1",
+      CLOWNFISH_APPLY_MERGEABLE_POLL_DELAY_MS: "0",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /checks are not clean: legacy-ci: FAILURE/);
+});
+
 test("apply-result blocks a merge when the PR head changed after worker review", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");
@@ -1348,7 +1375,87 @@ test("apply-result rejects a changed effective fingerprint during newer-main ado
   assert.equal(fs.existsSync(mergeStatePath), false);
 });
 
-test("apply-result does not update the branch while waiting for an adopted test merge", () => {
+test("apply-result refreshes a writable branch when adopted test-merge polling is exhausted", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(
+    binDir,
+    adoptionStubOptions({
+      mergeBaseSha: REVIEWED_BASE_SHA,
+      branchRefresh: true,
+      branchRefreshBaseSha: CURRENT_MAIN_SHA,
+      refreshedMergeTreeSha: MERGE_TREE_SHA,
+      refreshedCheckViews: [
+        {
+          mergeable: "MERGEABLE",
+          mergeStateStatus: "BLOCKED",
+          statusCheckRollup: [
+            { name: "CI", status: "IN_PROGRESS", conclusion: null },
+          ],
+        },
+        { mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" },
+      ],
+    }),
+  );
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(adoptionMergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    mergeStatePath,
+    env: {
+      CLOWNFISH_APPLY_MERGE_BINDING_ATTEMPTS: "2",
+      CLOWNFISH_APPLY_ADOPTED_TEST_MERGE_ATTEMPTS: "4",
+      CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0",
+      CLOWNFISH_APPLY_BRANCH_REFRESH_DELAY_MS: "0",
+      CLOWNFISH_APPLY_REFRESH_CHECK_ATTEMPTS: "3",
+      CLOWNFISH_APPLY_REFRESH_CHECK_DELAY_MS: "0",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "executed");
+  assert.equal(report.actions[0].reviewed_head_sha, EXPECTED_HEAD_SHA);
+  assert.equal(report.actions[0].merge_head_sha, REFRESHED_HEAD_SHA);
+  assert.equal(report.actions[0].branch_refresh.status, "adopted");
+  assert.equal(report.actions[0].branch_refresh.refresh_base_sha, CURRENT_MAIN_SHA);
+  assert.equal(report.actions[0].base_adoption.status, "adopted");
+  assert.equal(report.actions[0].base_adoption.reviewed_head_sha, EXPECTED_HEAD_SHA);
+  assert.equal(report.actions[0].base_adoption.merge_head_sha, REFRESHED_HEAD_SHA);
+  const ghCalls = readCallLog(callLogPath);
+  assert.equal(
+    ghCalls.filter(
+      (args) =>
+        args[0] === "api" &&
+        args[1] === `repos/openclaw/openclaw/git/commits/${TEST_MERGE_SHA}`,
+    ).length,
+    4,
+  );
+  assert.equal(ghCalls.some((args) => args[1]?.endsWith("/update-branch")), true);
+  assert.equal(
+    ghCalls.filter((args) => args[0] === "pr" && args[1] === "view").length >= 6,
+    true,
+  );
+  const mergeArgs = ghCalls.find((args) => args[0] === "pr" && args[1] === "merge");
+  assert.deepEqual(mergeArgs.slice(-3), [
+    "--squash",
+    "--match-head-commit",
+    REFRESHED_HEAD_SHA,
+  ]);
+});
+
+test("apply-result blocks when refreshed branch checks do not settle", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");
   const callLogPath = path.join(tmp, "gh-calls.jsonl");
@@ -1356,7 +1463,21 @@ test("apply-result does not update the branch while waiting for an adopted test 
   fs.writeFileSync(callLogPath, "");
   writeReadyMergeGhStub(
     binDir,
-    adoptionStubOptions({ mergeBaseSha: REVIEWED_BASE_SHA }),
+    adoptionStubOptions({
+      mergeBaseSha: REVIEWED_BASE_SHA,
+      branchRefresh: true,
+      branchRefreshBaseSha: CURRENT_MAIN_SHA,
+      refreshedMergeTreeSha: MERGE_TREE_SHA,
+      refreshedCheckViews: [
+        {
+          mergeable: "MERGEABLE",
+          mergeStateStatus: "BLOCKED",
+          statusCheckRollup: [
+            { name: "CI", status: "IN_PROGRESS", conclusion: null },
+          ],
+        },
+      ],
+    }),
   );
 
   const jobPath = path.join(tmp, "job.md");
@@ -1370,8 +1491,56 @@ test("apply-result does not update the branch while waiting for an adopted test 
     allowMerge: true,
     callLogPath,
     env: {
-      CLOWNFISH_APPLY_MERGE_BINDING_ATTEMPTS: "2",
-      CLOWNFISH_APPLY_ADOPTED_TEST_MERGE_ATTEMPTS: "4",
+      CLOWNFISH_APPLY_MERGE_BINDING_ATTEMPTS: "1",
+      CLOWNFISH_APPLY_ADOPTED_TEST_MERGE_ATTEMPTS: "1",
+      CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0",
+      CLOWNFISH_APPLY_BRANCH_REFRESH_ATTEMPTS: "1",
+      CLOWNFISH_APPLY_BRANCH_REFRESH_DELAY_MS: "0",
+      CLOWNFISH_APPLY_REFRESH_CHECK_ATTEMPTS: "2",
+      CLOWNFISH_APPLY_REFRESH_CHECK_DELAY_MS: "0",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /checks are pending: CI: IN_PROGRESS/);
+  const ghCalls = readCallLog(callLogPath);
+  assert.equal(
+    ghCalls.filter((args) => args[0] === "pr" && args[1] === "view").length,
+    3,
+  );
+  assert.equal(ghCalls.some((args) => args[0] === "pr" && args[1] === "merge"), false);
+});
+
+test("apply-result leaves an unwritable branch untouched after adopted test-merge exhaustion", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(
+    binDir,
+    adoptionStubOptions({
+      mergeBaseSha: REVIEWED_BASE_SHA,
+      maintainerCanModify: false,
+      headRepo: "contributor/openclaw",
+    }),
+  );
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(adoptionMergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    env: {
+      CLOWNFISH_APPLY_MERGE_BINDING_ATTEMPTS: "1",
+      CLOWNFISH_APPLY_ADOPTED_TEST_MERGE_ATTEMPTS: "1",
       CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0",
     },
   });
@@ -1379,17 +1548,8 @@ test("apply-result does not update the branch while waiting for an adopted test 
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
   assert.equal(report.actions[0].status, "blocked");
-  assert.match(report.actions[0].reason, /not based on the current main SHA/);
-  const ghCalls = readCallLog(callLogPath);
-  assert.equal(
-    ghCalls.filter(
-      (args) =>
-        args[0] === "api" &&
-        args[1] === `repos/openclaw/openclaw/git/commits/${TEST_MERGE_SHA}`,
-    ).length,
-    4,
-  );
-  assert.equal(ghCalls.some((args) => args[1]?.endsWith("/update-branch")), false);
+  assert.match(report.actions[0].reason, /branch is not writable/);
+  assert.equal(readCallLog(callLogPath).some((args) => args[1]?.endsWith("/update-branch")), false);
 });
 
 test("apply-result keeps ambiguous test merges on the normal attempt budget", () => {
@@ -1535,6 +1695,41 @@ test("apply-result keeps the exact-merge check pending while final state validat
     report.actions[0].reason,
     "GitHub comments, reviews, metadata, or checks changed during exact-merge authorization",
   );
+  assert.equal(report.actions[0].exact_merge_revocation.status, "revoked");
+  assert.equal(fs.existsSync(mergeStatePath), false);
+});
+
+test("apply-result blocks newly pending CI during exact-merge authorization", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeReadyMergeGhStub(
+    binDir,
+    adoptionStubOptions({ checksBecomePendingAfterExactCheck: true }),
+  );
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(adoptionMergeResultJson(), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+    env: {
+      CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0",
+      CLOWNFISH_APPLY_MERGEABLE_POLL_ATTEMPTS: "1",
+      CLOWNFISH_APPLY_MERGEABLE_POLL_DELAY_MS: "0",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /checks are pending: CI: IN_PROGRESS/);
   assert.equal(report.actions[0].exact_merge_revocation.status, "revoked");
   assert.equal(fs.existsSync(mergeStatePath), false);
 });
@@ -1863,6 +2058,70 @@ test("apply-result restores adopted-base proof when replaying an already-merged 
   assert.equal(report.actions[0].merge_commit_sha, SQUASH_COMMIT_SHA);
   assert.equal(report.actions[0].effective_diff_sha256, ADOPTION_EFFECTIVE_DIFF_SHA256);
   assert.equal(report.actions[0].verified_main_sha, CURRENT_MAIN_SHA);
+  assert.equal(report.actions[0].base_adoption.authorization_sha256, proof.authorization_sha256);
+});
+
+test("apply-result restores refreshed-head adoption proof after an interrupted merge report", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(mergeStatePath, "merged");
+  fs.writeFileSync(path.join(binDir, "branch-refresh-state"), "refreshed");
+  writeReadyMergeGhStub(
+    binDir,
+    adoptionStubOptions({
+      branchRefresh: true,
+      branchRefreshBaseSha: CURRENT_MAIN_SHA,
+      adoptionDriftPath: "src/other/unrelated.ts",
+      currentMainExtraPath: "src/other/unrelated.ts",
+    }),
+  );
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  const proof = baseAdoptionProof({
+    mergeHeadSha: REFRESHED_HEAD_SHA,
+    testMergeSha: REFRESHED_TEST_MERGE_SHA,
+    testMergeTreeSha: REFRESHED_MERGE_TREE_SHA,
+  });
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(adoptionMergeResultJson(), null, 2)}\n`);
+  fs.writeFileSync(
+    reportPath,
+    `${JSON.stringify(
+      {
+        checkpoint: "base_adoption_verified",
+        actions: [
+          {
+            target: "#60063",
+            status: "authorizing",
+            reviewed_head_sha: EXPECTED_HEAD_SHA,
+            merge_head_sha: REFRESHED_HEAD_SHA,
+            effective_diff_sha256: ADOPTION_EFFECTIVE_DIFF_SHA256,
+            verified_main_sha: CURRENT_MAIN_SHA,
+            base_adoption: proof,
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    mergeStatePath,
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "executed");
+  assert.equal(report.actions[0].reason, "already merged");
+  assert.equal(report.actions[0].reviewed_head_sha, EXPECTED_HEAD_SHA);
+  assert.equal(report.actions[0].merge_head_sha, REFRESHED_HEAD_SHA);
   assert.equal(report.actions[0].base_adoption.authorization_sha256, proof.authorization_sha256);
 });
 
@@ -2300,6 +2559,7 @@ function writeReadyMergeGhStub(
     headSha,
     mergeStateStatus = "CLEAN",
     mergeViews = null,
+    refreshedCheckViews = null,
     transientViewFailures = 0,
     statusCheckRollup = [{ name: "CI", status: "COMPLETED", conclusion: "SUCCESS" }],
     labels = [],
@@ -2315,10 +2575,12 @@ function writeReadyMergeGhStub(
     headRef = "feature/stale-test-merge",
     refreshedHeadSha = REFRESHED_HEAD_SHA,
     refreshedTestMergeSha = REFRESHED_TEST_MERGE_SHA,
+    refreshedMergeTreeSha = REFRESHED_MERGE_TREE_SHA,
     refreshedMergeBlobSha = mergeBlobSha,
+    reviewedBaseSha = CURRENT_MAIN_SHA,
+    branchRefreshBaseSha = reviewedBaseSha,
     mainAfterRefreshSha = CURRENT_MAIN_SHA,
     currentMainBlobSha = BASE_BLOB_SHA,
-    reviewedBaseSha = CURRENT_MAIN_SHA,
     currentMainExtraPath = "src/other/unrelated.ts",
     mergeFailure = null,
     mergeSucceedsWithoutState = false,
@@ -2335,6 +2597,7 @@ function writeReadyMergeGhStub(
     adoptionLabels = null,
     pendingCheckIssueComments = null,
     staleTestMergePolls = 0,
+    checksBecomePendingAfterExactCheck = false,
   },
 ) {
   const ghPath = path.join(binDir, "gh");
@@ -2363,7 +2626,9 @@ const path = require("node:path");
 const args = process.argv.slice(2);
 const merged = Boolean(process.env.MERGE_STATE && fs.existsSync(process.env.MERGE_STATE));
 const mergeViews = ${JSON.stringify(mergeViews)};
+const refreshedCheckViews = ${JSON.stringify(refreshedCheckViews)};
 const viewCountPath = ${JSON.stringify(viewCountPath)};
+const refreshedViewCountPath = ${JSON.stringify(path.join(binDir, "refreshed-view-count"))};
 const checkStatePath = ${JSON.stringify(path.join(binDir, "exact-merge-check.json"))};
 const branchRefreshStatePath = ${JSON.stringify(path.join(binDir, "branch-refresh-state"))};
 const adoptionStatePath = ${JSON.stringify(path.join(binDir, "adoption-started"))};
@@ -2547,15 +2812,15 @@ if (${JSON.stringify(adoptionValidation)} && args[0] === "repo" && args[1] === "
     sha: ${JSON.stringify(refreshedHeadSha)},
     parents: [
       { sha: ${JSON.stringify(headSha)} },
-      { sha: ${JSON.stringify(reviewedBaseSha)} }
+      { sha: ${JSON.stringify(branchRefreshBaseSha)} }
     ]
   });
 } else if (externalBinding && args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/commits/${refreshedTestMergeSha}") {
   write({
     sha: ${JSON.stringify(refreshedTestMergeSha)},
-    tree: { sha: ${JSON.stringify(REFRESHED_MERGE_TREE_SHA)} },
+    tree: { sha: ${JSON.stringify(refreshedMergeTreeSha)} },
     parents: [
-      { sha: ${JSON.stringify(reviewedBaseSha)} },
+      { sha: ${JSON.stringify(branchRefreshBaseSha)} },
       { sha: ${JSON.stringify(refreshedHeadSha)} }
     ]
   });
@@ -2644,14 +2909,27 @@ if (${JSON.stringify(adoptionValidation)} && args[0] === "repo" && args[1] === "
     process.stderr.write("HTTP 503: 503 Service Unavailable (https://api.github.com/graphql)\\n");
     process.exit(1);
   }
-  const mergeView = Array.isArray(mergeViews) ? mergeViews[Math.min(count, mergeViews.length - 1)] : {};
+  let mergeView = Array.isArray(mergeViews) ? mergeViews[Math.min(count, mergeViews.length - 1)] : {};
+  if (branchRefreshed() && Array.isArray(refreshedCheckViews)) {
+    const refreshedCount = fs.existsSync(refreshedViewCountPath)
+      ? Number(fs.readFileSync(refreshedViewCountPath, "utf8"))
+      : 0;
+    fs.writeFileSync(refreshedViewCountPath, String(refreshedCount + 1));
+    mergeView =
+      refreshedCheckViews[Math.min(refreshedCount, refreshedCheckViews.length - 1)] ?? {};
+  }
+  const exactMergePending = checkRuns().some((check) => check.status === "in_progress");
+  const liveStatusCheckRollup =
+    ${JSON.stringify(checksBecomePendingAfterExactCheck)} && exactMergePending
+      ? [{ name: "CI", status: "IN_PROGRESS", conclusion: null }]
+      : (mergeView.statusCheckRollup ?? ${JSON.stringify(statusCheckRollup)});
   write({
     baseRefName: "main",
     isDraft: false,
     mergeable: mergeView.mergeable ?? "MERGEABLE",
     mergeStateStatus: mergeView.mergeStateStatus ?? ${JSON.stringify(mergeStateStatus)},
     reviewDecision: "APPROVED",
-    statusCheckRollup: ${JSON.stringify(statusCheckRollup)}
+    statusCheckRollup: liveStatusCheckRollup
   });
 } else if (args[0] === "pr" && args[1] === "merge" && args[2] === "60063") {
   if (${JSON.stringify(mergeFailure)}) {
@@ -2677,13 +2955,14 @@ if (${JSON.stringify(adoptionValidation)} && args[0] === "repo" && args[1] === "
       driftCommitCount: adoptionDriftCommitCount,
       linear: adoptionLinear,
       validationFailure: adoptionValidationFailure,
+      checkoutHeadSha: branchRefresh ? refreshedHeadSha : headSha,
     });
   }
 }
 
 function writeAdoptionValidationStubs(
   binDir,
-  { driftPath, driftCommitCount, linear, validationFailure },
+  { driftPath, driftCommitCount, linear, validationFailure, checkoutHeadSha },
 ) {
   const gitPath = path.join(binDir, "git");
   const statePath = path.join(binDir, "adoption-git-state");
@@ -2714,7 +2993,7 @@ if (args[0] === "rev-parse") {
   else if (args[1] === "--is-shallow-repository") console.log("false");
   else if (args[1] === "HEAD^{tree}") console.log(${JSON.stringify(MERGE_TREE_SHA)});
   else if (args[1] === "HEAD^") console.log(${JSON.stringify(CURRENT_MAIN_SHA)});
-  else console.log(state === "adopted" ? ${JSON.stringify(adoptedSyntheticSha)} : state === "reviewed" ? ${JSON.stringify(reviewedSyntheticSha)} : ${JSON.stringify(EXPECTED_HEAD_SHA)});
+  else console.log(state === "adopted" ? ${JSON.stringify(adoptedSyntheticSha)} : state === "reviewed" ? ${JSON.stringify(reviewedSyntheticSha)} : ${JSON.stringify(checkoutHeadSha)});
   process.exit(0);
 }
 if (args[0] === "merge-base" && args[1] === "--is-ancestor") process.exit(${linear ? 0 : 1});
@@ -2945,15 +3224,20 @@ function baseAdoptionManifest() {
   };
 }
 
-function baseAdoptionProof() {
+function baseAdoptionProof({
+  mergeHeadSha = EXPECTED_HEAD_SHA,
+  testMergeSha = TEST_MERGE_SHA,
+  testMergeTreeSha = MERGE_TREE_SHA,
+} = {}) {
   const manifest = baseAdoptionManifest();
   const authorization = {
     policy: manifest.policy,
     reviewed_base_sha: REVIEWED_BASE_SHA,
     adopted_base_sha: CURRENT_MAIN_SHA,
     reviewed_head_sha: EXPECTED_HEAD_SHA,
-    test_merge_sha: TEST_MERGE_SHA,
-    test_merge_tree_sha: MERGE_TREE_SHA,
+    merge_head_sha: mergeHeadSha,
+    test_merge_sha: testMergeSha,
+    test_merge_tree_sha: testMergeTreeSha,
     effective_diff_files: 1,
     effective_diff_sha256: ADOPTION_EFFECTIVE_DIFF_SHA256,
     drift_commit_count: 1,


### PR DESCRIPTION
## Summary

- refresh writable PR branches when adopted-main test merges stay pinned to the old base
- preserve immutable reviewed-head proof while authorizing the refreshed merge head
- wait for refreshed checks to settle, reject pending or legacy failing contexts, and replay interrupted refreshed-head merges safely

## Validation

- `node --test test/apply-result.test.mjs` (72/72)
- `node --test test/preflight-external-pr-merge.test.mjs` (136/136)
- `npm run validate` (6,670 jobs)
- independent review findings addressed: final pending-check race, legacy status-context failures, refreshed-head replay
