### PR TITLE
chore(jobs): retry refreshed merge canaries

### DIFF
--- a/jobs/openclaw/inbox/live-pr-canary-retry-20260711T133857-001.md
+++ b/jobs/openclaw/inbox/live-pr-canary-retry-20260711T133857-001.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-canary-retry-20260711T133857-001
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#104110"
+cluster_refs:
+  - "#104110"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Classify this current-head canary independently. Merge only through the deterministic exact-head external preflight; repair only through a complete executable fix artifact."
+notes: "Fresh retry after adopted-main branch refresh on 2026-07-11. Observed head 880303e19b1bcfcecafba445b359c5ed41e31f2e; re-fetch live state before every mutation."
+---
+
+# Current-Head Canary Retry 1
+
+Hydrate live GitHub state for the listed PR and produce its current finalization path.
+
+Emit `merge_candidate` only with a complete merge preflight. If the PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight.
+
+Emit bounded `fix_needed`, `build_fix_artifact`, and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive work centrally.
+
+## Inventory
+
+### #104110 fix(agents): cancel pending bundle LSP requests when the agent stops
+
+- bucket: ready_for_maintainer
+- author: zhangguiping-xydt
+- draft: no
+- assignees: none
+- signals: size S, proof sufficient, diamond, ready for maintainer look
+- observed head: `880303e19b1bcfcecafba445b359c5ed41e31f2e`
+- live updated: 2026-07-11T12:27:13Z
+- live url: https://github.com/openclaw/openclaw/pull/104110

--- a/jobs/openclaw/inbox/live-pr-canary-retry-20260711T133857-002.md
+++ b/jobs/openclaw/inbox/live-pr-canary-retry-20260711T133857-002.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-canary-retry-20260711T133857-002
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#104433"
+cluster_refs:
+  - "#104433"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Classify this current-head canary independently. Merge only through the deterministic exact-head external preflight; repair only through a complete executable fix artifact."
+notes: "Fresh retry after adopted-main branch refresh on 2026-07-11. Observed head bcbc813b239dd4d8568a770aa13b007344d03cad; re-fetch live state before every mutation."
+---
+
+# Current-Head Canary Retry 2
+
+Hydrate live GitHub state for the listed PR and produce its current finalization path.
+
+Emit `merge_candidate` only with a complete merge preflight. If the PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight.
+
+Emit bounded `fix_needed`, `build_fix_artifact`, and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive work centrally.
+
+## Inventory
+
+### #104433 fix(openrouter): Fusion prompt corrupts boundary emoji in model IDs
+
+- bucket: ready_for_maintainer
+- author: zhangguiping-xydt
+- draft: no
+- assignees: none
+- signals: size S, proof sufficient, diamond, ready for maintainer look
+- observed head: `bcbc813b239dd4d8568a770aa13b007344d03cad`
+- live updated: 2026-07-11T11:35:46Z
+- live url: https://github.com/openclaw/openclaw/pull/104433

--- a/jobs/openclaw/inbox/live-pr-canary-retry-20260711T133857-003.md
+++ b/jobs/openclaw/inbox/live-pr-canary-retry-20260711T133857-003.md
@@ -1,0 +1,55 @@
+---
+repo: openclaw/openclaw
+cluster_id: live-pr-canary-retry-20260711T133857-003
+mode: autonomous
+allowed_actions:
+  - "merge"
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical: []
+candidates:
+  - "#104404"
+cluster_refs:
+  - "#104404"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Classify this current-head canary independently. Merge only through the deterministic exact-head external preflight; repair only through a complete executable fix artifact."
+notes: "Fresh retry after adopted-main branch refresh on 2026-07-11. Observed head f29f14e535c4cb466a596e4e8fa2a9860ce89a52; re-fetch live state before every mutation."
+---
+
+# Current-Head Canary Retry 3
+
+Hydrate live GitHub state for the listed PR and produce its current finalization path.
+
+Emit `merge_candidate` only with a complete merge preflight. If the PR is otherwise merge-shaped but lacks deterministic exact-head validation and Codex `/review`, emit a blocked `merge_candidate` with reason `external_merge_preflight_required`, `expected_head_sha`, `target_updated_at`, and concrete evidence so the executor can run the external merge preflight.
+
+Emit bounded `fix_needed`, `build_fix_artifact`, and `open_fix_pr` only for a concrete repair with a complete executable `fix_artifact`. Use `needs_human` only for unclear scope, active author follow-up, broad work, or another specific maintainer decision. Route security-sensitive work centrally.
+
+## Inventory
+
+### #104404 fix(agents): preserve UTF-16 boundaries in context pruning
+
+- bucket: ready_for_maintainer
+- author: mushuiyu886
+- draft: no
+- assignees: none
+- signals: size XS, proof sufficient, platinum, ready for maintainer look
+- observed head: `f29f14e535c4cb466a596e4e8fa2a9860ce89a52`
+- live updated: 2026-07-11T12:24:30Z
+- live url: https://github.com/openclaw/openclaw/pull/104404


### PR DESCRIPTION
## Summary

- queue isolated autonomous retries for openclaw/openclaw#104110, #104433, and #104404
- pin each inventory note to the current observed head while requiring live re-fetch before mutation
- keep comments, labels, close, force-push, and check bypass disabled

## Validation

- all three jobs pass `validate-job.mjs`
- `npm run validate` (6,673 jobs)
