### PR TITLE
fix(workflows): serialize Clownfish merge application

### DIFF
--- a/.github/workflows/cluster-worker.yml
+++ b/.github/workflows/cluster-worker.yml
@@ -97,6 +97,8 @@ jobs:
       allow_execute: ${{ steps.plan.outputs.allow_execute }}
       allow_fix_pr: ${{ steps.plan.outputs.allow_fix_pr }}
       allow_merge: ${{ steps.plan.outputs.allow_merge }}
+      may_merge: ${{ steps.plan.outputs.may_merge }}
+      target_repo: ${{ steps.plan.outputs.target_repo }}
     steps:
       - uses: actions/checkout@v5
 
@@ -234,6 +236,11 @@ jobs:
           const allowExecute = writeMode && process.env.INPUT_ALLOW_EXECUTE === "1" ? "1" : "0";
           const allowFixPr = writeMode && process.env.INPUT_ALLOW_FIX_PR === "1" ? "1" : "0";
           const allowMerge = writeMode && process.env.INPUT_ALLOW_MERGE === "1" ? "1" : "0";
+          const mayMerge =
+            allowMerge === "1" &&
+            job.frontmatter.allow_merge === true &&
+            allowedActions.has("merge") &&
+            !blockedActions.has("merge");
 
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `job=${job.relativePath}\n`);
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `mode=${mode}\n`);
@@ -249,6 +256,8 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `allow_execute=${allowExecute}\n`);
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `allow_fix_pr=${allowFixPr}\n`);
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `allow_merge=${allowMerge}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `may_merge=${mayMerge ? "1" : "0"}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `target_repo=${job.frontmatter.repo}\n`);
           NODE
 
   cluster:
@@ -411,9 +420,11 @@ jobs:
         if: ${{ always() && (needs.prepare.outputs.mode == 'execute' || needs.prepare.outputs.mode == 'autonomous') && needs.prepare.outputs.dry_run != 'true' }}
         uses: actions/upload-artifact@v7
         with:
-          name: projectclownfish-worker-${{ github.run_id }}-${{ github.run_attempt }}
+          name: projectclownfish-worker-${{ github.run_id }}
           path: .projectclownfish/runs
           if-no-files-found: warn
+          include-hidden-files: true
+          overwrite: true
 
       - name: Upload final worker artifacts
         if: ${{ always() && (!((needs.prepare.outputs.mode == 'execute' || needs.prepare.outputs.mode == 'autonomous') && needs.prepare.outputs.dry_run != 'true') || failure() || cancelled()) }}
@@ -423,9 +434,10 @@ jobs:
           path: |
             .projectclownfish/runs/**
           if-no-files-found: warn
+          include-hidden-files: true
 
   execute:
-    name: Execute and apply cluster actions
+    name: Prepare cluster mutations
     needs:
       - prepare
       - cluster
@@ -573,7 +585,7 @@ jobs:
       - name: Download worker artifacts
         uses: actions/download-artifact@v8
         with:
-          name: projectclownfish-worker-${{ github.run_id }}-${{ github.run_attempt }}
+          name: projectclownfish-worker-${{ github.run_id }}
           path: .projectclownfish/runs
 
       - name: Validate job
@@ -592,8 +604,139 @@ jobs:
         run: |
           npm run run-external-merge-preflights -- "${{ needs.prepare.outputs.job }}" \
             --latest \
+            --phase preflight \
             --max-prs "${{ vars.CLOWNFISH_EXTERNAL_PREFLIGHT_MAX_PRS || '5' }}" \
             --concurrency "${{ vars.CLOWNFISH_EXTERNAL_PREFLIGHT_CONCURRENCY || '3' }}"
+
+      - name: Upload pre-apply artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: projectclownfish-preapply-${{ github.run_id }}
+          path: .projectclownfish/runs
+          if-no-files-found: warn
+          include-hidden-files: true
+          overwrite: true
+
+      - name: Upload failed pre-apply artifacts
+        if: ${{ failure() || cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: projectclownfish-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            .projectclownfish/runs/**
+          if-no-files-found: warn
+          include-hidden-files: true
+
+  apply:
+    name: Apply cluster mutations
+    needs:
+      - prepare
+      - cluster
+      - execute
+    if: ${{ needs.execute.result == 'success' }}
+    runs-on: ${{ needs.prepare.outputs.execution_runner }}
+    timeout-minutes: 30
+    concurrency:
+      group: ${{ needs.prepare.outputs.may_merge == '1' && format('projectclownfish-merge-{0}', needs.prepare.outputs.target_repo) || format('projectclownfish-apply-{0}-{1}', github.run_id, github.run_attempt) }}
+      cancel-in-progress: false
+      queue: max
+    env:
+      CLOWNFISH_ALLOWED_OWNER: ${{ vars.CLOWNFISH_ALLOWED_OWNER || 'openclaw' }}
+      CLOWNFISH_ALLOW_EXECUTE: ${{ needs.cluster.outputs.allow_execute == '1' && '1' || '0' }}
+      CLOWNFISH_ALLOW_FIX_PR: ${{ needs.cluster.outputs.allow_fix_pr == '1' && '1' || '0' }}
+      CLOWNFISH_ALLOW_MERGE: ${{ needs.cluster.outputs.allow_merge || '0' }}
+      CLOWNFISH_POST_FLIGHT_IGNORE_CHECKS: ${{ vars.CLOWNFISH_POST_FLIGHT_IGNORE_CHECKS || 'auto-response,Labeler,Stale' }}
+      CLOWNFISH_MAX_ACTIVE_PRS_PER_AREA: ${{ vars.CLOWNFISH_MAX_ACTIVE_PRS_PER_AREA || '50' }}
+      CLOWNFISH_CLOSE_SUPERSEDED_SOURCE_PRS: ${{ vars.CLOWNFISH_CLOSE_SUPERSEDED_SOURCE_PRS || '0' }}
+      CLOWNFISH_APP_ID: ${{ vars.CLOWNFISH_APP_ID }}
+      CLOWNFISH_READ_GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Create GitHub App token
+        id: app_token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.CLOWNFISH_APP_ID }}
+          private-key: ${{ secrets.CLOWNFISH_APP_PRIVATE_KEY }}
+          owner: ${{ vars.CLOWNFISH_ALLOWED_OWNER || github.repository_owner }}
+          permission-checks: write
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Create workflow-capable GitHub App token
+        id: workflow_app_token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.CLOWNFISH_APP_ID }}
+          private-key: ${{ secrets.CLOWNFISH_APP_PRIVATE_KEY }}
+          owner: ${{ vars.CLOWNFISH_ALLOWED_OWNER || github.repository_owner }}
+          permission-checks: write
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+
+      - name: Select GitHub write token
+        env:
+          CLOWNFISH_APP_GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          CLOWNFISH_WORKFLOW_APP_GH_TOKEN: ${{ steps.workflow_app_token.outputs.token }}
+          CLOWNFISH_WRITE_GH_TOKEN: ${{ secrets.CLOWNFISH_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          summarize_gh_error() {
+            if [ ! -s /tmp/clownfish-gh-token-check.err ]; then
+              return 0
+            fi
+            head -n 5 /tmp/clownfish-gh-token-check.err |
+              sed -E \
+                -e 's/(authorization|bearer|token)[^[:space:]]+/\1=[redacted]/Ig' \
+                -e 's/[A-Za-z0-9_=-]{40,}/[redacted]/g'
+          }
+          for candidate in CLOWNFISH_WRITE_GH_TOKEN CLOWNFISH_WORKFLOW_APP_GH_TOKEN CLOWNFISH_APP_GH_TOKEN GITHUB_TOKEN; do
+            token="${!candidate:-}"
+            if [ -z "$token" ]; then
+              continue
+            fi
+            if full_name="$(GH_TOKEN="$token" gh api "repos/${CLOWNFISH_ALLOWED_OWNER}/openclaw" \
+              --jq 'select((.permissions.push // false) or (.permissions.maintain // false) or (.permissions.admin // false)) | .full_name' \
+              2>/tmp/clownfish-gh-token-check.err)" && [ -n "$full_name" ]; then
+              echo "GH_TOKEN=$token" >> "$GITHUB_ENV"
+              echo "selected $candidate for GitHub write/apply access"
+              exit 0
+            fi
+            echo "::warning::$candidate failed GitHub write/apply probe"
+            summarize_gh_error || true
+          done
+          echo "no GitHub token could reach repos/${CLOWNFISH_ALLOWED_OWNER}/openclaw"
+          exit 1
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+
+      - name: Download pre-apply artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: projectclownfish-preapply-${{ github.run_id }}
+          path: .projectclownfish/runs
+
+      - name: Validate job
+        run: npm run validate:job -- "${{ needs.prepare.outputs.job }}"
+
+      - name: Apply reviewed external merge preflights
+        if: ${{ env.CLOWNFISH_ALLOW_EXECUTE == '1' }}
+        env:
+          CLOWNFISH_CHECKS_GH_TOKEN: ${{ steps.app_token.outputs.token || steps.workflow_app_token.outputs.token }}
+        run: |
+          npm run run-external-merge-preflights -- "${{ needs.prepare.outputs.job }}" \
+            --latest \
+            --phase apply
 
       - name: Apply safe closure actions
         if: ${{ env.CLOWNFISH_ALLOW_EXECUTE == '1' }}
@@ -627,3 +770,4 @@ jobs:
           path: |
             .projectclownfish/runs/**
           if-no-files-found: warn
+          include-hidden-files: true

--- a/.github/workflows/comment-router.yml
+++ b/.github/workflows/comment-router.yml
@@ -54,6 +54,11 @@ jobs:
   route-comments:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      execute: ${{ steps.route.outputs.execute }}
+      target_repo: ${{ steps.route.outputs.target_repo }}
+      merge_since: ${{ steps.route.outputs.merge_since }}
+      merge_comment_ids: ${{ steps.route.outputs.merge_comment_ids }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -77,6 +82,7 @@ jobs:
           node-version: "24"
 
       - name: Route Clownfish comments
+        id: route
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token || secrets.CLOWNFISH_GH_TOKEN || github.token }}
           CLOWNFISH_CLAWSWEEPER_GH_TOKEN: ${{ secrets.CLOWNFISH_GH_TOKEN || steps.app_token.outputs.token || github.token }}
@@ -90,9 +96,12 @@ jobs:
           max_comments="${{ github.event_name == 'workflow_dispatch' && inputs.max_comments || vars.CLOWNFISH_COMMENT_MAX_COMMENTS || '100' }}"
           runner="${{ github.event_name == 'workflow_dispatch' && inputs.runner || vars.CLOWNFISH_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
           execution_runner="${{ github.event_name == 'workflow_dispatch' && inputs.execution_runner || vars.CLOWNFISH_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}"
+          merge_scope_file=".projectclownfish/comment-router-deferred-merges.json"
 
           args=(
             --write-report
+            --defer-merges
+            --deferred-merge-file "$merge_scope_file"
             --repo "$target_repo"
             --lookback-minutes "$lookback_minutes"
             --max-comments "$max_comments"
@@ -108,6 +117,34 @@ jobs:
             args+=(--execute)
           fi
           npm run comment-router -- "${args[@]}"
+
+          SCOPE_FILE="$merge_scope_file" node --input-type=module <<'NODE'
+          import fs from "node:fs";
+
+          const scope = JSON.parse(fs.readFileSync(process.env.SCOPE_FILE, "utf8"));
+          if (!Array.isArray(scope.comment_ids)) throw new Error("deferred merge scope is missing comment_ids");
+          const outputs = {
+            execute: String(scope.execute === true),
+            target_repo: String(scope.repo ?? ""),
+            merge_since: String(scope.since ?? ""),
+            merge_comment_ids: scope.comment_ids.map(String).join(","),
+          };
+          for (const [name, value] of Object.entries(outputs)) {
+            if (value.includes("\n")) throw new Error(`invalid newline in ${name}`);
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+          }
+          NODE
+
+      - name: Upload deferred merge scope
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: comment-router-merge-scope-${{ github.run_id }}
+          path: .projectclownfish/comment-router-deferred-merges.json
+          if-no-files-found: warn
+          include-hidden-files: true
+          overwrite: true
+          retention-days: 14
 
       - name: Commit comment router ledger
         if: always()
@@ -126,6 +163,9 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          route_report=".projectclownfish/comment-router-route-report.json"
+          mkdir -p "$(dirname "$route_report")"
+          cp results/comment-router-latest.json "$route_report"
           git add results/comment-router.json results/comment-router-latest.json jobs/ 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No comment router changes"
@@ -138,6 +178,196 @@ jobs:
               exit 0
             fi
             git fetch origin main
-            git rebase -X theirs origin/main
+            git rebase -X ours origin/main
+
+            REPORT_FILE="$route_report" node --input-type=module <<'NODE'
+          import fs from "node:fs";
+          import path from "node:path";
+          import { appendLedger, readLedger, writeLedger } from "./scripts/comment-router-utils.mjs";
+
+          const report = JSON.parse(fs.readFileSync(process.env.REPORT_FILE, "utf8"));
+          const ledgerFile = path.join("results", "comment-router.json");
+          const latestFile = path.join("results", "comment-router-latest.json");
+          const recordable = (report.commands ?? []).filter((command) =>
+            ["executed", "skipped"].includes(command.status),
+          );
+          if (recordable.length > 0) {
+            const ledger = readLedger(ledgerFile);
+            appendLedger(ledger, recordable);
+            writeLedger(ledgerFile, ledger);
+          }
+          fs.copyFileSync(process.env.REPORT_FILE, latestFile);
+          NODE
+
+            git add results/comment-router.json results/comment-router-latest.json
+            if git diff --cached --quiet; then
+              if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ]; then
+                echo "No comment router changes after refresh"
+                exit 0
+              fi
+            elif [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ]; then
+              git commit -m "chore: record Clownfish comment routing"
+            else
+              git commit --amend --no-edit
+            fi
           done
-          git push
+          exit 1
+
+  merge-comments:
+    needs: route-comments
+    if: ${{ needs.route-comments.result == 'success' && needs.route-comments.outputs.execute == 'true' && needs.route-comments.outputs.merge_comment_ids != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: projectclownfish-merge-${{ needs.route-comments.outputs.target_repo }}
+      cancel-in-progress: false
+      queue: max
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Download deferred merge scope
+        uses: actions/download-artifact@v8
+        with:
+          name: comment-router-merge-scope-${{ github.run_id }}
+          path: .projectclownfish/comment-router-merge-scope
+
+      - name: Create GitHub App token
+        id: app_token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.CLOWNFISH_APP_ID }}
+          private-key: ${{ secrets.CLOWNFISH_APP_PRIVATE_KEY }}
+          owner: ${{ vars.CLOWNFISH_ALLOWED_OWNER || github.repository_owner }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+
+      - name: Replay deferred merge comments
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token || secrets.CLOWNFISH_GH_TOKEN || github.token }}
+          CLOWNFISH_ALLOW_AUTOMERGE: ${{ vars.CLOWNFISH_ALLOW_AUTOMERGE || '0' }}
+          CLOWNFISH_ALLOW_MERGE: ${{ vars.CLOWNFISH_ALLOW_MERGE || '0' }}
+          EXPECTED_TARGET_REPO: ${{ needs.route-comments.outputs.target_repo }}
+          EXPECTED_SINCE: ${{ needs.route-comments.outputs.merge_since }}
+          EXPECTED_COMMENT_IDS: ${{ needs.route-comments.outputs.merge_comment_ids }}
+        run: |
+          set -euo pipefail
+          scope_file=".projectclownfish/comment-router-merge-scope/comment-router-deferred-merges.json"
+          SCOPE_FILE="$scope_file" node --input-type=module <<'NODE'
+          import fs from "node:fs";
+
+          const scope = JSON.parse(fs.readFileSync(process.env.SCOPE_FILE, "utf8"));
+          const actualIds = Array.isArray(scope.comment_ids) ? scope.comment_ids.map(String).join(",") : "";
+          if (scope.execute !== true) throw new Error("deferred merge scope is not executable");
+          if (scope.repo !== process.env.EXPECTED_TARGET_REPO) throw new Error("deferred merge target repo changed");
+          if (scope.since !== process.env.EXPECTED_SINCE) throw new Error("deferred merge since scope changed");
+          if (actualIds !== process.env.EXPECTED_COMMENT_IDS) throw new Error("deferred merge comment IDs changed");
+          NODE
+
+          target_repo="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).repo' "$scope_file")"
+          since="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).since' "$scope_file")"
+          comment_ids="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).comment_ids.join(",")' "$scope_file")"
+          npm run comment-router -- \
+            --execute \
+            --write-report \
+            --merge-only \
+            --merge-scope-file "$scope_file" \
+            --repo "$target_repo" \
+            --since "$since" \
+            --comment-ids "$comment_ids"
+
+      - name: Commit merged comment ledger
+        env:
+          EXPECTED_TARGET_REPO: ${{ needs.route-comments.outputs.target_repo }}
+          EXPECTED_COMMENT_IDS: ${{ needs.route-comments.outputs.merge_comment_ids }}
+        run: |
+          set -euo pipefail
+          report_file=".projectclownfish/comment-router-merge-report.json"
+          cp results/comment-router-latest.json "$report_file"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          apply_report() {
+            REPORT_FILE="$report_file" node --input-type=module <<'NODE'
+          import fs from "node:fs";
+          import path from "node:path";
+          import { appendLedger, readLedger, writeLedger } from "./scripts/comment-router-utils.mjs";
+
+          const report = JSON.parse(fs.readFileSync(process.env.REPORT_FILE, "utf8"));
+          const expectedIds = new Set(String(process.env.EXPECTED_COMMENT_IDS ?? "").split(",").filter(Boolean));
+          const actualIds = new Set((report.commands ?? []).map((command) => String(command.comment_id)));
+          if (report.mode !== "merge_only") throw new Error("merge replay report is not merge_only");
+          if (report.repo !== process.env.EXPECTED_TARGET_REPO) throw new Error("merge replay target repo changed");
+          if (expectedIds.size !== actualIds.size || [...expectedIds].some((id) => !actualIds.has(id))) {
+            throw new Error("merge replay report comment IDs changed");
+          }
+
+          const ledgerFile = path.join("results", "comment-router.json");
+          const latestFile = path.join("results", "comment-router-latest.json");
+          const recordable = (report.commands ?? []).filter((command) =>
+            ["executed", "skipped"].includes(command.status),
+          );
+          if (recordable.length > 0) {
+            const ledger = readLedger(ledgerFile);
+            appendLedger(ledger, recordable);
+            writeLedger(ledgerFile, ledger);
+          }
+          fs.mkdirSync(path.dirname(latestFile), { recursive: true });
+          fs.copyFileSync(process.env.REPORT_FILE, latestFile);
+          NODE
+          }
+
+          apply_report
+          git add results/comment-router.json results/comment-router-latest.json 2>/dev/null || true
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: record queued Clownfish merges"
+          fi
+
+          published=0
+          for attempt in 1 2 3; do
+            echo "Ledger push attempt ${attempt}"
+            if git push origin HEAD:main; then
+              published=1
+              break
+            fi
+            git fetch origin main
+            git rebase -X ours origin/main
+            apply_report
+            git add results/comment-router.json results/comment-router-latest.json
+            if git diff --cached --quiet; then
+              if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ]; then
+                echo "Merged comment ledger already recorded"
+                published=1
+                break
+              fi
+            elif [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ]; then
+              git commit -m "chore: record queued Clownfish merges"
+            else
+              git commit --amend --no-edit
+            fi
+          done
+          if [ "$published" != "1" ]; then
+            exit 1
+          fi
+
+          mkdir -p .projectclownfish/comment-router-merge-result
+          cp results/comment-router.json .projectclownfish/comment-router-merge-result/merge-ledger.json
+          cp "$report_file" .projectclownfish/comment-router-merge-result/merge-report.json
+
+      - name: Upload merge replay result
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: comment-router-merge-result-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .projectclownfish/comment-router-merge-result/
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 14

--- a/.github/workflows/external-merge-preflight.yml
+++ b/.github/workflows/external-merge-preflight.yml
@@ -39,6 +39,7 @@ jobs:
     timeout-minutes: 45
     outputs:
       preflight_passed: ${{ steps.outcome.outputs.preflight_passed }}
+      target_repo: ${{ steps.outcome.outputs.target_repo }}
     steps:
       - uses: actions/checkout@v5
 
@@ -110,7 +111,18 @@ jobs:
           run_dir=".projectclownfish/external-merge-preflight"
           npm run preflight-external-merge -- "$SOURCE_JOB" --pr "$PULL_REQUEST" --run-dir "$run_dir"
           npm run review-results -- "$run_dir"
-          node --input-type=module -e 'import fs from "node:fs"; const report = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); const passed = report.status === "passed"; fs.appendFileSync(process.env.GITHUB_OUTPUT, `preflight_passed=${passed}\n`); if (!passed) console.log(`::notice title=External merge preflight blocked::${report.reason ?? "unknown"}`);' "$run_dir/preflight-report.json"
+          PREFLIGHT_REPORT="$run_dir/preflight-report.json" node --input-type=module <<'NODE'
+          import fs from "node:fs";
+          import { parseJob } from "./scripts/lib.mjs";
+
+          const report = JSON.parse(fs.readFileSync(process.env.PREFLIGHT_REPORT, "utf8"));
+          const passed = report.status === "passed";
+          const targetRepo = parseJob(process.env.SOURCE_JOB).frontmatter.repo;
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `preflight_passed=${passed}\ntarget_repo=${targetRepo}\n`);
+          if (!passed) {
+            console.log(`::notice title=External merge preflight blocked::${report.reason ?? "unknown"}`);
+          }
+          NODE
 
       - name: Upload preflight artifact
         if: always()
@@ -123,6 +135,8 @@ jobs:
             .projectclownfish/external-merge-preflight/cluster-plan.json
             .projectclownfish/external-merge-preflight/preflight-report.json
           if-no-files-found: warn
+          include-hidden-files: true
+          overwrite: true
 
       - name: Fail blocked preflight
         if: ${{ always() && steps.outcome.outputs.preflight_passed != 'true' }}
@@ -136,6 +150,10 @@ jobs:
     if: ${{ needs.preflight.result == 'success' && needs.preflight.outputs.preflight_passed == 'true' && inputs.apply && vars.CLOWNFISH_ALLOW_EXECUTE == '1' && vars.CLOWNFISH_ALLOW_MERGE == '1' }}
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 15
+    concurrency:
+      group: projectclownfish-merge-${{ needs.preflight.outputs.target_repo }}
+      cancel-in-progress: false
+      queue: max
     steps:
       - uses: actions/checkout@v5
 
@@ -177,7 +195,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: external-merge-apply-${{ github.run_id }}
+          name: external-merge-apply-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             .projectclownfish/external-merge-preflight/preflight-job.md
             .projectclownfish/external-merge-preflight/result.json
@@ -185,3 +203,4 @@ jobs:
             .projectclownfish/external-merge-preflight/preflight-report.json
             .projectclownfish/external-merge-preflight/apply-report.json
           if-no-files-found: warn
+          include-hidden-files: true

--- a/scripts/comment-router-utils.mjs
+++ b/scripts/comment-router-utils.mjs
@@ -62,7 +62,12 @@ export function appendLedger(current, entries) {
         : null,
     }));
   const byCommentVersion = new Map((current.commands ?? []).map((entry) => [ledgerEntryKey(entry), entry]));
-  for (const entry of compact) byCommentVersion.set(ledgerEntryKey(entry), entry);
+  for (const entry of compact) {
+    const key = ledgerEntryKey(entry);
+    const previous = byCommentVersion.get(key);
+    if (previous?.status === "executed" && entry.status !== "executed") continue;
+    byCommentVersion.set(key, entry);
+  }
   current.updated_at = new Date().toISOString();
   current.commands = [...byCommentVersion.values()].slice(-1000);
 }

--- a/scripts/comment-router.mjs
+++ b/scripts/comment-router.mjs
@@ -73,9 +73,18 @@ const model = String(args.model ?? process.env.CLOWNFISH_MODEL ?? "gpt-5.5");
 const headPrefix = String(args["head-prefix"] ?? process.env.CLOWNFISH_HEAD_PREFIX ?? DEFAULT_HEAD_PREFIX);
 const label = String(args.label ?? process.env.CLOWNFISH_LABEL ?? DEFAULT_LABEL);
 const execute = Boolean(args.execute);
+const deferMerges = Boolean(args["defer-merges"]);
+const mergeOnly = Boolean(args["merge-only"]);
 const replayLegacyAutomerge = Boolean(args["replay-legacy-automerge"]);
 const writeReport = Boolean(args["write-report"] || execute);
 const waitForCapacity = Boolean(args["wait-for-capacity"]);
+const deferredMergeFile = path.resolve(
+  repoRoot(),
+  String(args["deferred-merge-file"] ?? ".projectclownfish/comment-router-deferred-merges.json"),
+);
+const mergeScopeFile = args["merge-scope-file"]
+  ? path.resolve(repoRoot(), String(args["merge-scope-file"]))
+  : null;
 const maxLiveWorkers = readMaxLiveWorkers(args);
 const maxComments = positiveInteger(args["max-comments"] ?? process.env.CLOWNFISH_COMMENT_MAX_COMMENTS ?? 100, "max-comments");
 const maxAutocloseTargets = positiveInteger(
@@ -120,6 +129,27 @@ const clownfishAuthors = commaSet(
 assertRepo(targetRepo, "repo");
 assertRepo(clownfishRepo, "clownfish-repo");
 assertRepo(clawsweeperRepo, "clawsweeper-repo");
+if (deferMerges && mergeOnly) {
+  throw new Error("--defer-merges and --merge-only are mutually exclusive");
+}
+if (mergeOnly && !execute) {
+  throw new Error("--merge-only requires --execute");
+}
+if (mergeOnly && requestedCommentIds.size === 0) {
+  throw new Error("--merge-only requires --comment-ids for exact replay scope");
+}
+if (mergeOnly && !args.since) {
+  throw new Error("--merge-only requires --since from the deferred replay scope");
+}
+if (mergeOnly && !mergeScopeFile) {
+  throw new Error("--merge-only requires --merge-scope-file for exact replay validation");
+}
+if (mergeScopeFile && !mergeOnly) {
+  throw new Error("--merge-scope-file requires --merge-only");
+}
+if (args["deferred-merge-file"] && !deferMerges) {
+  throw new Error("--deferred-merge-file requires --defer-merges");
+}
 if (replayLegacyAutomerge && requestedCommentIds.size === 0) {
   throw new Error("--replay-legacy-automerge requires --comment-ids for exact replay scope");
 }
@@ -134,6 +164,7 @@ const processedLegacyAutomergeReplays = new Set(
 );
 const plannedAutoRepairHeads = new Set();
 const collaboratorPermissionCache = new Map();
+const mergeScope = mergeOnly ? readMergeScope(mergeScopeFile) : null;
 const allComments = listRecentComments();
 const selectedComments = selectCommentsById(allComments, { ids: requestedCommentIds });
 if (selectedComments.missingIds.length > 0) {
@@ -143,10 +174,26 @@ if (selectedComments.missingIds.length > 0) {
   );
 }
 const comments = selectedComments.comments;
-const commandCandidates = selectCommandCandidates(comments, {
-  limit: maxComments,
-  parse: (comment) => parseCommand(comment.body) ?? parseTrustedAutomation(comment, { trustedAuthors: trustedBots }),
-});
+const parseComment = (comment) =>
+  parseCommand(comment.body) ?? parseTrustedAutomation(comment, { trustedAuthors: trustedBots });
+let commandCandidates;
+if (mergeOnly) {
+  commandCandidates = comments.map((comment) => ({ comment, parsed: parseComment(comment) }));
+  const invalid = commandCandidates.filter(({ parsed }) => !parsed || !MERGE_INTENTS.has(parsed.intent));
+  if (invalid.length > 0) {
+    throw new Error(
+      `--merge-only scope contains comments that are not direct merge intents: ${invalid
+        .map(({ comment }) => comment.id)
+        .join(", ")}`,
+    );
+  }
+  validateMergeReplayComments(mergeScope, commandCandidates);
+} else {
+  commandCandidates = selectCommandCandidates(comments, {
+    limit: maxComments,
+    parse: parseComment,
+  });
+}
 const commands = [];
 
 for (const { comment, parsed } of commandCandidates) {
@@ -176,13 +223,20 @@ for (const { comment, parsed } of commandCandidates) {
     status: "pending",
     actions: [],
   };
-  commands.push(classifyCommand(command));
+  commands.push(
+    execute && deferMerges && MERGE_INTENTS.has(command.intent)
+      ? classifyDeferredMerge(command)
+      : classifyCommand(command),
+  );
 }
 
 const actionable = commands.filter((command) => command.status === "ready");
+const deferredMergeCommands = commands.filter((command) => command.status === "deferred");
+const generatedAt = new Date().toISOString();
 const report = {
   status: execute ? "executed" : "dry_run",
-  generated_at: new Date().toISOString(),
+  mode: mergeOnly ? "merge_only" : deferMerges ? "route" : "all",
+  generated_at: generatedAt,
   repo: targetRepo,
   clownfish_repo: clownfishRepo,
   clawsweeper_repo: clawsweeperRepo,
@@ -195,6 +249,7 @@ const report = {
   scanned_comments: comments.length,
   commands_seen: commands.length,
   actionable: actionable.length,
+  deferred_merge_comments: deferredMergeCommands.length,
   trusted_bots: [...trustedBots],
   allowed_repository_permissions: [...allowedRepositoryPermissions],
   max_auto_repairs_per_head: maxAutoRepairsPerHead,
@@ -210,12 +265,51 @@ if (execute) {
       : assertLiveWorkerCapacity({ repo: clownfishRepo, workflow, requested: dispatchCount, maxLiveWorkers });
   }
   for (const command of actionable) executeCommand(command);
-  appendLedger(ledger, commands);
+  appendLedger(
+    ledger,
+    commands.filter((command) => command.status !== "deferred"),
+  );
   writeLedger(ledgerPath(), ledger);
 }
 
+if (deferMerges) {
+  writeDeferredMergeScope(deferredMergeFile, {
+    generatedAt,
+    commands: deferredMergeCommands,
+  });
+}
 if (writeReport) writeReportFile(repoRoot(), report);
 console.log(JSON.stringify(report, null, 2));
+
+function classifyDeferredMerge(command) {
+  if (command.trusted_bot) {
+    if (!trustedBots.has(String(command.author ?? "").toLowerCase())) {
+      return { ...command, status: "ignored", reason: "trusted automation author is not allowed" };
+    }
+  } else {
+    const authorization = resolveMaintainerCommandAuthorization(command);
+    command.author_repository_permission = authorization.repositoryPermission;
+    if (!authorization.allowed) {
+      return {
+        ...command,
+        status: "ignored",
+        reason: authorization.reason,
+      };
+    }
+  }
+  if (!command.issue_number) {
+    return { ...command, status: "ignored", reason: "could not resolve issue or PR number" };
+  }
+  if (command.comment_version_key && processedCommentVersions.has(command.comment_version_key)) {
+    return { ...command, status: "skipped", reason: "comment version already processed in ledger" };
+  }
+  return {
+    ...command,
+    status: "deferred",
+    reason: "direct merge intent deferred to the serialized merge replay job",
+    actions: [{ action: "merge", status: "deferred" }],
+  };
+}
 
 function classifyCommand(command) {
   if (command.trusted_bot) {
@@ -1293,6 +1387,104 @@ function hasLabel(target, name) {
 
 function ledgerPath() {
   return path.join(repoRoot(), "results", "comment-router.json");
+}
+
+function writeDeferredMergeScope(file, { generatedAt, commands: deferredCommands }) {
+  const scope = {
+    schema_version: 1,
+    generated_at: generatedAt,
+    repo: targetRepo,
+    clownfish_repo: clownfishRepo,
+    since,
+    execute,
+    mode: "merge_only",
+    comment_ids: deferredCommands.map((command) => command.comment_id),
+    comments: deferredCommands.map((command) => ({
+      comment_id: command.comment_id,
+      comment_version_key: command.comment_version_key,
+      comment_url: command.comment_url,
+      comment_created_at: command.comment_created_at,
+      comment_updated_at: command.comment_updated_at,
+      issue_number: command.issue_number,
+      intent: command.intent,
+      author: command.author,
+      expected_head_sha: command.expected_head_sha,
+      finding_id: command.finding_id,
+    })),
+  };
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(scope, null, 2)}\n`);
+}
+
+function readMergeScope(file) {
+  let scope;
+  try {
+    scope = JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch (error) {
+    throw new Error(`could not read deferred merge scope ${file}: ${error.message}`);
+  }
+  if (scope?.schema_version !== 1) throw new Error("deferred merge scope schema_version must be 1");
+  if (scope.mode !== "merge_only") throw new Error("deferred merge scope mode must be merge_only");
+  if (scope.execute !== true) throw new Error("deferred merge scope is not executable");
+  if (scope.repo !== targetRepo) throw new Error("deferred merge scope target repo changed");
+  if (scope.clownfish_repo !== clownfishRepo) throw new Error("deferred merge scope Clownfish repo changed");
+  if (scope.since !== since) throw new Error("deferred merge scope since changed");
+  if (!Array.isArray(scope.comment_ids) || !Array.isArray(scope.comments)) {
+    throw new Error("deferred merge scope is missing comment_ids or comments");
+  }
+  const scopedIds = scope.comment_ids.map(String);
+  const requestedIds = [...requestedCommentIds].map(String);
+  assertExactIdSet(scopedIds, requestedIds, "deferred merge scope comment IDs changed");
+  const detailIds = scope.comments.map((comment) => String(comment?.comment_id ?? ""));
+  assertExactIdSet(scopedIds, detailIds, "deferred merge scope comment details changed");
+  return scope;
+}
+
+function validateMergeReplayComments(scope, candidates) {
+  const scopedById = new Map(scope.comments.map((comment) => [String(comment.comment_id), comment]));
+  assertExactIdSet(
+    scope.comment_ids.map(String),
+    candidates.map(({ comment }) => String(comment.id)),
+    "deferred merge replay comment IDs changed",
+  );
+  for (const { comment, parsed } of candidates) {
+    const id = String(comment.id);
+    const scoped = scopedById.get(id);
+    const current = {
+      comment_version_key: commentVersionKey({
+        comment_id: id,
+        comment_updated_at: comment.updated_at,
+      }),
+      issue_number: issueNumberFromUrl(comment.issue_url),
+      intent: parsed.intent,
+      author: comment.user?.login ?? null,
+      expected_head_sha: parsed.expected_head_sha ?? null,
+    };
+    for (const field of [
+      "comment_version_key",
+      "issue_number",
+      "intent",
+      "author",
+      "expected_head_sha",
+    ]) {
+      if ((scoped?.[field] ?? null) !== current[field]) {
+        throw new Error(`deferred merge comment ${id} changed field ${field}`);
+      }
+    }
+  }
+}
+
+function assertExactIdSet(expected, actual, message) {
+  const expectedSet = new Set(expected);
+  const actualSet = new Set(actual);
+  if (
+    expectedSet.size !== expected.length ||
+    actualSet.size !== actual.length ||
+    expectedSet.size !== actualSet.size ||
+    [...expectedSet].some((id) => !actualSet.has(id))
+  ) {
+    throw new Error(message);
+  }
 }
 
 function idempotencyKey(parsed, issueNumber, commentId, commentUpdatedAt) {

--- a/scripts/run-external-merge-preflights.mjs
+++ b/scripts/run-external-merge-preflights.mjs
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import { assertAllowedOwner, parseArgs, parseJob, repoRoot, validateJob } from "./lib.mjs";
 
 const MERGE_ACTIONS = new Set(["merge_candidate", "merge_canonical"]);
+const PHASES = new Set(["preflight", "apply", "all"]);
 const execFileAsync = promisify(execFile);
 
 const args = parseArgs(process.argv.slice(2));
@@ -25,14 +26,20 @@ const childHeartbeatMs = positiveInteger(
   "CLOWNFISH_EXTERNAL_PREFLIGHT_HEARTBEAT_MS",
 );
 const runRootArg = args["run-root"];
+const phase = String(args.phase ?? "all");
 
 if (!jobPath) {
-  console.error("usage: node scripts/run-external-merge-preflights.mjs <job.md> [result.json] [--latest] [--dry-run]");
+  console.error(
+    "usage: node scripts/run-external-merge-preflights.mjs <job.md> [result.json] [--latest] [--dry-run] [--phase preflight|apply|all]",
+  );
   process.exit(2);
 }
 if (!resultPathArg && !latest) {
   console.error("result path is required unless --latest is set");
   process.exit(2);
+}
+if (!PHASES.has(phase)) {
+  throw new Error("--phase must be preflight, apply, or all");
 }
 
 const job = parseJob(jobPath);
@@ -50,34 +57,46 @@ if (result.cluster_id !== job.frontmatter.cluster_id) {
 }
 
 const runRoot = path.resolve(String(runRootArg ?? path.dirname(resultPath)));
-const requests = findPreflightRequests(result).slice(0, maxPrs);
-const report = {
-  repo: result.repo,
-  cluster_id: result.cluster_id,
-  result_path: path.relative(repoRoot(), resultPath),
-  dry_run: dryRun,
-  preflight_concurrency: concurrency,
-  generated_at: new Date().toISOString(),
-  status: requests.length > 0 ? "planned" : "skipped",
-  actions: [],
-};
-
-const reviewedActions = await mapLimit(requests, concurrency, runPreflightReview);
-for (const action of reviewedActions) {
-  report.actions.push(await applyReviewedPreflight(action));
-}
-
-if (report.actions.some((action) => action.status === "executed")) {
-  report.status = "executed";
-} else if (report.actions.some((action) => action.status === "passed")) {
-  report.status = "passed";
-} else if (report.actions.some((action) => action.status === "blocked")) {
-  report.status = "blocked";
-}
-
 const reportPath = path.join(runRoot, "external-merge-preflight-report.json");
-fs.mkdirSync(path.dirname(reportPath), { recursive: true });
-fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+let report;
+
+if (phase === "preflight" || phase === "all") {
+  const requests = findPreflightRequests(result).slice(0, maxPrs);
+  report = {
+    repo: result.repo,
+    cluster_id: result.cluster_id,
+    result_path: path.relative(repoRoot(), resultPath),
+    dry_run: dryRun,
+    preflight_concurrency: concurrency,
+    generated_at: new Date().toISOString(),
+    status: requests.length > 0 ? "planned" : "skipped",
+    actions: [],
+  };
+  const reviewedActions = await mapLimit(requests, concurrency, runPreflightReview);
+  report.actions = reviewedActions;
+  report.preflight_completed_at = new Date().toISOString();
+  updateReportStatus(report);
+  persistReport(report);
+}
+
+if (phase === "apply") {
+  report = loadReport();
+}
+
+if (phase === "apply" || phase === "all") {
+  report.dry_run = dryRun;
+  report.apply_started_at = new Date().toISOString();
+  for (let index = 0; index < report.actions.length; index += 1) {
+    if (report.actions[index].status !== "passed") continue;
+    report.actions[index] = await applyReviewedPreflight(report.actions[index]);
+    updateReportStatus(report);
+    persistReport(report);
+  }
+  report.apply_completed_at = new Date().toISOString();
+  updateReportStatus(report);
+  persistReport(report);
+}
+
 console.log(JSON.stringify(report, null, 2));
 
 function findPreflightRequests(workerResult) {
@@ -175,7 +194,16 @@ async function applyReviewedPreflight(action) {
     };
   }
 
-  const runDir = path.resolve(repoRoot(), action.run_dir);
+  const runDir = resolveRunDir(action);
+  const preflightReport = readJsonIfExists(path.join(runDir, "preflight-report.json"));
+  if (preflightReport?.status !== "passed") {
+    return {
+      ...action,
+      status: "blocked",
+      reason: preflightReport?.reason ?? "external merge preflight report is missing or no longer passed",
+    };
+  }
+
   const apply = await runNode([
     "scripts/apply-result.mjs",
     path.join(runDir, "preflight-job.md"),
@@ -187,6 +215,7 @@ async function applyReviewedPreflight(action) {
     return {
       ...action,
       status: "blocked",
+      reviewed_head_sha: preflightReport.reviewed_head_sha ?? action.reviewed_head_sha ?? null,
       reason: `guarded merge apply failed: ${compact(apply.stderr || apply.stdout)}`,
     };
   }
@@ -196,6 +225,7 @@ async function applyReviewedPreflight(action) {
   return {
     ...action,
     status: executed ? "executed" : "blocked",
+    reviewed_head_sha: preflightReport.reviewed_head_sha ?? action.reviewed_head_sha ?? null,
     apply_actions: applyReport?.actions ?? [],
     reason: executed ? "guarded external merge applied" : "guarded applicator did not execute a merge",
   };
@@ -227,6 +257,50 @@ async function runNode(commandArgs) {
     clearInterval(heartbeat);
     console.error(`${label}: finished after ${Math.round((Date.now() - started) / 1000)}s`);
   }
+}
+
+function loadReport() {
+  if (!fs.existsSync(reportPath)) {
+    throw new Error(`external merge preflight report does not exist: ${reportPath}`);
+  }
+  const existing = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  if (existing.repo !== result.repo) {
+    throw new Error(`preflight report repo ${existing.repo} does not match result repo ${result.repo}`);
+  }
+  if (existing.cluster_id !== result.cluster_id) {
+    throw new Error(
+      `preflight report cluster ${existing.cluster_id} does not match result cluster ${result.cluster_id}`,
+    );
+  }
+  if (existing.result_path !== path.relative(repoRoot(), resultPath)) {
+    throw new Error("preflight report result path does not match the requested worker result");
+  }
+  if (!Array.isArray(existing.actions)) {
+    throw new Error("preflight report actions must be an array");
+  }
+  return existing;
+}
+
+function persistReport(value) {
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  fs.writeFileSync(reportPath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function updateReportStatus(value) {
+  if (value.actions.some((action) => action.status === "executed")) {
+    value.status = "executed";
+  } else if (value.actions.some((action) => action.status === "passed")) {
+    value.status = "passed";
+  } else if (value.actions.some((action) => action.status === "blocked")) {
+    value.status = "blocked";
+  } else {
+    value.status = "skipped";
+  }
+}
+
+function resolveRunDir(action) {
+  if (!action.run_dir) throw new Error(`preflight action ${action.target ?? "unknown"} is missing run_dir`);
+  return path.resolve(repoRoot(), action.run_dir);
 }
 
 function findLatestResultPath() {

--- a/test/app-token-auth.test.mjs
+++ b/test/app-token-auth.test.mjs
@@ -425,7 +425,7 @@ test("cluster-worker exports a dedicated App token for exact checks", () => {
         /CLOWNFISH_CHECKS_GH_TOKEN: \$\{\{ steps\.app_token\.outputs\.token \|\| steps\.workflow_app_token\.outputs\.token \}\}/g,
       ) ?? []
     ).length,
-    3,
+    4,
   );
 });
 

--- a/test/comment-router-merge-split.test.mjs
+++ b/test/comment-router-merge-split.test.mjs
@@ -1,0 +1,441 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const workflow = fs.readFileSync(path.join(repoRoot, ".github", "workflows", "comment-router.yml"), "utf8");
+const reviewedHead = "a".repeat(40);
+const mergedHead = "b".repeat(40);
+const since = "2026-07-12T00:00:00.000Z";
+const comments = [
+  {
+    id: 202,
+    node_id: "IC_merge",
+    issue_url: "https://api.github.com/repos/openclaw/openclaw/issues/2",
+    html_url: "https://github.com/openclaw/openclaw/pull/2#issuecomment-202",
+    user: { login: "clawsweeper[bot]" },
+    author_association: "NONE",
+    body: `<!-- clawsweeper-verdict: pass sha=${reviewedHead} -->`,
+    created_at: "2026-07-12T00:02:00.000Z",
+    updated_at: "2026-07-12T00:02:00.000Z",
+  },
+  {
+    id: 101,
+    node_id: "IC_status",
+    issue_url: "https://api.github.com/repos/openclaw/openclaw/issues/1",
+    html_url: "https://github.com/openclaw/openclaw/issues/1#issuecomment-101",
+    user: { login: "maintainer" },
+    author_association: "MEMBER",
+    body: "/clownfish status",
+    created_at: "2026-07-12T00:01:00.000Z",
+    updated_at: "2026-07-12T00:01:00.000Z",
+  },
+];
+
+test("route phase defers direct merge intents and exact replay records them once", () => {
+  const fixture = makeFixture();
+  const scopeFile = path.join(fixture.root, ".projectclownfish", "deferred-merges.json");
+  const route = runRouter(fixture, [
+    "--execute",
+    "--defer-merges",
+    "--deferred-merge-file",
+    scopeFile,
+    "--repo",
+    "openclaw/openclaw",
+    "--since",
+    since,
+    "--max-comments",
+    "10",
+  ]);
+
+  assert.equal(route.status, 0, route.stderr || route.stdout);
+  const routeReport = JSON.parse(route.stdout);
+  assert.equal(routeReport.mode, "route");
+  assert.equal(routeReport.actionable, 1);
+  assert.equal(routeReport.deferred_merge_comments, 1);
+  assert.deepEqual(
+    routeReport.commands.map((command) => [command.comment_id, command.status]),
+    [
+      ["202", "deferred"],
+      ["101", "executed"],
+    ],
+  );
+
+  const scope = readJson(scopeFile);
+  assert.equal(scope.repo, "openclaw/openclaw");
+  assert.equal(scope.since, since);
+  assert.equal(scope.execute, true);
+  assert.deepEqual(scope.comment_ids, ["202"]);
+  assert.equal(scope.comments[0].comment_version_key, "202:2026-07-12T00:02:00.000Z");
+
+  const routeLedger = readJson(path.join(fixture.root, "results", "comment-router.json"));
+  assert.deepEqual(routeLedger.commands.map((command) => command.comment_id), ["101"]);
+
+  let state = readJson(fixture.state);
+  assert.equal(state.merged, false);
+  assert.equal(state.issue_comments["1"].length, 1);
+  assert.equal(state.issue_comments["2"].length, 0);
+  assert.equal(state.calls.filter((call) => call.type === "pr_merge").length, 0);
+  assert.equal(state.calls.filter((call) => call.comment_id === "202").length, 0);
+
+  const replay = runRouter(fixture, [
+    "--execute",
+    "--merge-only",
+    "--merge-scope-file",
+    scopeFile,
+    "--repo",
+    scope.repo,
+    "--since",
+    scope.since,
+    "--comment-ids",
+    scope.comment_ids.join(","),
+  ]);
+
+  assert.equal(replay.status, 0, replay.stderr || replay.stdout);
+  const replayReport = JSON.parse(replay.stdout);
+  assert.equal(replayReport.mode, "merge_only");
+  assert.equal(replayReport.commands.length, 1);
+  assert.equal(replayReport.commands[0].comment_id, "202");
+  assert.equal(replayReport.commands[0].status, "executed");
+
+  const replayLedger = readJson(path.join(fixture.root, "results", "comment-router.json"));
+  assert.deepEqual(
+    replayLedger.commands.map((command) => [command.comment_id, command.status]),
+    [
+      ["101", "executed"],
+      ["202", "executed"],
+    ],
+  );
+
+  state = readJson(fixture.state);
+  assert.equal(state.merged, true);
+  assert.equal(state.issue_comments["1"].length, 1);
+  assert.equal(state.issue_comments["2"].length, 1);
+  assert.match(state.issue_comments["2"][0].body, /clownfish-command:202:2026-07-12T00:02:00.000Z/);
+  assert.equal(state.calls.filter((call) => call.type === "pr_merge").length, 1);
+  assert.equal(state.calls.filter((call) => call.comment_id === "202").length, 0);
+});
+
+test("merge replay fails closed when a queued comment is edited", () => {
+  const fixture = makeFixture();
+  const scopeFile = path.join(fixture.root, ".projectclownfish", "deferred-merges.json");
+  const route = runRouter(fixture, [
+    "--execute",
+    "--defer-merges",
+    "--deferred-merge-file",
+    scopeFile,
+    "--repo",
+    "openclaw/openclaw",
+    "--since",
+    since,
+    "--max-comments",
+    "10",
+  ]);
+  assert.equal(route.status, 0, route.stderr || route.stdout);
+
+  const editedComments = comments.map((comment) =>
+    comment.id === 202
+      ? {
+          ...comment,
+          body: `<!-- clawsweeper-verdict: pass sha=${"c".repeat(40)} -->`,
+          updated_at: "2026-07-12T00:04:00.000Z",
+        }
+      : comment,
+  );
+  const replay = runRouter(
+    fixture,
+    [
+      "--execute",
+      "--merge-only",
+      "--merge-scope-file",
+      scopeFile,
+      "--repo",
+      "openclaw/openclaw",
+      "--since",
+      since,
+      "--comment-ids",
+      "202",
+    ],
+    editedComments,
+  );
+
+  assert.notEqual(replay.status, 0);
+  assert.match(replay.stderr, /deferred merge comment 202 changed field comment_version_key/);
+  const state = readJson(fixture.state);
+  assert.equal(state.merged, false);
+  assert.equal(state.calls.filter((call) => call.type === "pr_merge").length, 0);
+});
+
+test("duplicate deferred scopes replay one merge and preserve executed audit", () => {
+  const fixture = makeFixture();
+  const scopeFiles = ["first", "second"].map((name) =>
+    path.join(fixture.root, ".projectclownfish", `deferred-merges-${name}.json`),
+  );
+  for (const scopeFile of scopeFiles) {
+    const route = runRouter(fixture, [
+      "--execute",
+      "--defer-merges",
+      "--deferred-merge-file",
+      scopeFile,
+      "--repo",
+      "openclaw/openclaw",
+      "--since",
+      since,
+      "--max-comments",
+      "10",
+    ]);
+    assert.equal(route.status, 0, route.stderr || route.stdout);
+    assert.deepEqual(readJson(scopeFile).comment_ids, ["202"]);
+  }
+
+  for (const [index, scopeFile] of scopeFiles.entries()) {
+    const replay = runRouter(fixture, [
+      "--execute",
+      "--merge-only",
+      "--merge-scope-file",
+      scopeFile,
+      "--repo",
+      "openclaw/openclaw",
+      "--since",
+      since,
+      "--comment-ids",
+      "202",
+    ]);
+    assert.equal(replay.status, 0, replay.stderr || replay.stdout);
+    assert.equal(JSON.parse(replay.stdout).commands[0].status, index === 0 ? "executed" : "skipped");
+  }
+
+  const state = readJson(fixture.state);
+  assert.equal(state.calls.filter((call) => call.type === "pr_merge").length, 1);
+  const ledger = readJson(path.join(fixture.root, "results", "comment-router.json"));
+  assert.equal(ledger.commands.find((command) => command.comment_id === "202").status, "executed");
+});
+
+test("route phase preserves dry-run behavior without deferring or mutating", () => {
+  const fixture = makeFixture();
+  const scopeFile = path.join(fixture.root, ".projectclownfish", "deferred-merges.json");
+  const result = runRouter(fixture, [
+    "--write-report",
+    "--defer-merges",
+    "--deferred-merge-file",
+    scopeFile,
+    "--repo",
+    "openclaw/openclaw",
+    "--since",
+    since,
+    "--max-comments",
+    "10",
+  ]);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.status, "dry_run");
+  assert.equal(report.mode, "route");
+  assert.equal(report.deferred_merge_comments, 0);
+  assert.equal(report.commands.find((command) => command.comment_id === "202").status, "ready");
+  assert.deepEqual(readJson(scopeFile).comment_ids, []);
+  assert.equal(fs.existsSync(path.join(fixture.root, "results", "comment-router.json")), false);
+
+  const state = readJson(fixture.state);
+  assert.equal(state.merged, false);
+  assert.deepEqual(state.issue_comments, { 1: [], 2: [] });
+  assert.deepEqual(state.calls, []);
+});
+
+test("merge-only requires executable exact replay scope", () => {
+  for (const [args, message] of [
+    [["--execute", "--merge-only", "--comment-ids", "202"], /requires --since/],
+    [["--execute", "--merge-only", "--since", since], /requires --comment-ids/],
+    [["--merge-only", "--since", since, "--comment-ids", "202"], /requires --execute/],
+    [
+      ["--execute", "--merge-only", "--since", since, "--comment-ids", "202"],
+      /requires --merge-scope-file/,
+    ],
+  ]) {
+    const result = spawnSync(process.execPath, ["scripts/comment-router.mjs", ...args], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, CLOWNFISH_REPO: "openclaw/clownfish" },
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, message);
+  }
+});
+
+test("workflow holds the merge queue through replay and ledger publication", () => {
+  const routeStart = workflow.indexOf("  route-comments:");
+  const mergeStart = workflow.indexOf("  merge-comments:");
+  const recordStart = workflow.indexOf("  record-merge-comments:");
+  assert.ok(routeStart >= 0 && mergeStart > routeStart);
+  assert.equal(recordStart, -1);
+
+  const routeJob = workflow.slice(routeStart, mergeStart);
+  const mergeJob = workflow.slice(mergeStart);
+
+  assert.doesNotMatch(routeJob, /\n    concurrency:/);
+  assert.match(routeJob, /--defer-merges/);
+  assert.match(routeJob, /comment-router-merge-scope-\$\{\{ github\.run_id \}\}/);
+  assert.match(routeJob, /overwrite: true/);
+  assert.match(routeJob, /merge_comment_ids: \$\{\{ steps\.route\.outputs\.merge_comment_ids \}\}/);
+  assert.match(routeJob, /git rebase -X ours origin\/main/);
+  assert.match(routeJob, /appendLedger\(ledger, recordable\)/);
+  assert.match(routeJob, /git rev-parse HEAD\)" = "\$\(git rev-parse origin\/main\)"[\s\S]*?git commit -m "chore: record Clownfish comment routing"/);
+  assert.match(routeJob, /git commit --amend --no-edit/);
+  assert.doesNotMatch(routeJob, /git rebase -X theirs/);
+
+  assert.match(mergeJob, /\n    concurrency:\n      group: projectclownfish-merge-\$\{\{ needs\.route-comments\.outputs\.target_repo \}\}/);
+  assert.match(mergeJob, /cancel-in-progress: false/);
+  assert.match(mergeJob, /queue: max/);
+  assert.match(mergeJob, /ref: main/);
+  assert.match(mergeJob, /--merge-only/);
+  assert.match(mergeJob, /--merge-scope-file "\$scope_file"/);
+  assert.match(mergeJob, /--comment-ids "\$comment_ids"/);
+  assert.match(mergeJob, /appendLedger\(ledger, recordable\)/);
+  assert.match(mergeJob, /git push origin HEAD:main/);
+  assert.match(mergeJob, /comment-router-merge-result-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/);
+  assert.ok(mergeJob.indexOf("Replay deferred merge comments") < mergeJob.indexOf("Commit merged comment ledger"));
+  assert.ok(mergeJob.indexOf("Commit merged comment ledger") < mergeJob.indexOf("Upload merge replay result"));
+  assert.equal((workflow.match(/\n    concurrency:/g) ?? []).length, 1);
+});
+
+function makeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-comment-router-"));
+  const scripts = path.join(root, "scripts");
+  const bin = path.join(root, "bin");
+  const state = path.join(root, "state.json");
+  fs.mkdirSync(scripts, { recursive: true });
+  fs.mkdirSync(bin, { recursive: true });
+  fs.mkdirSync(path.join(root, "results"), { recursive: true });
+  for (const file of ["comment-router.mjs", "comment-router-core.mjs", "comment-router-utils.mjs", "lib.mjs"]) {
+    fs.copyFileSync(path.join(repoRoot, "scripts", file), path.join(scripts, file));
+  }
+  fs.writeFileSync(
+    state,
+    `${JSON.stringify({ merged: false, issue_comments: { 1: [], 2: [] }, calls: [] }, null, 2)}\n`,
+  );
+  writeFakeGh(path.join(bin, "gh"));
+  return { root, bin, state };
+}
+
+function runRouter(fixture, args, fixtureComments = comments) {
+  return spawnSync(process.execPath, ["scripts/comment-router.mjs", ...args], {
+    cwd: fixture.root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fixture.bin}${path.delimiter}${process.env.PATH}`,
+      CLOWNFISH_REPO: "openclaw/clownfish",
+      CLOWNFISH_ALLOW_AUTOMERGE: "1",
+      CLOWNFISH_ALLOW_MERGE: "1",
+      FAKE_GH_STATE: fixture.state,
+      FAKE_GH_COMMENTS: JSON.stringify(fixtureComments),
+    },
+  });
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeFakeGh(file) {
+  fs.writeFileSync(
+    file,
+    `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+const stateFile = process.env.FAKE_GH_STATE;
+const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+const comments = JSON.parse(process.env.FAKE_GH_COMMENTS);
+const save = () => fs.writeFileSync(stateFile, JSON.stringify(state, null, 2) + "\\n");
+const send = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
+const inputPayload = () => {
+  const index = args.indexOf("--input");
+  return index >= 0 ? JSON.parse(fs.readFileSync(args[index + 1], "utf8")) : {};
+};
+
+if (args[0] === "api") {
+  const endpoint = args[1];
+  if (endpoint.startsWith("repos/openclaw/openclaw/issues/comments?since=")) {
+    send([comments]);
+    process.exit(0);
+  }
+  if (endpoint === "repos/openclaw/openclaw/collaborators/maintainer/permission") {
+    send({ permission: "write" });
+    process.exit(0);
+  }
+  const issueComments = endpoint.match(/^repos\\/openclaw\\/openclaw\\/issues\\/(\\d+)\\/comments\\?per_page=100$/);
+  if (issueComments) {
+    send([state.issue_comments[issueComments[1]] || []]);
+    process.exit(0);
+  }
+  const createComment = endpoint.match(/^repos\\/openclaw\\/openclaw\\/issues\\/(\\d+)\\/comments$/);
+  if (createComment && args.includes("POST")) {
+    const payload = inputPayload();
+    state.issue_comments[createComment[1]] ||= [];
+    state.issue_comments[createComment[1]].push({ body: payload.body });
+    state.calls.push({ type: "comment", issue_number: createComment[1], body: payload.body });
+    save();
+    send({});
+    process.exit(0);
+  }
+  const reaction = endpoint.match(/^repos\\/openclaw\\/openclaw\\/issues\\/comments\\/(\\d+)\\/reactions$/);
+  if (reaction && args.includes("POST")) {
+    const payload = inputPayload();
+    state.calls.push({ type: "reaction", comment_id: reaction[1], content: payload.content });
+    save();
+    send({});
+    process.exit(0);
+  }
+  if (endpoint === "graphql") {
+    const subject = args.find((arg) => arg.startsWith("subjectId=")) || "";
+    state.calls.push({ type: "clear_reaction", comment_id: subject.includes("status") ? "101" : "202" });
+    save();
+    send({ data: {} });
+    process.exit(0);
+  }
+  if (endpoint === "repos/openclaw/openclaw/issues/1") {
+    send({ number: 1, state: "open", title: "status target", labels: [] });
+    process.exit(0);
+  }
+  if (endpoint === "repos/openclaw/openclaw/issues/2") {
+    send({ number: 2, state: "open", title: "merge target", labels: [], pull_request: {} });
+    process.exit(0);
+  }
+}
+
+if (args[0] === "pr" && args[1] === "view" && args[2] === "2") {
+  send({
+    headRefName: "feature",
+    headRefOid: "${reviewedHead}",
+    author: { login: "contributor" },
+    baseRefName: "main",
+    isDraft: false,
+    labels: [{ name: "clownfish:automerge" }],
+    mergeable: "MERGEABLE",
+    mergeCommit: state.merged ? { oid: "${mergedHead}" } : null,
+    mergeStateStatus: "CLEAN",
+    mergedAt: state.merged ? "2026-07-12T00:03:00.000Z" : null,
+    reviewDecision: "APPROVED",
+    state: state.merged ? "MERGED" : "OPEN",
+    statusCheckRollup: [{ name: "ci", status: "COMPLETED", conclusion: "SUCCESS" }],
+    title: "merge target"
+  });
+  process.exit(0);
+}
+
+if (args[0] === "pr" && args[1] === "merge" && args[2] === "2") {
+  state.merged = true;
+  state.calls.push({ type: "pr_merge", number: "2", args });
+  save();
+  process.exit(0);
+}
+
+process.stderr.write("unexpected fake gh invocation: " + JSON.stringify(args) + "\\n");
+process.exit(1);
+`,
+  );
+  fs.chmodSync(file, 0o755);
+}

--- a/test/comment-router-utils.test.mjs
+++ b/test/comment-router-utils.test.mjs
@@ -76,3 +76,36 @@ test("appendLedger preserves a legacy automerge bridge replay", () => {
     ],
   );
 });
+
+test("appendLedger never downgrades an executed command to skipped", () => {
+  const idempotencyKey = "comment-router:openclaw/openclaw:2:202:2026-07-12T00:02:00Z:automerge";
+  const ledger = {
+    updated_at: null,
+    commands: [
+      {
+        idempotency_key: idempotencyKey,
+        comment_id: "202",
+        comment_version_key: "202:2026-07-12T00:02:00Z",
+        status: "executed",
+        intent: "automerge",
+        issue_number: 2,
+        repo: "openclaw/openclaw",
+      },
+    ],
+  };
+
+  appendLedger(ledger, [
+    {
+      idempotency_key: idempotencyKey,
+      comment_id: "202",
+      comment_version_key: "202:2026-07-12T00:02:00Z",
+      status: "skipped",
+      intent: "automerge",
+      issue_number: 2,
+      repo: "openclaw/openclaw",
+    },
+  ]);
+
+  assert.equal(ledger.commands.length, 1);
+  assert.equal(ledger.commands[0].status, "executed");
+});

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -105,10 +105,11 @@ test("cluster worker chains blocked merge candidates through external preflight"
   assert.match(runnerScript, /scripts\/review-results\.mjs/);
   assert.match(runnerScript, /CLOWNFISH_ALLOW_MERGE !== "1"/);
   assert.match(runnerScript, /scripts\/apply-result\.mjs/);
+  assert.match(runnerScript, /const phase = String\(args\.phase \?\? "all"\)/);
   assert.match(runnerScript, /const reviewedActions = await mapLimit\(requests, concurrency, runPreflightReview\)/);
   assert.match(
     runnerScript,
-    /for \(const action of reviewedActions\) \{\s*report\.actions\.push\(await applyReviewedPreflight\(action\)\);\s*\}/,
+    /for \(let index = 0; index < report\.actions\.length; index \+= 1\) \{[\s\S]*?await applyReviewedPreflight\(report\.actions\[index\]\)/,
   );
   assert.match(runnerScript, /const execFileAsync = promisify\(execFile\)/);
   assert.match(runnerScript, /CLOWNFISH_EXTERNAL_PREFLIGHT_HEARTBEAT_MS/);
@@ -143,13 +144,112 @@ test("cluster worker chains blocked merge candidates through external preflight"
   assert.equal((clusterWorkflow.match(/permission-checks: write/g) ?? []).length >= 2, true);
   assert.match(
     clusterWorkflow,
-    /npm run run-external-merge-preflights -- "\$\{\{ needs\.prepare\.outputs\.job \}\}"[\s\S]*?--max-prs "\$\{\{ vars\.CLOWNFISH_EXTERNAL_PREFLIGHT_MAX_PRS \|\| '5' \}\}"[\s\S]*?--concurrency "\$\{\{ vars\.CLOWNFISH_EXTERNAL_PREFLIGHT_CONCURRENCY \|\| '3' \}\}"/,
+    /npm run run-external-merge-preflights -- "\$\{\{ needs\.prepare\.outputs\.job \}\}"[\s\S]*?--phase preflight[\s\S]*?--max-prs "\$\{\{ vars\.CLOWNFISH_EXTERNAL_PREFLIGHT_MAX_PRS \|\| '5' \}\}"[\s\S]*?--concurrency "\$\{\{ vars\.CLOWNFISH_EXTERNAL_PREFLIGHT_CONCURRENCY \|\| '3' \}\}"/,
   );
-  assert.match(clusterWorkflow, /- name: Run external merge preflights[\s\S]*?- name: Apply safe closure actions/);
+  assert.match(
+    clusterWorkflow,
+    /- name: Apply reviewed external merge preflights[\s\S]*?--phase apply/,
+  );
   assert.match(
     clusterWorkflow,
     /- name: Tag Clownfish targets[\s\S]*?- name: Verify mutation integrity[\s\S]*?- name: Upload final worker artifacts/,
   );
+});
+
+test("external merge runner persists preflight for a reviewer-free sequential apply", () => {
+  const fixture = makeRunnerFixture();
+  try {
+    const liveEnv = {
+      ...fixture.env,
+      CLOWNFISH_ALLOW_EXECUTE: "1",
+      CLOWNFISH_ALLOW_MERGE: "1",
+    };
+    const preflight = runExternalMergeRunner(fixture, ["--phase", "preflight"], liveEnv);
+    assert.equal(preflight.status, 0, preflight.stderr || preflight.stdout);
+
+    const initialReport = JSON.parse(fs.readFileSync(fixture.reportPath, "utf8"));
+    assert.equal(initialReport.status, "passed");
+    assert.equal(initialReport.actions[0].status, "passed");
+    assert.ok(initialReport.preflight_completed_at);
+    assert.equal(fs.existsSync(fixture.mergeLogPath), false);
+
+    writeExecutable(
+      fixture.codexPath,
+      `#!/usr/bin/env node
+require("node:fs").writeFileSync(${JSON.stringify(fixture.unexpectedReviewPath)}, "reviewer invoked during apply");
+process.exit(91);
+`,
+    );
+
+    const gatedApply = runExternalMergeRunner(
+      fixture,
+      ["--phase", "apply"],
+      { ...liveEnv, CLOWNFISH_ALLOW_MERGE: "0" },
+    );
+    assert.equal(gatedApply.status, 0, gatedApply.stderr || gatedApply.stdout);
+    let report = JSON.parse(fs.readFileSync(fixture.reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "passed");
+    assert.match(report.actions[0].reason, /merge gate disabled/);
+    assert.equal(fs.existsSync(fixture.mergeLogPath), false);
+
+    const dryRunApply = runExternalMergeRunner(fixture, ["--phase", "apply", "--dry-run"], liveEnv);
+    assert.equal(dryRunApply.status, 0, dryRunApply.stderr || dryRunApply.stdout);
+    report = JSON.parse(fs.readFileSync(fixture.reportPath, "utf8"));
+    assert.equal(report.dry_run, true);
+    assert.equal(report.actions[0].status, "passed");
+    assert.match(report.actions[0].reason, /dry run/);
+    assert.equal(fs.existsSync(fixture.mergeLogPath), false);
+
+    const apply = runExternalMergeRunner(fixture, ["--phase", "apply"], liveEnv);
+    assert.equal(apply.status, 0, apply.stderr || apply.stdout);
+    report = JSON.parse(fs.readFileSync(fixture.reportPath, "utf8"));
+    assert.equal(report.generated_at, initialReport.generated_at);
+    assert.equal(report.status, "executed", JSON.stringify(report, null, 2));
+    assert.equal(report.dry_run, false);
+    assert.equal(report.actions[0].status, "executed");
+    assert.equal(report.actions[0].apply_actions.length, 1);
+    assert.ok(report.apply_completed_at);
+    assert.equal(fs.existsSync(fixture.unexpectedReviewPath), false);
+    assert.deepEqual(fs.readFileSync(fixture.mergeLogPath, "utf8").trim().split("\n"), ["123"]);
+    const nestedApplyReportPath = path.join(
+      fixture.runRoot,
+      "external-merge-preflight-123",
+      "apply-report.json",
+    );
+    const nestedApplyReport = fs.readFileSync(nestedApplyReportPath, "utf8");
+
+    const secondApply = runExternalMergeRunner(fixture, ["--phase", "apply"], liveEnv);
+    assert.equal(secondApply.status, 0, secondApply.stderr || secondApply.stdout);
+    assert.equal(fs.readFileSync(nestedApplyReportPath, "utf8"), nestedApplyReport);
+    assert.deepEqual(fs.readFileSync(fixture.mergeLogPath, "utf8").trim().split("\n"), ["123"]);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("external merge runner defaults to all while preserving dry-run", () => {
+  const fixture = makeRunnerFixture();
+  try {
+    const child = runExternalMergeRunner(
+      fixture,
+      ["--dry-run"],
+      {
+        ...fixture.env,
+        CLOWNFISH_ALLOW_EXECUTE: "1",
+        CLOWNFISH_ALLOW_MERGE: "1",
+      },
+    );
+    assert.equal(child.status, 0, child.stderr || child.stdout);
+
+    const report = JSON.parse(fs.readFileSync(fixture.reportPath, "utf8"));
+    assert.equal(report.status, "passed");
+    assert.equal(report.dry_run, true);
+    assert.equal(report.actions[0].status, "passed");
+    assert.match(report.actions[0].reason, /dry run; guarded applicator not invoked/);
+    assert.equal(fs.existsSync(fixture.mergeLogPath), false);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
 });
 
 test("external preflight job policy routes planned worker merges even with self-authored proof", () => {
@@ -3600,6 +3700,85 @@ test("external merge preflight blocks merge-risk labels", () => {
   assert.match(report.reason, /blocked live label: merge-risk: availability/);
 });
 
+function makeRunnerFixture() {
+  const fixture = makeFixture({
+    statusCheckRollup: [
+      {
+        name: "fixture",
+        workflowName: "fixture",
+        status: "COMPLETED",
+        conclusion: "SUCCESS",
+        startedAt: "2026-06-19T00:00:00Z",
+        completedAt: "2026-06-19T00:00:01Z",
+      },
+    ],
+  });
+  const runRoot = path.join(fixture.root, "runner");
+  const resultPath = path.join(fixture.root, "runner-result.json");
+  const reportPath = path.join(runRoot, "external-merge-preflight-report.json");
+  const unexpectedReviewPath = path.join(fixture.root, "unexpected-review");
+  fs.writeFileSync(
+    resultPath,
+    `${JSON.stringify(
+      {
+        status: "planned",
+        repo: "openclaw/openclaw",
+        cluster_id: "fixture-source",
+        mode: "plan",
+        actions: [
+          {
+            target: "#123",
+            action: "merge_candidate",
+            status: "blocked",
+            reason: "external_merge_preflight_required",
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return {
+    ...fixture,
+    runRoot,
+    resultPath,
+    reportPath,
+    unexpectedReviewPath,
+    env: {
+      ...process.env,
+      PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH}`,
+      CLOWNFISH_ALLOWED_OWNER: "openclaw",
+      CLOWNFISH_APPLY_MERGE_BINDING_ATTEMPTS: "1",
+      CLOWNFISH_APPLY_MERGE_BINDING_DELAY_MS: "0",
+      CLOWNFISH_APPLY_MERGEABLE_POLL_DELAY_MS: "0",
+      CLOWNFISH_APP_ID: "3535277",
+      CLOWNFISH_CHECKS_GH_TOKEN: "fixture-checks-token",
+      CLOWNFISH_EXTERNAL_PREFLIGHT_HEARTBEAT_MS: "10000",
+      CLOWNFISH_MERGEABLE_POLL_DELAY_MS: "0",
+    },
+  };
+}
+
+function runExternalMergeRunner(fixture, extraArgs, env) {
+  return spawnSync(
+    process.execPath,
+    [
+      "scripts/run-external-merge-preflights.mjs",
+      fixture.jobPath,
+      fixture.resultPath,
+      "--run-root",
+      fixture.runRoot,
+      ...extraArgs,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env,
+      timeout: 60_000,
+    },
+  );
+}
+
 function runPreflightFixture(fixture, extraEnv = {}) {
   const child = spawnSync(
     process.execPath,
@@ -3679,6 +3858,9 @@ function makeFixture({
   const mergeTreeSha = "c".repeat(40);
   const syntheticMergeSha = "d".repeat(40);
   const baseBlobSha = "e".repeat(40);
+  const squashCommitSha = "f".repeat(40);
+  const baseTreeSha = "1".repeat(40);
+  const squashTreeSha = "2".repeat(40);
   const effectiveContent = "fixture effective content\n";
   const mergeBlobSha = createHash("sha1")
     .update(`blob ${Buffer.byteLength(effectiveContent)}\0`)
@@ -3698,6 +3880,10 @@ function makeFixture({
   const codexPromptPath = path.join(root, "codex-prompt.txt");
   const codexArgsPath = path.join(root, "codex-args.json");
   const codexCountPath = path.join(root, "codex-count");
+  const codexPath = path.join(binDir, "codex");
+  const mergeLogPath = path.join(root, "merge.log");
+  const mergedStatePath = path.join(root, "merged");
+  const exactMergeCheckStatePath = path.join(root, "exact-merge-check.json");
   const gitConfigStatePath = path.join(root, "git-config-state");
   const gitIncludedConfigStatePath = path.join(root, "git-included-config-state");
   const finalIssueComments = rehydratedIssueComments ?? issueComments;
@@ -3763,7 +3949,29 @@ const path = require("node:path");
 const args = process.argv.slice(2);
 const head = ${JSON.stringify(headSha)};
 const base = ${JSON.stringify(baseSha)};
+const baseTree = ${JSON.stringify(baseTreeSha)};
+const mergeTree = ${JSON.stringify(mergeTreeSha)};
+const testMerge = ${JSON.stringify(syntheticMergeSha)};
+const squashCommit = ${JSON.stringify(squashCommitSha)};
+const squashTree = ${JSON.stringify(squashTreeSha)};
+const baseBlob = ${JSON.stringify(baseBlobSha)};
+const mergeBlob = ${JSON.stringify(mergeBlobSha)};
 const mergeViews = ${JSON.stringify(mergeViews)};
+const mergedStatePath = ${JSON.stringify(mergedStatePath)};
+const mergeLogPath = ${JSON.stringify(mergeLogPath)};
+const exactMergeCheckStatePath = ${JSON.stringify(exactMergeCheckStatePath)};
+const isMerged = () => fs.existsSync(mergedStatePath);
+function write(value) {
+  process.stdout.write(JSON.stringify(value));
+}
+function exactMergeChecks() {
+  return fs.existsSync(exactMergeCheckStatePath)
+    ? JSON.parse(fs.readFileSync(exactMergeCheckStatePath, "utf8"))
+    : [];
+}
+function writeExactMergeCheck(check) {
+  fs.writeFileSync(exactMergeCheckStatePath, JSON.stringify([check]));
+}
 function nextValue(name, initial, refreshed) {
   const counterPath = path.join(${JSON.stringify(root)}, name);
   const count = fs.existsSync(counterPath) ? Number(fs.readFileSync(counterPath, "utf8")) : 0;
@@ -3778,12 +3986,17 @@ if (args[0] === "repo" && args[1] === "clone") {
   fs.writeFileSync(path.join(target, "src", "effective.ts"), ${JSON.stringify(effectiveContent)});
   process.exit(0);
 }
+if (args[0] === "pr" && args[1] === "merge") {
+  fs.appendFileSync(mergeLogPath, "123\\n");
+  fs.writeFileSync(mergedStatePath, "merged");
+  process.exit(0);
+}
 if (args[0] === "pr" && args[1] === "view") {
   const counterPath = ${JSON.stringify(path.join(root, "pr-view-count"))};
   const count = fs.existsSync(counterPath) ? Number(fs.readFileSync(counterPath, "utf8")) : 0;
   fs.writeFileSync(counterPath, String(count + 1));
   const mergeView = Array.isArray(mergeViews) ? mergeViews[Math.min(count, mergeViews.length - 1)] : {};
-  console.log(JSON.stringify({ comments: mergeView.comments ?? ${JSON.stringify(issueComments)}, headRefOid: mergeView.headRefOid ?? head, isDraft: false, mergeStateStatus: mergeView.mergeStateStatus ?? ${JSON.stringify(mergeStateStatus)}, mergeable: mergeView.mergeable ?? "MERGEABLE", reviewDecision: mergeView.reviewDecision ?? "APPROVED", reviews: mergeView.reviews ?? ${JSON.stringify(reviews)}, statusCheckRollup: mergeView.statusCheckRollup ?? ${JSON.stringify(statusCheckRollup)}, updatedAt: mergeView.updatedAt ?? "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" }));
+  write({ baseRefName: "main", comments: mergeView.comments ?? ${JSON.stringify(issueComments)}, headRefOid: mergeView.headRefOid ?? head, isDraft: false, mergeCommit: { oid: isMerged() ? squashCommit : testMerge }, mergeStateStatus: mergeView.mergeStateStatus ?? ${JSON.stringify(mergeStateStatus)}, mergeable: mergeView.mergeable ?? "MERGEABLE", mergedAt: isMerged() ? "2026-06-19T00:10:00Z" : null, reviewDecision: mergeView.reviewDecision ?? "APPROVED", reviews: mergeView.reviews ?? ${JSON.stringify(reviews)}, state: isMerged() ? "MERGED" : "OPEN", statusCheckRollup: mergeView.statusCheckRollup ?? ${JSON.stringify(statusCheckRollup)}, updatedAt: mergeView.updatedAt ?? "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" });
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {
@@ -3802,7 +4015,93 @@ if (args[0] === "api" && args[1].includes("/pulls/123/comments")) {
   process.exit(0);
 }
 if (args[0] === "api" && args[1].includes("/issues/123/comments")) {
-  console.log(${JSON.stringify(JSON.stringify(issueComments))});
+  const comments = ${JSON.stringify(issueComments)};
+  console.log(JSON.stringify(args.includes("--slurp") ? [comments] : comments));
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/ref/heads/main") {
+  write({ object: { sha: base } });
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/rules/branches/main") {
+  write([
+    {
+      type: "required_status_checks",
+      parameters: {
+        strict_required_status_checks_policy: true,
+        required_status_checks: [
+          { context: "clownfish/exact-merge", integration_id: 3535277 },
+        ],
+      },
+    },
+  ]);
+  process.exit(0);
+}
+if (args[0] === "api" && args[1].startsWith("repos/openclaw/openclaw/commits/" + testMerge + "/check-runs?")) {
+  const checks = exactMergeChecks();
+  write({ total_count: checks.length, check_runs: checks });
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/check-runs" && args.includes("POST")) {
+  const inputIndex = args.indexOf("--input");
+  const payload = JSON.parse(fs.readFileSync(args[inputIndex + 1], "utf8"));
+  const check = {
+    id: 4242,
+    name: payload.name,
+    head_sha: payload.head_sha,
+    external_id: payload.external_id,
+    status: payload.status,
+    conclusion: payload.conclusion ?? null,
+    app: { id: 3535277 },
+  };
+  writeExactMergeCheck(check);
+  write(check);
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/check-runs/4242" && args.includes("PATCH")) {
+  const inputIndex = args.indexOf("--input");
+  const payload = JSON.parse(fs.readFileSync(args[inputIndex + 1], "utf8"));
+  const previous = exactMergeChecks()[0];
+  const check = {
+    id: 4242,
+    name: payload.name,
+    head_sha: previous?.head_sha ?? testMerge,
+    external_id: previous?.external_id,
+    status: payload.status,
+    conclusion: payload.conclusion,
+    app: { id: 3535277 },
+  };
+  writeExactMergeCheck(check);
+  write(check);
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/commits/" + testMerge) {
+  write({ sha: testMerge, tree: { sha: mergeTree }, parents: [{ sha: base }, { sha: head }] });
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/commits/" + squashCommit) {
+  write({ sha: squashCommit, tree: { sha: squashTree }, parents: [{ sha: base }] });
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/commits/" + base) {
+  write({ sha: base, tree: { sha: baseTree }, parents: [] });
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/trees/" + baseTree + "?recursive=1") {
+  write({
+    truncated: false,
+    tree: [{ path: "src/effective.ts", mode: "100644", type: "blob", sha: baseBlob }],
+  });
+  process.exit(0);
+}
+if (
+  args[0] === "api" &&
+  [mergeTree, squashTree].some((tree) => args[1] === "repos/openclaw/openclaw/git/trees/" + tree + "?recursive=1")
+) {
+  write({
+    truncated: false,
+    tree: [{ path: "src/effective.ts", mode: "100644", type: "blob", sha: mergeBlob }],
+  });
   process.exit(0);
 }
 if (args[0] === "api" && args[1].endsWith("/issues/123")) {
@@ -3811,7 +4110,7 @@ if (args[0] === "api" && args[1].endsWith("/issues/123")) {
     { state: "open", updated_at: ${JSON.stringify(issueUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, assignees: ${JSON.stringify(pullAssignees)} },
     { state: ${JSON.stringify(finalState)}, updated_at: ${JSON.stringify(finalIssueUpdatedAt)}, labels: ${JSON.stringify(finalPullLabels)}, assignees: ${JSON.stringify(finalPullAssignees)} },
   );
-  console.log(JSON.stringify({ ...issue, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/openclaw/openclaw/pull/123", pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/123" } }));
+  console.log(JSON.stringify({ number: 123, ...issue, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/openclaw/openclaw/pull/123", pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/123" } }));
   process.exit(0);
 }
 if (args[0] === "api" && args[1].endsWith("/pulls/123")) {
@@ -3820,7 +4119,7 @@ if (args[0] === "api" && args[1].endsWith("/pulls/123")) {
     { state: "open", updated_at: ${JSON.stringify(pullUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, assignees: ${JSON.stringify(pullAssignees)}, headSha: head },
     { state: ${JSON.stringify(finalState)}, updated_at: ${JSON.stringify(finalPullUpdatedAt)}, labels: ${JSON.stringify(finalPullLabels)}, assignees: ${JSON.stringify(finalPullAssignees)}, headSha: ${JSON.stringify(finalHeadSha)} },
   );
-  console.log(JSON.stringify({ number: 123, ...pull, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/openclaw/openclaw/pull/123", user: ${JSON.stringify(pullUser)}, head: { sha: pull.headSha, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: base, ref: "main" } }));
+  write({ number: 123, ...pull, state: isMerged() ? "closed" : pull.state, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/openclaw/openclaw/pull/123", merged_at: isMerged() ? "2026-06-19T00:10:00Z" : null, merge_commit_sha: isMerged() ? squashCommit : testMerge, user: ${JSON.stringify(pullUser)}, head: { sha: pull.headSha, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: base, ref: "main" } });
   process.exit(0);
 }
 process.stderr.write("unexpected gh command: " + args.join(" "));
@@ -3961,7 +4260,7 @@ if (failure && args[0] === "check:changed") {
 `,
   );
   writeExecutable(
-    path.join(binDir, "codex"),
+    codexPath,
     `#!/usr/bin/env node
 const fs = require("node:fs");
 const args = process.argv.slice(2);
@@ -4001,6 +4300,7 @@ if (!${JSON.stringify(codexSkipsSecondWrite)} || count === 0) {
   return {
     baseSha,
     binDir,
+    codexPath,
     effectiveDiffSha256,
     codexArgsPath,
     codexCountPath,
@@ -4009,7 +4309,9 @@ if (!${JSON.stringify(codexSkipsSecondWrite)} || count === 0) {
     headSha,
     jobPath,
     mergeTreeSha,
+    mergeLogPath,
     pnpmCommandsPath,
+    root,
     runDir,
     syntheticMergeSha,
   };

--- a/test/workflow-serialization.test.mjs
+++ b/test/workflow-serialization.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const clusterWorkflow = readWorkflow("cluster-worker.yml");
+const externalWorkflow = readWorkflow("external-merge-preflight.yml");
+const commentRouterWorkflow = readWorkflow("comment-router.yml");
+
+test("cluster workers prepare in parallel and serialize final mutations by target repo", () => {
+  assert.match(clusterWorkflow, /target_repo: \$\{\{ steps\.plan\.outputs\.target_repo \}\}/);
+  assert.match(clusterWorkflow, /target_repo=\$\{job\.frontmatter\.repo\}/);
+  assert.match(clusterWorkflow, /may_merge: \$\{\{ steps\.plan\.outputs\.may_merge \}\}/);
+  assert.match(clusterWorkflow, /may_merge=\$\{mayMerge \? "1" : "0"\}/);
+
+  const prepareMutations = jobBody(clusterWorkflow, "execute", "apply");
+  assert.match(prepareMutations, /--phase preflight/);
+  assert.match(prepareMutations, /name: projectclownfish-preapply-/);
+  assert.doesNotMatch(prepareMutations, /npm run apply-result/);
+  assert.doesNotMatch(prepareMutations, /npm run post-flight/);
+  assert.doesNotMatch(prepareMutations, /--phase apply/);
+
+  const applyMutations = jobBody(clusterWorkflow, "apply");
+  assert.match(
+    applyMutations,
+    /needs\.prepare\.outputs\.may_merge == '1'[\s\S]*?projectclownfish-merge-\{0\}[\s\S]*?needs\.prepare\.outputs\.target_repo[\s\S]*?projectclownfish-apply-\{0\}-\{1\}/,
+  );
+  assert.match(applyMutations, /cancel-in-progress: false/);
+  assert.match(applyMutations, /queue: max/);
+  assert.match(applyMutations, /name: projectclownfish-preapply-/);
+  assert.match(applyMutations, /--phase apply/);
+  assert.match(applyMutations, /npm run apply-result/);
+  assert.match(applyMutations, /npm run post-flight/);
+});
+
+test("standalone preflight and comment-router merges share the repository mutation queue", () => {
+  const externalApply = jobBody(externalWorkflow, "apply");
+  assert.match(externalWorkflow, /target_repo: \$\{\{ steps\.outcome\.outputs\.target_repo \}\}/);
+  assert.match(externalApply, /group: projectclownfish-merge-\$\{\{ needs\.preflight\.outputs\.target_repo \}\}/);
+  assert.match(externalApply, /cancel-in-progress: false/);
+  assert.match(externalApply, /queue: max/);
+  assert.match(
+    externalWorkflow,
+    /external-merge-preflight-\$\{\{ github\.run_id \}\}/,
+  );
+
+  const router = jobBody(commentRouterWorkflow, "route-comments", "merge-comments");
+  const routerMerge = jobBody(commentRouterWorkflow, "merge-comments");
+  assert.doesNotMatch(router, /\n    concurrency:/);
+  assert.match(router, /--defer-merges/);
+  assert.match(routerMerge, /group: projectclownfish-merge-\$\{\{ needs\.route-comments\.outputs\.target_repo \}\}/);
+  assert.match(routerMerge, /cancel-in-progress: false/);
+  assert.match(routerMerge, /queue: max/);
+  assert.match(routerMerge, /--merge-only/);
+  assert.match(routerMerge, /--merge-scope-file/);
+  assert.match(routerMerge, /git push origin HEAD:main/);
+  assert.doesNotMatch(commentRouterWorkflow, /\n  record-merge-comments:/);
+});
+
+test("serialized workflow artifacts include hidden ProjectClownfish paths", () => {
+  for (const workflow of [clusterWorkflow, externalWorkflow, commentRouterWorkflow]) {
+    const uploads = workflow.match(/uses: actions\/upload-artifact@v7/g) ?? [];
+    const hiddenOptIns = workflow.match(/include-hidden-files: true/g) ?? [];
+    assert.ok(uploads.length > 0);
+    assert.equal(hiddenOptIns.length, uploads.length);
+  }
+});
+
+test("producer artifacts survive failed-job reruns", () => {
+  for (const [workflow, name] of [
+    [clusterWorkflow, "projectclownfish-worker"],
+    [clusterWorkflow, "projectclownfish-preapply"],
+    [externalWorkflow, "external-merge-preflight"],
+    [commentRouterWorkflow, "comment-router-merge-scope"],
+  ]) {
+    const producer = new RegExp(
+      `uses: actions/upload-artifact@v7[\\s\\S]*?name: ${name}-\\$\\{\\{ github\\.run_id \\}\\}[\\s\\S]*?overwrite: true`,
+    );
+    const consumer = new RegExp(
+      `uses: actions/download-artifact@v8[\\s\\S]*?name: ${name}-\\$\\{\\{ github\\.run_id \\}\\}`,
+    );
+    assert.match(workflow, producer);
+    assert.match(workflow, consumer);
+    assert.doesNotMatch(
+      workflow,
+      new RegExp(`${name}-\\$\\{\\{ github\\.run_id \\}\\}-\\$\\{\\{ github\\.run_attempt \\}\\}`),
+    );
+  }
+});
+
+function readWorkflow(name) {
+  return fs.readFileSync(path.join(repoRoot, ".github", "workflows", name), "utf8");
+}
+
+function jobBody(workflow, jobName, nextJobName = null) {
+  const start = workflow.indexOf(`\n  ${jobName}:\n`);
+  assert.notEqual(start, -1, `missing ${jobName} job`);
+  const end = nextJobName ? workflow.indexOf(`\n  ${nextJobName}:\n`, start + 1) : workflow.length;
+  assert.notEqual(end, -1, `missing ${nextJobName} job`);
+  return workflow.slice(start, end);
+}


### PR DESCRIPTION
## Summary

- split merge preflight/review from final mutation application
- serialize all merge-capable jobs per target repository while keeping preparation parallel
- defer comment-router merge intents into the same repository queue with exact comment-version replay
- keep ledger publication inside the queue and preserve hidden/rerun-scoped artifacts

## Validation

- `npm run validate` (6,673 jobs)
- `node --test test/comment-router*.test.mjs test/workflow-serialization.test.mjs test/app-token-auth.test.mjs test/preflight-external-pr-merge.test.mjs` (190 passed)
- focused post-rebase router/workflow tests (11 passed)
- workflow YAML parse and `git diff --check`
- actionlint clean except its stale schema rejecting GitHub `concurrency.queue: max`