### PR TITLE
fix(preflight): handle ClawSweeper review-start leases

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -2636,6 +2636,13 @@ function isClawSweeperReviewStartComment({ author, body, pull }) {
   const normalized = String(body ?? "").trim();
   if (!/^clawsweeper status: review started\.(?:\r?\n|$)/i.test(normalized)) return false;
   if (/<!--\s*clawsweeper-(?:verdict|action):/i.test(normalized)) return false;
+  const visibleBody = normalized.replace(/<!--[\s\S]*?-->/g, "").trim().toLowerCase();
+  if (
+    hasActionableClawSweeperReviewSignal(visibleBody) ||
+    hasSecuritySensitiveText([visibleBody])
+  ) {
+    return false;
+  }
 
   const statusOpeners =
     normalized.match(/<!--\s*clawsweeper-review-status:started\b/gi) ?? [];
@@ -2673,7 +2680,8 @@ function isClawSweeperReviewStartComment({ author, body, pull }) {
     lease.item === pullNumber &&
     Number.isFinite(startedAt) &&
     Number.isFinite(leaseExpiresAt) &&
-    leaseExpiresAt > startedAt
+    leaseExpiresAt > startedAt &&
+    leaseExpiresAt > Date.now()
   );
 }
 

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -756,13 +756,15 @@ function readOnlyBlockers({
     const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
     return isClawSweeperReviewStartComment({ author, body: comment.body, pull });
   });
-  const isStaleIssueCommentCoveredByReviewStart = (comment) => {
+  const isStaleReadyCommentCoveredByReviewStart = (comment) => {
     if (!hasExactHeadClawSweeperReviewStart) return false;
     const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
-    return (
-      isClawSweeperAuthor(author) &&
-      isStaleAutomationReviewComment({ author, body: comment.body, pull })
-    );
+    return isStaleClawSweeperReadyReviewComment({
+      author,
+      body: comment.body,
+      pull,
+      view,
+    });
   };
   const reviewComments =
     hydratedReviewComments ??
@@ -777,7 +779,6 @@ function readOnlyBlockers({
     ...issueComments
       .filter(
         (comment) =>
-          !isStaleIssueCommentCoveredByReviewStart(comment) &&
           !isNonBlockingCommentEvidence(comment, {
             pull,
             view,
@@ -817,7 +818,7 @@ function readOnlyBlockers({
   const actionableIssueComments = issueComments.filter(
     (comment, index) =>
       !isSupersededDependencyGuardNotice(comment, issueComments.slice(index + 1), { pull, view }) &&
-      !isStaleIssueCommentCoveredByReviewStart(comment) &&
+      !isStaleReadyCommentCoveredByReviewStart(comment) &&
       isActionableCommentEvidence(comment, {
         pull,
         view,
@@ -2616,6 +2617,20 @@ function isClawSweeperReadyReviewComment({ author, body, pull, view = null }) {
   return !hasActionableClawSweeperReviewSignal(currentReview, { view }) && hasClawSweeperReadyReviewSignal(currentReview);
 }
 
+function isStaleClawSweeperReadyReviewComment({ author, body, pull, view = null }) {
+  if (!isClawSweeperAuthor(author)) return false;
+  const normalized = String(body ?? "").trim().toLowerCase();
+  const marker = parseClawSweeperReadyMarker({ body: normalized, pull });
+  const headSha = String(pull?.head?.sha ?? "").toLowerCase();
+  if (!marker || !/^[0-9a-f]{40}$/.test(headSha) || marker.sha === headSha) return false;
+
+  const currentReview = normalized.split(/<details>/, 1)[0];
+  return (
+    !hasActionableClawSweeperReviewSignal(currentReview, { view }) &&
+    hasClawSweeperReadyReviewSignal(currentReview)
+  );
+}
+
 function isClawSweeperReviewStartComment({ author, body, pull }) {
   if (!isClawSweeperAuthor(author)) return false;
   const normalized = String(body ?? "").trim();
@@ -2818,31 +2833,39 @@ function isTrustedExactHeadReadyReviewComment(comment, { pull }) {
 }
 
 function hasExactHeadClawSweeperReadyMarker({ body, pull }) {
-  if (/<!--\s*clawsweeper-action:/i.test(body)) return false;
+  const marker = parseClawSweeperReadyMarker({ body, pull });
+  const headSha = String(pull?.head?.sha ?? "").toLowerCase();
+  return Boolean(marker && /^[0-9a-f]{40}$/.test(headSha) && marker.sha === headSha);
+}
+
+function parseClawSweeperReadyMarker({ body, pull }) {
+  if (/<!--\s*clawsweeper-action:/i.test(body)) return null;
 
   const verdictOpeners = body.match(/<!--\s*clawsweeper-verdict:/gi) ?? [];
-  if (verdictOpeners.length !== 1) return false;
+  if (verdictOpeners.length !== 1) return null;
   const verdicts = [...body.matchAll(/<!--\s*clawsweeper-verdict:([a-z-]+)\s+([^>]*)-->/gi)];
-  if (verdicts.length !== 1 || verdicts[0][1].toLowerCase() !== "needs-human") return false;
+  if (verdicts.length !== 1 || verdicts[0][1].toLowerCase() !== "needs-human") return null;
 
   const attributes = parseMarkerAttributes(verdicts[0][2]);
-  if (!attributes) return false;
+  if (!attributes) return null;
   const reviewOpeners = body.match(/<!--\s*clawsweeper-review(?=\s)/gi) ?? [];
-  if (reviewOpeners.length !== 1) return false;
+  if (reviewOpeners.length !== 1) return null;
   const reviews = [...body.matchAll(/<!--\s*clawsweeper-review\s+([^>]*)-->/gi)];
-  if (reviews.length !== 1) return false;
+  if (reviews.length !== 1) return null;
   const reviewAttributes = parseMarkerAttributes(reviews[0][1]);
-  if (!reviewAttributes) return false;
+  if (!reviewAttributes) return null;
 
-  const headSha = String(pull?.head?.sha ?? "").toLowerCase();
   const pullNumber = String(pull?.number ?? "");
-  return (
-    /^[0-9a-f]{40}$/.test(headSha) &&
-    attributes.sha?.toLowerCase() === headSha &&
-    attributes.item === pullNumber &&
-    attributes.confidence === "high" &&
-    reviewAttributes.item === pullNumber
-  );
+  const reviewedHeadSha = String(attributes.sha ?? "").toLowerCase();
+  if (
+    !/^[0-9a-f]{40}$/.test(reviewedHeadSha) ||
+    attributes.item !== pullNumber ||
+    attributes.confidence !== "high" ||
+    reviewAttributes.item !== pullNumber
+  ) {
+    return null;
+  }
+  return { sha: reviewedHeadSha };
 }
 
 function parseMarkerAttributes(input) {

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -2636,13 +2636,6 @@ function isClawSweeperReviewStartComment({ author, body, pull }) {
   const normalized = String(body ?? "").trim();
   if (!/^clawsweeper status: review started\.(?:\r?\n|$)/i.test(normalized)) return false;
   if (/<!--\s*clawsweeper-(?:verdict|action):/i.test(normalized)) return false;
-  const visibleBody = normalized.replace(/<!--[\s\S]*?-->/g, "").trim().toLowerCase();
-  if (
-    hasActionableClawSweeperReviewSignal(visibleBody) ||
-    hasSecuritySensitiveText([visibleBody])
-  ) {
-    return false;
-  }
 
   const statusOpeners =
     normalized.match(/<!--\s*clawsweeper-review-status:started\b/gi) ?? [];
@@ -2660,6 +2653,22 @@ function isClawSweeperReviewStartComment({ author, body, pull }) {
     statuses.length !== 1 ||
     leaseOpeners.length !== 1 ||
     leases.length !== 1
+  ) {
+    return false;
+  }
+  const statusEnd = statuses[0].index + statuses[0][0].length;
+  const leaseEnd = leases[0].index + leases[0][0].length;
+  if (
+    statuses[0].index >= leases[0].index ||
+    normalized.slice(statusEnd, leases[0].index).trim() ||
+    normalized.slice(leaseEnd).trim()
+  ) {
+    return false;
+  }
+  const visibleBody = normalized.slice(0, statuses[0].index).trim().toLowerCase();
+  if (
+    hasActionableClawSweeperReviewSignal(visibleBody) ||
+    hasSecuritySensitiveText([visibleBody])
   ) {
     return false;
   }

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -752,6 +752,18 @@ function readOnlyBlockers({
   const blockers = [];
   const trustedAuthorEvidenceApprovalAt = trustedAuthorEvidenceApprovalTimestamp(issueComments, { pull });
   const trustedAuthorProgressApprovalAt = trustedAuthorProgressApprovalTimestamp(issueComments, { pull });
+  const hasExactHeadClawSweeperReviewStart = issueComments.some((comment) => {
+    const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
+    return isClawSweeperReviewStartComment({ author, body: comment.body, pull });
+  });
+  const isStaleIssueCommentCoveredByReviewStart = (comment) => {
+    if (!hasExactHeadClawSweeperReviewStart) return false;
+    const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
+    return (
+      isClawSweeperAuthor(author) &&
+      isStaleAutomationReviewComment({ author, body: comment.body, pull })
+    );
+  };
   const reviewComments =
     hydratedReviewComments ??
     ghJson(["api", `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}/comments?per_page=100`]);
@@ -765,6 +777,7 @@ function readOnlyBlockers({
     ...issueComments
       .filter(
         (comment) =>
+          !isStaleIssueCommentCoveredByReviewStart(comment) &&
           !isNonBlockingCommentEvidence(comment, {
             pull,
             view,
@@ -804,6 +817,7 @@ function readOnlyBlockers({
   const actionableIssueComments = issueComments.filter(
     (comment, index) =>
       !isSupersededDependencyGuardNotice(comment, issueComments.slice(index + 1), { pull, view }) &&
+      !isStaleIssueCommentCoveredByReviewStart(comment) &&
       isActionableCommentEvidence(comment, {
         pull,
         view,
@@ -2502,6 +2516,7 @@ function hasActionableApprovedReviewBody(body) {
 
 function isBenignAutomationComment({ author, body, pull, view }) {
   const currentReview = String(body).split(/<details>/, 1)[0];
+  if (isClawSweeperReviewStartComment({ author, body, pull })) return true;
   if (isClawSweeperAuthor(author) && hasClawSweeperReadyReviewSignal(currentReview)) {
     return isClawSweeperReadyReviewComment({ author, body, pull, view });
   }
@@ -2544,6 +2559,7 @@ function commentReviewShas(body) {
   const normalized = String(body ?? "").toLowerCase();
   const patterns = [
     /<!--\s*clawsweeper-(?:verdict|action):[^>]*\bsha=([0-9a-f]{40})\b[^>]*-->/g,
+    /<!--\s*clawsweeper-review-status:started[^>]*\bsha=([0-9a-f]{40})\b[^>]*-->/g,
     /\blast reviewed commit:\s*(?:https?:\/\/\S+\/commit\/)?([0-9a-f]{40})\b/g,
     /\breviewed against\s*(?:\[[^\]]+\]\()?https?:\/\/\S+\/commit\/([0-9a-f]{40})\)?/g,
   ];
@@ -2600,12 +2616,58 @@ function isClawSweeperReadyReviewComment({ author, body, pull, view = null }) {
   return !hasActionableClawSweeperReviewSignal(currentReview, { view }) && hasClawSweeperReadyReviewSignal(currentReview);
 }
 
+function isClawSweeperReviewStartComment({ author, body, pull }) {
+  if (!isClawSweeperAuthor(author)) return false;
+  const normalized = String(body ?? "").trim();
+  if (!/^clawsweeper status: review started\.(?:\r?\n|$)/i.test(normalized)) return false;
+  if (/<!--\s*clawsweeper-(?:verdict|action):/i.test(normalized)) return false;
+
+  const statusOpeners =
+    normalized.match(/<!--\s*clawsweeper-review-status:started\b/gi) ?? [];
+  const statuses = [
+    ...normalized.matchAll(
+      /<!--\s*clawsweeper-review-status:started\s+([^>]*)-->/gi,
+    ),
+  ];
+  const leaseOpeners = normalized.match(/<!--\s*clawsweeper-review-lease\b/gi) ?? [];
+  const leases = [
+    ...normalized.matchAll(/<!--\s*clawsweeper-review-lease\s+([^>]*)-->/gi),
+  ];
+  if (
+    statusOpeners.length !== 1 ||
+    statuses.length !== 1 ||
+    leaseOpeners.length !== 1 ||
+    leases.length !== 1
+  ) {
+    return false;
+  }
+
+  const status = parseMarkerAttributes(statuses[0][1]);
+  const lease = parseMarkerAttributes(leases[0][1]);
+  if (!status || !lease) return false;
+
+  const headSha = String(pull?.head?.sha ?? "").toLowerCase();
+  const pullNumber = String(pull?.number ?? "");
+  const startedAt = Date.parse(status.started_at ?? "");
+  const leaseExpiresAt = Date.parse(status.lease_expires_at ?? "");
+  return (
+    /^[0-9a-f]{40}$/.test(headSha) &&
+    status.item === pullNumber &&
+    status.sha?.toLowerCase() === headSha &&
+    status.v === "1" &&
+    lease.item === pullNumber &&
+    Number.isFinite(startedAt) &&
+    Number.isFinite(leaseExpiresAt) &&
+    leaseExpiresAt > startedAt
+  );
+}
+
 function hasClawSweeperReadyReviewSignal(body) {
   const firstLine = String(body).split(/\r?\n/, 1)[0].trim();
   return (
     isClawSweeperMaintainerReviewHeader(firstLine) &&
     /result:\s*ready for maintainer review\./.test(body) &&
-    /(review metrics:\*\*\s*none identified|review metrics:\s*none identified|no (?:clawsweeper |automated )?repair(?: job| lane)? is (?:needed|indicated)|no (?:clawsweeper |automated )?repair(?: or product decision)? remains|no concrete (?:code finding|contributor-facing blocker left)|remaining action is normal maintainer review)/.test(
+    /(review metrics:\*\*\s*none identified|review metrics:\s*none identified|no (?:clawsweeper |automated )?repair(?: job| lane)? is (?:needed|indicated)|no concrete (?:code finding|contributor-facing blocker left)|remaining action is normal maintainer review)/.test(
       body,
     )
   );

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -2605,7 +2605,7 @@ function hasClawSweeperReadyReviewSignal(body) {
   return (
     isClawSweeperMaintainerReviewHeader(firstLine) &&
     /result:\s*ready for maintainer review\./.test(body) &&
-    /(review metrics:\*\*\s*none identified|review metrics:\s*none identified|no (?:clawsweeper |automated )?repair(?: job| lane)? is (?:needed|indicated)|no concrete (?:code finding|contributor-facing blocker left)|remaining action is normal maintainer review)/.test(
+    /(review metrics:\*\*\s*none identified|review metrics:\s*none identified|no (?:clawsweeper |automated )?repair(?: job| lane)? is (?:needed|indicated)|no (?:clawsweeper |automated )?repair(?: or product decision)? remains|no concrete (?:code finding|contributor-facing blocker left)|remaining action is normal maintainer review)/.test(
       body,
     )
   );

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -1082,7 +1082,7 @@ test("external merge preflight tolerates non-actionable automation comments", ()
   assert.equal(report.status, "passed");
 });
 
-test("external merge preflight accepts an exact-head ClawSweeper review with no repair or product decision remaining", () => {
+test("external merge preflight ignores a stale ready review and exact-head ClawSweeper review-start lease", () => {
   const headSha = "a".repeat(40);
   const fixture = makeFixture({
     headSha,
@@ -1094,18 +1094,30 @@ test("external merge preflight accepts an exact-head ClawSweeper review with no 
           "Codex review: needs maintainer review before merge.",
           "",
           "**Review metrics:** none identified.",
-          "",
-          "**Merge readiness**",
           "Result: ready for maintainer review.",
           "",
           "**Next step before merge**",
-          "- No automated repair or product decision remains; normal maintainer review should gate merging the already clean exact head.",
+          "- No automated repair is needed; the remaining action is normal maintainer review.",
           "",
-          `<!-- clawsweeper-verdict:needs-human item=123 sha=${headSha} confidence=high updated_at=2026-07-11T22:30:53Z reviewed_at=2026-07-11T22:34:04.182Z lease_owner=github-run-29170593449-1 -->`,
-          "<!-- clawsweeper-review-version item=123 reviewed_at=2026-07-11T22:34:04.182Z sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa v=1 -->",
+          `<!-- clawsweeper-verdict:needs-human item=123 sha=${"b".repeat(40)} confidence=high -->`,
           "<!-- clawsweeper-review item=123 -->",
         ].join("\n"),
-        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-ready",
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-stale-ready",
+      },
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: [
+          "ClawSweeper status: review started.",
+          "",
+          "I am starting a fresh review of this pull request.",
+          "",
+          "This placeholder means the worker is alive and reading the current context.",
+          "",
+          `<!-- clawsweeper-review-status:started item=123 sha=${headSha} started_at=2026-07-11T22:30:53.000Z lease_expires_at=2026-07-11T23:00:53.000Z v=1 -->`,
+          "<!-- clawsweeper-review-lease item=123 -->",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-review-started",
       },
     ],
   });
@@ -1114,6 +1126,43 @@ test("external merge preflight accepts an exact-head ClawSweeper review with no 
   assert.equal(report.status, "passed", report.reason);
   assert.equal(result.actions[0]?.action, "merge_canonical");
 });
+
+for (const [name, body] of [
+  [
+    "unmarked",
+    [
+      "ClawSweeper status: review started.",
+      "",
+      "I am starting a fresh review of this pull request.",
+    ].join("\n"),
+  ],
+  [
+    "wrong item",
+    [
+      "ClawSweeper status: review started.",
+      "",
+      `<!-- clawsweeper-review-status:started item=456 sha=${"a".repeat(40)} started_at=2026-07-11T22:30:53.000Z lease_expires_at=2026-07-11T23:00:53.000Z v=1 -->`,
+      "<!-- clawsweeper-review-lease item=456 -->",
+    ].join("\n"),
+  ],
+]) {
+  test(`external merge preflight keeps ${name} ClawSweeper review-start prose blocking`, () => {
+    const fixture = makeFixture({
+      issueComments: [
+        {
+          author: { login: "clawsweeper[bot]" },
+          authorAssociation: "CONTRIBUTOR",
+          body,
+          url: `https://github.com/openclaw/openclaw/pull/123#issuecomment-${name}`,
+        },
+      ],
+    });
+    const { report } = runPreflightFixture(fixture);
+
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, /actionable top-level issue comment/);
+  });
+}
 
 test("external merge preflight accepts current guard clearance and structured author proof", () => {
   const headSha = "a".repeat(40);

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -1084,6 +1084,8 @@ test("external merge preflight tolerates non-actionable automation comments", ()
 
 test("external merge preflight ignores a stale ready review and exact-head ClawSweeper review-start lease", () => {
   const headSha = "a".repeat(40);
+  const startedAt = new Date(Date.now() - 60_000).toISOString();
+  const leaseExpiresAt = new Date(Date.now() + 30 * 60_000).toISOString();
   const fixture = makeFixture({
     headSha,
     issueComments: [
@@ -1114,7 +1116,7 @@ test("external merge preflight ignores a stale ready review and exact-head ClawS
           "",
           "This placeholder means the worker is alive and reading the current context.",
           "",
-          `<!-- clawsweeper-review-status:started item=123 sha=${headSha} started_at=2026-07-11T22:30:53.000Z lease_expires_at=2026-07-11T23:00:53.000Z v=1 -->`,
+          `<!-- clawsweeper-review-status:started item=123 sha=${headSha} started_at=${startedAt} lease_expires_at=${leaseExpiresAt} v=1 -->`,
           "<!-- clawsweeper-review-lease item=123 -->",
         ].join("\n"),
         url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-review-started",
@@ -1126,6 +1128,64 @@ test("external merge preflight ignores a stale ready review and exact-head ClawS
   assert.equal(report.status, "passed", report.reason);
   assert.equal(result.actions[0]?.action, "merge_canonical");
 });
+
+for (const [name, startedAt, leaseExpiresAt, extraLine] of [
+  [
+    "expired",
+    "1999-12-31T23:30:00.000Z",
+    "2000-01-01T00:00:00.000Z",
+    "This placeholder means the worker is alive and reading the current context.",
+  ],
+  [
+    "contradictory",
+    new Date(Date.now() - 60_000).toISOString(),
+    new Date(Date.now() + 30 * 60_000).toISOString(),
+    "Do not merge; security issue remains.",
+  ],
+]) {
+  test(`external merge preflight keeps ${name} ClawSweeper review-start leases blocking`, () => {
+    const headSha = "a".repeat(40);
+    const fixture = makeFixture({
+      headSha,
+      issueComments: [
+        {
+          author: { login: "clawsweeper[bot]" },
+          authorAssociation: "CONTRIBUTOR",
+          body: [
+            "Codex review: needs maintainer review before merge.",
+            "",
+            "**Review metrics:** none identified.",
+            "Result: ready for maintainer review.",
+            "",
+            "**Next step before merge**",
+            "- No automated repair is needed; the remaining action is normal maintainer review.",
+            "",
+            `<!-- clawsweeper-verdict:needs-human item=123 sha=${"b".repeat(40)} confidence=high -->`,
+            "<!-- clawsweeper-review item=123 -->",
+          ].join("\n"),
+          url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-stale-ready",
+        },
+        {
+          author: { login: "clawsweeper[bot]" },
+          authorAssociation: "CONTRIBUTOR",
+          body: [
+            "ClawSweeper status: review started.",
+            "",
+            extraLine,
+            "",
+            `<!-- clawsweeper-review-status:started item=123 sha=${headSha} started_at=${startedAt} lease_expires_at=${leaseExpiresAt} v=1 -->`,
+            "<!-- clawsweeper-review-lease item=123 -->",
+          ].join("\n"),
+          url: `https://github.com/openclaw/openclaw/pull/123#issuecomment-review-started-${name}`,
+        },
+      ],
+    });
+    const { report } = runPreflightFixture(fixture);
+
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, /security-sensitive signal|actionable top-level issue comment/);
+  });
+}
 
 for (const [name, body] of [
   [

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -1082,6 +1082,39 @@ test("external merge preflight tolerates non-actionable automation comments", ()
   assert.equal(report.status, "passed");
 });
 
+test("external merge preflight accepts an exact-head ClawSweeper review with no repair or product decision remaining", () => {
+  const headSha = "a".repeat(40);
+  const fixture = makeFixture({
+    headSha,
+    issueComments: [
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: [
+          "Codex review: needs maintainer review before merge.",
+          "",
+          "**Review metrics:** none identified.",
+          "",
+          "**Merge readiness**",
+          "Result: ready for maintainer review.",
+          "",
+          "**Next step before merge**",
+          "- No automated repair or product decision remains; normal maintainer review should gate merging the already clean exact head.",
+          "",
+          `<!-- clawsweeper-verdict:needs-human item=123 sha=${headSha} confidence=high updated_at=2026-07-11T22:30:53Z reviewed_at=2026-07-11T22:34:04.182Z lease_owner=github-run-29170593449-1 -->`,
+          "<!-- clawsweeper-review-version item=123 reviewed_at=2026-07-11T22:34:04.182Z sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa v=1 -->",
+          "<!-- clawsweeper-review item=123 -->",
+        ].join("\n"),
+        url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-ready",
+      },
+    ],
+  });
+  const { report, result } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "passed", report.reason);
+  assert.equal(result.actions[0]?.action, "merge_canonical");
+});
+
 test("external merge preflight accepts current guard clearance and structured author proof", () => {
   const headSha = "a".repeat(40);
   const fixture = makeFixture({

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -1129,7 +1129,7 @@ test("external merge preflight ignores a stale ready review and exact-head ClawS
   assert.equal(result.actions[0]?.action, "merge_canonical");
 });
 
-for (const [name, startedAt, leaseExpiresAt, extraLine] of [
+for (const [name, startedAt, leaseExpiresAt, extraLine, trailingLine = ""] of [
   [
     "expired",
     "1999-12-31T23:30:00.000Z",
@@ -1140,6 +1140,13 @@ for (const [name, startedAt, leaseExpiresAt, extraLine] of [
     "contradictory",
     new Date(Date.now() - 60_000).toISOString(),
     new Date(Date.now() + 30 * 60_000).toISOString(),
+    "Do not merge; security issue remains.",
+  ],
+  [
+    "trailing contradictory",
+    new Date(Date.now() - 60_000).toISOString(),
+    new Date(Date.now() + 30 * 60_000).toISOString(),
+    "This placeholder means the worker is alive and reading the current context.",
     "Do not merge; security issue remains.",
   ],
 ]) {
@@ -1175,6 +1182,7 @@ for (const [name, startedAt, leaseExpiresAt, extraLine] of [
             "",
             `<!-- clawsweeper-review-status:started item=123 sha=${headSha} started_at=${startedAt} lease_expires_at=${leaseExpiresAt} v=1 -->`,
             "<!-- clawsweeper-review-lease item=123 -->",
+            trailingLine,
           ].join("\n"),
           url: `https://github.com/openclaw/openclaw/pull/123#issuecomment-review-started-${name}`,
         },


### PR DESCRIPTION
## Summary

- accept only marker-valid, exact-head ClawSweeper review-start leases as transient automation state
- let a current review lease supersede stale ClawSweeper review comments without weakening standalone exact-head approval checks
- keep unmarked, wrong-item, malformed, and contradictory comments blocking

## Validation

- live-shape focused preflight suite: 6/6 passed
- `node --check scripts/preflight-external-pr-merge.mjs`
- `git diff --check`
- full preflight suite running
- independent review round two pending