### PR TITLE
chore(jobs): add next guarded PR tranche

### DIFF
--- a/jobs/openclaw/inbox/exact-merge-104554-parallel-mcp-20260711.md
+++ b/jobs/openclaw/inbox/exact-merge-104554-parallel-mcp-20260711.md
@@ -1,0 +1,50 @@
+---
+repo: openclaw/openclaw
+cluster_id: exact-merge-104554-parallel-mcp-20260711
+mode: autonomous
+expected_head_sha: 0a1b721ae6a1a4eeffd21d0b31ad4969cb0f2d53
+allowed_actions:
+  - "merge"
+blocked_actions:
+  - "comment"
+  - "label"
+  - "close"
+  - "fix"
+  - "raise_pr"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unresolved_review"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+canonical:
+  - "#104554"
+candidates:
+  - "#104554"
+cluster_refs:
+  - "#104554"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: false
+allow_merge: true
+require_external_merge_preflight: true
+allow_post_merge_close: false
+require_fix_before_close: false
+canonical_hint: "Merge only PR #104554 after deterministic validation and Codex review bind to its exact live head."
+notes: "Qualified on 2026-07-11 at exact head 0a1b721ae6a1a4eeffd21d0b31ad4969cb0f2d53. The PR is open, non-draft, maintainer-editable, rebaseable, exact-head checks are clean, ClawSweeper reports sufficient proof, and the change is limited to the Parallel MCP runtime plus its focused test. Re-fetch live state and stop if the head or merge policy changes."
+---
+
+# Exact Merge: #104554
+
+Hydrate live GitHub state for
+https://github.com/openclaw/openclaw/pull/104554 and emit a blocked
+`merge_candidate` with reason `external_merge_preflight_required`,
+`expected_head_sha`, `target_updated_at`, and concrete evidence.
+
+The executor must run the deterministic exact-head external merge preflight,
+including focused validation of the two Parallel MCP files and Codex review,
+then apply only the reviewed merge action. No comments, labels, fixes,
+closures, refreshes, replacement PRs, or adjacent work are allowed.

--- a/jobs/openclaw/inbox/repair-103998-rpc-timeout-cap-20260711.md
+++ b/jobs/openclaw/inbox/repair-103998-rpc-timeout-cap-20260711.md
@@ -1,0 +1,72 @@
+---
+repo: openclaw/openclaw
+cluster_id: repair-103998-rpc-timeout-cap-20260711
+mode: autonomous
+expected_head_sha: 5fb33b7c0cd5df9b231fde41b3c7fb5ea61037c1
+allowed_actions:
+  - "fix"
+  - "raise_pr"
+blocked_actions:
+  - "merge"
+  - "comment"
+  - "label"
+  - "close"
+  - "force_push"
+  - "bypass_checks"
+require_human_for:
+  - "security_sensitive"
+  - "unclear_canonical"
+  - "broad_code_delta"
+  - "active_author_followup"
+maintainer_calibration:
+  - "Repair only the maintainer-editable contributor branch for #103998. Keep the five-minute command-wide settle budget, but cap each usage.cost RPC at min(10 seconds, remaining budget) and update focused coverage."
+canonical:
+  - "#103998"
+candidates:
+  - "#103998"
+cluster_refs:
+  - "#103998"
+  - "#103882"
+  - "#103961"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+require_external_merge_preflight: false
+allow_post_merge_close: false
+require_fix_before_close: true
+canonical_hint: "Repair only the existing writable contributor branch for #103998 by separating the long cache-settle budget from the bounded per-RPC transport timeout."
+notes: "Qualified on 2026-07-11 at exact head 5fb33b7c0cd5df9b231fde41b3c7fb5ea61037c1 after exact-head Codex and ClawSweeper review. The current branch fixes stale-cache polling but passes the five-minute settle remainder into each usage.cost RPC, allowing an unresponsive Gateway call to wait far longer than the prior 10-second transport cap. Re-fetch live state and stop if the head or review context changes."
+---
+
+# Repair #103998 RPC Timeout
+
+Repair the existing contributor branch for
+https://github.com/openclaw/openclaw/pull/103998 only.
+
+## Goal
+
+Preserve the long bounded wait for usage-cache settlement without allowing one
+unresponsive Gateway RPC to consume that whole budget.
+
+- Keep the five-minute default command-wide usage-cost settle deadline.
+- Cap each `usage.cost` RPC at the smaller of 10 seconds and the remaining
+  command budget.
+- Preserve explicit shorter `--timeout` values as strict command-wide bounds.
+- Replace the current long-per-RPC expectation with focused coverage for the
+  per-RPC cap and short total-budget behavior.
+
+## Required Validation
+
+- Run the focused gateway CLI coverage tests for usage-cost settlement.
+- Run `pnpm check:changed`.
+- Run exact-head Codex review and address any actionable finding.
+
+## Boundaries
+
+- Expected production owner: `src/cli/gateway-cli/register.ts`.
+- Expected tests: `src/cli/gateway-cli.coverage.test.ts`.
+- Do not change Gateway cache behavior, add a new CLI option, or touch adjacent
+  PR #103961.
+- Do not merge, comment, label, close, create a replacement PR, or force-push.


### PR DESCRIPTION
## Summary

- add an exact-head repair-only job for openclaw/openclaw#103998 that separates the five-minute settle deadline from a 10-second per-RPC cap
- add an exact-head merge-preflight-only job for openclaw/openclaw#104554
- block comments, labels, closure, force-push, replacement work, and adjacent mutations in both lanes

## Validation

- `npm run validate -- jobs/openclaw/inbox/repair-103998-rpc-timeout-cap-20260711.md jobs/openclaw/inbox/exact-merge-104554-parallel-mcp-20260711.md`
- rendered both jobs in autonomous mode
- `git diff --check`