### PR TITLE
fix(queue): authorize guarded contributor rebases

### DIFF
--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2678,10 +2678,12 @@ function expectedHeadShaForSource(job, number) {
 function isRepairOnlyMergeRiskRemediationJob(job) {
   const allowed = new Set(job.frontmatter.allowed_actions ?? []);
   const blocked = new Set(job.frontmatter.blocked_actions ?? []);
+  const allowedActionSet =
+    allowed.size === 2 || (allowed.size === 3 && allowed.has("force_push"));
   return (
     job.frontmatter.allow_fix_pr === true &&
     job.frontmatter.allow_merge === false &&
-    allowed.size === 2 &&
+    allowedActionSet &&
     allowed.has("fix") &&
     allowed.has("raise_pr") &&
     blocked.has("comment") &&

--- a/scripts/import-gitcrawl-clusters.mjs
+++ b/scripts/import-gitcrawl-clusters.mjs
@@ -37,6 +37,8 @@ const allowInstantClose = booleanArg("allow-instant-close", false);
 const editEnabledByDefault = mode === "autonomous" || mode === "execute";
 const allowMerge = booleanArg("allow-merge", editEnabledByDefault);
 const allowFixPr = booleanArg("allow-fix-pr", editEnabledByDefault);
+const allowForcePush = booleanArg("allow-force-push", false);
+const allowGuardedForcePush = allowFixPr && editEnabledByDefault && allowForcePush;
 const allowPostMergeClose = booleanArg("allow-post-merge-close", allowMerge || allowFixPr);
 const skipExisting = args["skip-existing"] !== "false";
 const existingResultsOnly = Boolean(args["existing-results-only"] ?? args.existing_results_only);
@@ -67,7 +69,7 @@ if (selectingFromGitcrawl) {
 
 if (clusterIds.length === 0) {
   console.error(
-    "usage: node scripts/import-gitcrawl-clusters.mjs <cluster-id> [...] [--from-gitcrawl] [--limit N] [--min-size N] [--min-open-members N] [--repo owner/repo] [--db path] [--out dir] [--existing-dir dir] [--existing-results-dir dir] [--existing-results-only] [--existing-results-action-policy all|terminal] [--mode plan|autonomous] [--suffix name] [--overlap-policy skip-any|skip-full|exclude-existing] [--security-policy skip-full|skip-any|include] [--block-label pattern] [--include-blocked-labels] [--live-state-filter] [--gh-bin gh] [--dry-run] [--json] [--allow-instant-close] [--allow-merge true|false] [--allow-fix-pr true|false] [--allow-post-merge-close true|false]",
+    "usage: node scripts/import-gitcrawl-clusters.mjs <cluster-id> [...] [--from-gitcrawl] [--limit N] [--min-size N] [--min-open-members N] [--repo owner/repo] [--db path] [--out dir] [--existing-dir dir] [--existing-results-dir dir] [--existing-results-only] [--existing-results-action-policy all|terminal] [--mode plan|autonomous] [--suffix name] [--overlap-policy skip-any|skip-full|exclude-existing] [--security-policy skip-full|skip-any|include] [--block-label pattern] [--include-blocked-labels] [--live-state-filter] [--gh-bin gh] [--dry-run] [--json] [--allow-instant-close] [--allow-merge true|false] [--allow-fix-pr true|false] [--allow-force-push true|false] [--allow-post-merge-close true|false]",
   );
   process.exit(2);
 }
@@ -85,6 +87,10 @@ if (!["skip-full", "skip-any", "include"].includes(securityPolicy)) {
 }
 if (!["all", "terminal"].includes(existingResultsActionPolicy)) {
   console.error("existing-results-action-policy must be all or terminal");
+  process.exit(2);
+}
+if (allowForcePush && !allowGuardedForcePush) {
+  console.error("--allow-force-push requires execute/autonomous mode with --allow-fix-pr true");
   process.exit(2);
 }
 
@@ -241,8 +247,9 @@ for (const clusterId of clusterIds) {
     "  - close",
     ...(allowMerge ? ["  - merge"] : []),
     ...(allowFixPr ? ["  - fix", "  - raise_pr"] : []),
+    ...(allowGuardedForcePush ? ["  - force_push"] : []),
     "blocked_actions:",
-    "  - force_push",
+    ...(allowGuardedForcePush ? [] : ["  - force_push"]),
     "  - bypass_checks",
     ...(allowMerge ? [] : ["  - merge"]),
     ...(allowFixPr ? [] : ["  - fix", "  - raise_pr"]),
@@ -364,6 +371,7 @@ if (jsonOutput) {
       limit,
       min_size: minSize,
       min_open_members: minOpenMembers,
+      allow_force_push: allowForcePush,
     },
     totals: {
       generated: generated.length,

--- a/scripts/import-github-pr-inventory.mjs
+++ b/scripts/import-github-pr-inventory.mjs
@@ -68,6 +68,10 @@ const bucketFilter = String(args.bucket ?? defaultBucketFor({ mode, strategy }))
 const skipExisting = args["skip-existing"] !== "false";
 const includeSecurity = Boolean(args["include-security-candidates"]);
 const includeMergeRisk = Boolean(args["include-merge-risk-candidates"] ?? args.include_merge_risk_candidates);
+const allowForcePush = strictBooleanFlag(
+  args["allow-force-push"] ?? args.allow_force_push,
+  "allow-force-push",
+);
 const repairOnlyMergeRiskInventory =
   strategy === "remediation" && includeMergeRisk && bucketFilter === "merge_risk_remediation";
 const conflictingBranchRepairInventory =
@@ -116,6 +120,9 @@ if (hydrateIncludeRefs && inventorySource !== "pr-list") die("--hydrate-include-
 if (hydrateIncludeRefs && !includeRefs) die("--hydrate-include-refs requires --include-refs-file");
 if (!["stale", "recent", "bucket"].includes(sort)) die("--sort must be stale, recent, or bucket");
 if (!["all", "terminal"].includes(existingResultsActionPolicy)) die("--existing-results-action-policy must be all or terminal");
+if (allowForcePush && (mode !== "autonomous" || strategy !== "remediation")) {
+  die("--allow-force-push requires autonomous remediation mode");
+}
 
 const existingRefs = skipExisting ? existingRefsForStrategy() : new Set();
 if (skipExisting) mergeRefs(existingRefs, existingPublishedResultRefs(existingResultsDir, repo, existingResultsActionPolicy));
@@ -171,6 +178,7 @@ const payload = sanitizeJsonValue({
     skip_existing: skipExisting,
     include_security_candidates: includeSecurity,
     include_merge_risk_candidates: strategy === "remediation" ? includeMergeRisk : null,
+    allow_force_push: strategy === "remediation" ? allowForcePush : null,
     checks_success_preflight: strategy === "remediation" ? checksSuccessPreflight : null,
     checks_success_retry_cooldown_hours: checksSuccessPreflight ? checksSuccessRetryCooldownHours : null,
     checks_success_main_sha: checksSuccessPreflight ? checksSuccessMainSha : null,
@@ -1220,16 +1228,24 @@ function writeJob(batch, index) {
   const refs = batch.map((candidate) => candidate.ref);
   const remediation = strategy === "remediation";
   const autonomousRemediation = remediation && mode === "autonomous";
+  const allowGuardedForcePush = autonomousRemediation && allowForcePush;
   const mergeRiskRemediation = remediation && batch.some((candidate) => hasMergeRiskLabel(candidate.labels));
   const allowedActions = remediation
     ? mergeRiskRemediation
-      ? ["fix", "raise_pr"]
-      : ["merge", "fix", "raise_pr"]
+      ? ["fix", "raise_pr", ...(allowGuardedForcePush ? ["force_push"] : [])]
+      : ["merge", "fix", "raise_pr", ...(allowGuardedForcePush ? ["force_push"] : [])]
     : lowSignal
       ? ["comment", "close"]
       : ["comment", "label", "close"];
   const blockedActions = remediation
-    ? ["comment", "label", "close", ...(mergeRiskRemediation ? ["merge"] : []), "force_push", "bypass_checks"]
+    ? [
+        "comment",
+        "label",
+        "close",
+        ...(mergeRiskRemediation ? ["merge"] : []),
+        ...(allowGuardedForcePush ? [] : ["force_push"]),
+        "bypass_checks",
+      ]
     : lowSignal
       ? ["force_push", "bypass_checks", "merge", "fix", "raise_pr", "label"]
     : ["force_push", "bypass_checks", "merge", "fix", "raise_pr"];
@@ -1755,6 +1771,15 @@ function booleanFlag(value) {
   if (value === true) return true;
   if (value === false || value == null) return false;
   return ["1", "true", "yes", "on"].includes(String(value).trim().toLowerCase());
+}
+
+function strictBooleanFlag(value, name) {
+  if (value === true) return true;
+  if (value === false || value == null) return false;
+  const normalized = String(value).trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  die(`--${name} must be true or false`);
 }
 
 function limitArg(name, fallback) {

--- a/test/execute-fix-artifact.test.mjs
+++ b/test/execute-fix-artifact.test.mjs
@@ -446,7 +446,7 @@ test("execute-fix-artifact permits non-security merge-risk labels for repair-onl
   const reportPath = path.join(fixture.runDir, "fix-execution-report.json");
   const ghLog = path.join(fixture.root, "gh.log");
 
-  fs.writeFileSync(fixture.jobPath, repairOnlyRiskJobFile(clusterId));
+  fs.writeFileSync(fixture.jobPath, repairOnlyRiskJobFile(clusterId, { allowForcePush: true }));
   const result = resultFile(clusterId);
   result.actions = [
     { action: "fix_needed", status: "planned", target: "#1" },
@@ -2265,7 +2265,7 @@ security_sensitive: false
 `;
 }
 
-function repairOnlyRiskJobFile(clusterId) {
+function repairOnlyRiskJobFile(clusterId, { allowForcePush = false } = {}) {
   return `---
 repo: openclaw/openclaw
 cluster_id: ${clusterId}
@@ -2273,13 +2273,12 @@ mode: autonomous
 allowed_actions:
   - fix
   - raise_pr
-blocked_actions:
+${allowForcePush ? "  - force_push\n" : ""}blocked_actions:
   - comment
   - label
   - close
   - merge
-  - force_push
-  - bypass_checks
+${allowForcePush ? "" : "  - force_push\n"}  - bypass_checks
 require_human_for:
   - security_sensitive
 canonical: []

--- a/test/import-gitcrawl-clusters.test.mjs
+++ b/test/import-gitcrawl-clusters.test.mjs
@@ -93,6 +93,34 @@ test("cluster import can live-skip stale local open refs", { skip: hasSqlite ? f
   assert.equal(payload.skipped[0].reason, "closed_only");
 });
 
+test("autonomous cluster repair jobs require explicit guarded force-push authorization", { skip: hasSqlite ? false : "sqlite3 missing" }, () => {
+  const fixture = makeFixture();
+  seedPortableGitcrawlDb(fixture.db);
+
+  const defaultResult = runWrittenImport(fixture, "--mode", "autonomous", "--allow-fix-pr", "true");
+  assert.equal(defaultResult.status, 0, defaultResult.stderr || defaultResult.stdout);
+  const defaultPayload = JSON.parse(defaultResult.stdout);
+  const defaultJob = fs.readFileSync(path.join(fixture.out, path.basename(defaultPayload.generated[0].path)), "utf8");
+  assert.match(defaultJob, /blocked_actions:\n(?:  - .+\n)*  - force_push/);
+
+  const result = runWrittenImport(
+    fixture,
+    "--mode",
+    "autonomous",
+    "--allow-fix-pr",
+    "true",
+    "--allow-force-push",
+    "true",
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const payload = JSON.parse(result.stdout);
+  const job = fs.readFileSync(path.join(fixture.out, path.basename(payload.generated[0].path)), "utf8");
+
+  assert.equal(payload.options.allow_force_push, true);
+  assert.match(job, /allowed_actions:\n(?:  - .+\n)*  - force_push\nblocked_actions:/);
+  assert.doesNotMatch(job, /blocked_actions:\n(?:  - .+\n)*  - force_push/);
+});
+
 function runImport(fixture, ...extraArgs) {
   return spawnSync(
     process.execPath,
@@ -110,6 +138,29 @@ function runImport(fixture, ...extraArgs) {
       "--existing-results-dir",
       fixture.results,
       "--dry-run",
+      "--json",
+      ...extraArgs,
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+}
+
+function runWrittenImport(fixture, ...extraArgs) {
+  return spawnSync(
+    process.execPath,
+    [
+      "scripts/import-gitcrawl-clusters.mjs",
+      "--from-gitcrawl",
+      "--limit",
+      "1",
+      "--db",
+      fixture.db,
+      "--out",
+      fixture.out,
+      "--existing-dir",
+      fixture.existing,
+      "--existing-results-dir",
+      fixture.results,
       "--json",
       ...extraArgs,
     ],

--- a/test/import-github-pr-inventory.test.mjs
+++ b/test/import-github-pr-inventory.test.mjs
@@ -87,6 +87,7 @@ test("remediation inventory enables plan and autonomous finalization recommendat
   assert.match(job, /  - "merge"/);
   assert.match(job, /  - "fix"/);
   assert.match(job, /blocked_actions:\n  - "comment"/);
+  assert.match(job, /blocked_actions:[\s\S]*  - "force_push"/);
   assert.match(job, /allow_fix_pr: true/);
   assert.match(job, /allow_merge: true/);
   assert.match(job, /allow_post_merge_close: false/);
@@ -110,9 +111,55 @@ test("remediation inventory enables plan and autonomous finalization recommendat
   const autonomousPayload = JSON.parse(autonomous.stdout);
   const autonomousJob = fs.readFileSync(path.join(fixture.out, path.basename(autonomousPayload.generated[0].path)), "utf8");
   assert.match(autonomousJob, /mode: autonomous/);
+  assert.match(autonomousJob, /blocked_actions:[\s\S]*  - "force_push"/);
   assert.match(autonomousJob, /autonomous remediation assessment/);
   assert.match(autonomousJob, /Mutations are limited to deterministic merge\/fix gates/);
   assert.match(autonomousJob, /deterministic applicator\/executor owns the actual merge or fix PR mutation/);
+
+  const autonomousWithPush = runImport(
+    fixture,
+    "--write",
+    "--strategy",
+    "remediation",
+    "--bucket",
+    "ready_for_maintainer",
+    "--skip-existing",
+    "false",
+    "--allow-force-push",
+  );
+  assert.equal(autonomousWithPush.status, 0, autonomousWithPush.stderr || autonomousWithPush.stdout);
+  const autonomousWithPushPayload = JSON.parse(autonomousWithPush.stdout);
+  const autonomousWithPushJob = fs.readFileSync(
+    path.join(fixture.out, path.basename(autonomousWithPushPayload.generated[0].path)),
+    "utf8",
+  );
+  assert.equal(autonomousWithPushPayload.options.allow_force_push, true);
+  assert.match(autonomousWithPushJob, /allowed_actions:[\s\S]*  - "force_push"/);
+  assert.doesNotMatch(autonomousWithPushJob, /blocked_actions:\n(?:  - ".+"\n)*  - "force_push"/);
+});
+
+test("force-push authorization rejects malformed or non-autonomous use", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.gh);
+
+  const malformed = runImport(fixture, "--allow-force-push=garbage");
+  assert.notEqual(malformed.status, 0);
+  assert.match(malformed.stderr, /--allow-force-push must be true or false/);
+
+  const plan = runImport(
+    fixture,
+    "--mode",
+    "plan",
+    "--strategy",
+    "remediation",
+    "--allow-force-push",
+  );
+  assert.notEqual(plan.status, 0);
+  assert.match(plan.stderr, /--allow-force-push requires autonomous remediation mode/);
+
+  const triage = runImport(fixture, "--strategy", "triage", "--allow-force-push");
+  assert.notEqual(triage.status, 0);
+  assert.match(triage.stderr, /--allow-force-push requires autonomous remediation mode/);
 });
 
 test("autonomous remediation defaults to hydrated pr-list intake", () => {
@@ -274,6 +321,7 @@ test("remediation inventory routes opted-in merge-risk candidates to repair-only
     "--inventory-source",
     "pr-list",
     "--include-merge-risk-candidates",
+    "--allow-force-push",
     "--bucket",
     "merge_risk_remediation",
     "--batch-size",
@@ -292,6 +340,7 @@ test("remediation inventory routes opted-in merge-risk candidates to repair-only
   const job = fs.readFileSync(path.join(fixture.out, path.basename(payload.generated[0].path)), "utf8");
   assert.match(job, /candidates:\n  - "#113"\ncluster_refs:\n  - "#113"/);
   assert.match(job, /allowed_actions:\n  - "fix"\n  - "raise_pr"/);
+  assert.match(job, /allowed_actions:[\s\S]*  - "force_push"/);
   assert.match(job, /blocked_actions:[\s\S]*  - "merge"/);
   assert.match(job, /allow_merge: false/);
   assert.match(job, /Merge-risk candidates are repair-only and must not be merged from this shard/);


### PR DESCRIPTION
## Summary

- add explicit `--allow-force-push` authorization for autonomous remediation and gitcrawl cluster imports
- keep plan mode and default autonomous imports force-push blocked
- allow repair-only merge-risk jobs to carry the optional guarded capability
- reject malformed or non-autonomous force-push option use before hydration

This closes the policy mismatch exposed by run https://github.com/openclaw/clownfish/actions/runs/29174408362, where a validated contributor rebase could not be published because its generated remediation job blocked `force_push`. The executor still requires live maintainer editability, exact-head checks, validation, review, and force-with-lease.

## Validation

- `node --test test/import-github-pr-inventory.test.mjs test/import-gitcrawl-clusters.test.mjs test/execute-fix-artifact.test.mjs` (101 passed)
- `node --test test/import-github-pr-inventory.test.mjs` after strict parser hardening (30 passed)
- `npm run validate` (6,679 jobs)
- `git diff --check`
- independent review completed with all findings addressed
