### PR TITLE
feat(import): add bounded hydration concurrency

### DIFF
--- a/scripts/import-github-pr-inventory.mjs
+++ b/scripts/import-github-pr-inventory.mjs
@@ -1924,15 +1924,24 @@ async function ghJsonWithRetryAsync(ghArgs, { operation }) {
 }
 
 function isRetryableGhError(error) {
-  const message = String(error?.stderr ?? error?.message ?? error);
+  if (error?.killed === true || error?.code === "ETIMEDOUT" || error?.signal === "SIGTERM") return true;
+  const message = ghErrorText(error);
   return /timed out|timeout|TLS handshake|connection reset|502 Bad Gateway|503 Service Unavailable|504 Gateway Timeout|secondary rate|Something went wrong while executing your query/i.test(
     message,
   );
 }
 
 function isMissingPullRequestError(error) {
-  const message = String(error?.stderr ?? error?.message ?? error);
+  const message = ghErrorText(error);
   return /Could not resolve to a PullRequest with the number of \d+\.|HTTP 404: Not Found/i.test(message);
+}
+
+function ghErrorText(error) {
+  const text = [error?.stderr, error?.stdout, error?.message]
+    .map((value) => String(value ?? "").trim())
+    .filter(Boolean)
+    .join("\n");
+  return text || String(error);
 }
 
 function numberFromEnv(name, fallback) {

--- a/scripts/import-github-pr-inventory.mjs
+++ b/scripts/import-github-pr-inventory.mjs
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFile, execFileSync, spawnSync } from "node:child_process";
+import { promisify } from "node:util";
 import { parseArgs, parseJob, repoRoot } from "./lib.mjs";
 import { hasSecuritySensitiveText } from "./security-sensitive.mjs";
 
 const PASSING_CHECK_CONCLUSIONS = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"]);
 const CLEAN_MERGE_STATES = new Set(["CLEAN"]);
 const IGNORED_CHECKS = new Set(["auto-response", "Labeler", "Stale"]);
+const execFileAsync = promisify(execFile);
 const args = parseArgs(process.argv.slice(2));
 const repo = String(args.repo ?? "openclaw/openclaw");
 const [owner, name] = repo.split("/");
@@ -82,6 +84,15 @@ const hydrateIncludeRefs = Boolean(args["hydrate-include-refs"] ?? args.hydrate_
 const minScore = numberArg("min-score", 2);
 const maxFiles = numberArg("max-files", 120);
 const limitForHydration = limit === "all" ? 500 : Number(limit);
+const hydrationConcurrency = boundedInteger(
+  args["hydration-concurrency"] ??
+    args.hydration_concurrency ??
+    process.env.CLOWNFISH_GITHUB_IMPORT_HYDRATION_CONCURRENCY,
+  4,
+  "--hydration-concurrency",
+  1,
+  8,
+);
 const defaultSearchLimit = checksSuccessPreflight
   ? 1000
   : Math.min(Math.max(limitForHydration * 20, 200), 1000);
@@ -137,7 +148,7 @@ const publishedConflictingRepairClusterIds =
 const checksSuccessAttempts =
   skipExisting && checksSuccessPreflight ? existingChecksSuccessAttempts(existingDir) : new Map();
 if (checksSuccessPreflight) checksSuccessMainSha = fetchChecksSuccessMainSha();
-const rawOpenPullRequests = fetchOpenPullRequests();
+const rawOpenPullRequests = await fetchOpenPullRequests();
 if (strategy === "low-signal") hydrateLowSignalPullRequestFiles(rawOpenPullRequests);
 const candidates = dedupeCandidates(
   rawOpenPullRequests
@@ -172,6 +183,7 @@ const payload = sanitizeJsonValue({
     bucket: bucketFilter,
     min_score: strategy === "low-signal" ? minScore : null,
     max_files: strategy === "low-signal" ? maxFiles : null,
+    hydration_concurrency: hydrationConcurrency,
     low_signal_hydrate_limit: strategy === "low-signal" ? lowSignalHydrateLimit : null,
     low_signal_blocked_labels:
       strategy === "low-signal" ? blockedLowSignalLabelPatterns.map((pattern) => pattern.source) : [],
@@ -213,14 +225,14 @@ if (jsonOutput) {
   for (const item of generated) console.log(item.path);
 }
 
-function fetchOpenPullRequests() {
+async function fetchOpenPullRequests() {
   if (fetchOpenPullRequests.cache) return fetchOpenPullRequests.cache;
   if (inventorySource === "search") {
-    fetchOpenPullRequests.cache = fetchOpenPullRequestsFromSearch();
+    fetchOpenPullRequests.cache = await fetchOpenPullRequestsFromSearch();
     return fetchOpenPullRequests.cache;
   }
   if (inventorySource === "pr-list") {
-    fetchOpenPullRequests.cache = fetchOpenPullRequestsFromPrList();
+    fetchOpenPullRequests.cache = await fetchOpenPullRequestsFromPrList();
     return fetchOpenPullRequests.cache;
   }
   const query = `query($endCursor:String){
@@ -263,7 +275,7 @@ function fetchOpenPullRequests() {
   return pulls;
 }
 
-function fetchOpenPullRequestsFromSearch() {
+async function fetchOpenPullRequestsFromSearch() {
   const fields = [
     "assignees",
     "author",
@@ -305,32 +317,37 @@ function fetchOpenPullRequestsFromSearch() {
   if (!Array.isArray(pulls)) throw new Error("GitHub PR search returned a non-array payload");
   const normalized = pulls.map(normalizeSearchPullRequest);
   if (!checksSuccessPreflight) return normalized;
-  return hydrateChecksSuccessPullRequests(
+  return await hydrateChecksSuccessPullRequests(
     normalized
       .filter((pull) => !prListMergeBlocker(pull, { requireExactHead: false }))
       .filter((pull) => shouldRetryChecksSuccessPullRequest(pull)),
   );
 }
 
-function hydrateChecksSuccessPullRequests(pulls) {
+async function hydrateChecksSuccessPullRequests(pulls) {
   const hydratedPulls = [];
-  for (const pull of pulls) {
-    let hydrated;
-    try {
-      hydrated = hydrateChecksSuccessPullRequest(pull.number);
-    } catch (error) {
-      const retryable = isRetryableGhError(error);
-      const missing = isMissingPullRequestError(error);
-      if (!retryable && !missing) throw error;
-      const failure = retryable ? "failed after retries" : "could not be hydrated";
-      console.error(`hydrate pull request #${pull.number} ${failure}; skipping candidate`);
-      continue;
+  for (let index = 0; index < pulls.length; index += hydrationConcurrency) {
+    const window = pulls.slice(index, index + hydrationConcurrency);
+    const outcomes = await hydratePullRequestWindow(window, hydrateChecksSuccessPullRequest);
+    let acceptedLimitReached = false;
+
+    for (const { pull, hydrated, error } of outcomes) {
+      if (error) {
+        const retryable = isRetryableGhError(error);
+        const missing = isMissingPullRequestError(error);
+        if (!retryable && !missing) throw error;
+        const failure = retryable ? "failed after retries" : "could not be hydrated";
+        console.error(`hydrate pull request #${pull.number} ${failure}; skipping candidate`);
+        continue;
+      }
+      if (acceptedLimitReached || !hydrated) continue;
+      const normalized = normalizePrListPullRequest(hydrated);
+      if (!acceptHydratedChecksSuccessPullRequest(normalized)) continue;
+      hydratedPulls.push(normalized);
+      if (limit !== "all" && hydratedPulls.length >= limitForHydration) acceptedLimitReached = true;
     }
-    if (!hydrated) continue;
-    const normalized = normalizePrListPullRequest(hydrated);
-    if (!acceptHydratedChecksSuccessPullRequest(normalized)) continue;
-    hydratedPulls.push(normalized);
-    if (limit !== "all" && hydratedPulls.length >= limitForHydration) break;
+
+    if (acceptedLimitReached) break;
   }
   return hydratedPulls;
 }
@@ -521,16 +538,16 @@ function normalizedGitSha(value) {
   return /^[0-9a-f]{40}$/.test(sha) ? sha : null;
 }
 
-function hydrateChecksSuccessPullRequest(number) {
+async function hydrateChecksSuccessPullRequest(number) {
   const attempts = numberFromEnv("CLOWNFISH_CHECKS_SUCCESS_MERGEABILITY_POLL_ATTEMPTS", 3);
   const delayMs = nonNegativeNumberFromEnv("CLOWNFISH_CHECKS_SUCCESS_MERGEABILITY_POLL_DELAY_MS", 1_000);
   let hydrated = null;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    hydrated = hydratePullRequestForPrListFallback(number);
+    hydrated = await hydratePullRequestForPrListFallbackAsync(number);
     if (!hasUnknownMergeability(hydrated)) return hydrated;
     if (attempt < attempts) {
       console.error(`pull request #${number} mergeability is UNKNOWN on attempt ${attempt}/${attempts}; polling`);
-      if (delayMs > 0) sleepMs(delayMs);
+      if (delayMs > 0) await sleepMsAsync(delayMs);
     }
   }
   return hydrated;
@@ -566,7 +583,7 @@ function hydratedPullRequestSummary(pull) {
   ].join(" ");
 }
 
-function fetchOpenPullRequestsFromPrList() {
+async function fetchOpenPullRequestsFromPrList() {
   if (hydrateIncludeRefs) {
     const pulls = fetchOpenPullRequestsFromIncludedRefs();
     if (!checksSuccessPreflight) return pulls;
@@ -583,7 +600,7 @@ function fetchOpenPullRequestsFromPrList() {
   );
   let pulls;
   if (conflictingBranchRepairInventory) {
-    pulls = fetchOpenPullRequestsFromPrListFallback();
+    pulls = await fetchOpenPullRequestsFromPrListFallback();
   } else {
     try {
       pulls = ghJsonWithRetry(
@@ -606,7 +623,7 @@ function fetchOpenPullRequestsFromPrList() {
     } catch (error) {
       if (!isRetryableGhError(error)) throw error;
       console.error("list open pull request inventory failed after retries; falling back to search plus per-PR hydration");
-      pulls = fetchOpenPullRequestsFromPrListFallback();
+      pulls = await fetchOpenPullRequestsFromPrListFallback();
     }
   }
   if (!Array.isArray(pulls)) throw new Error("GitHub PR list returned a non-array payload");
@@ -640,8 +657,8 @@ function fetchOpenPullRequestsFromIncludedRefs() {
   return pulls;
 }
 
-function fetchOpenPullRequestsFromPrListFallback() {
-  const searchCandidates = fetchOpenPullRequestsFromSearch()
+async function fetchOpenPullRequestsFromPrListFallback() {
+  const searchCandidates = (await fetchOpenPullRequestsFromSearch())
     .filter((pull) => {
       const ref = `#${pull.number}`;
       if (includeRefs && !includeRefs.has(ref)) return false;
@@ -652,27 +669,61 @@ function fetchOpenPullRequestsFromPrListFallback() {
     })
     .slice(0, prListFallbackSearchLimit);
   const pulls = [];
-  for (const pull of searchCandidates) {
-    let hydrated;
-    try {
-      hydrated = hydratePullRequestForPrListFallback(pull.number);
-    } catch (error) {
-      if (!isRetryableGhError(error)) throw error;
-      console.error(`hydrate pull request #${pull.number} failed after retries; skipping candidate`);
-      continue;
+  for (let index = 0; index < searchCandidates.length; index += hydrationConcurrency) {
+    const window = searchCandidates.slice(index, index + hydrationConcurrency);
+    const outcomes = await hydratePullRequestWindow(window, hydratePullRequestForPrListFallbackAsync);
+    let acceptedLimitReached = false;
+
+    for (const { pull, hydrated, error } of outcomes) {
+      if (error) {
+        if (!isRetryableGhError(error)) throw error;
+        console.error(`hydrate pull request #${pull.number} failed after retries; skipping candidate`);
+        continue;
+      }
+      if (acceptedLimitReached || !hydrated) continue;
+      const normalized = normalizePrListPullRequest(hydrated);
+      if (!conflictingBranchRepairInventory && prListMergeBlocker(normalized)) continue;
+      if (conflictingBranchRepairInventory && !conflictingBranchRepairProfile(normalized)) continue;
+      pulls.push(hydrated);
+      if (limit !== "all" && pulls.length >= limitForHydration) acceptedLimitReached = true;
     }
-    if (!hydrated) continue;
-    const normalized = normalizePrListPullRequest(hydrated);
-    if (!conflictingBranchRepairInventory && prListMergeBlocker(normalized)) continue;
-    if (conflictingBranchRepairInventory && !conflictingBranchRepairProfile(normalized)) continue;
-    pulls.push(hydrated);
-    if (limit !== "all" && pulls.length >= limitForHydration) break;
+
+    if (acceptedLimitReached) break;
   }
   return pulls;
 }
 
+async function hydratePullRequestWindow(pulls, hydrate) {
+  return await Promise.all(
+    pulls.map(async (pull) => {
+      try {
+        return { pull, hydrated: await hydrate(pull.number), error: null };
+      } catch (error) {
+        return { pull, hydrated: null, error };
+      }
+    }),
+  );
+}
+
 function hydratePullRequestForPrListFallback(number) {
   const pull = ghJsonWithRetry(
+    [
+      "pr",
+      "view",
+      String(number),
+      "--repo",
+      repo,
+      "--json",
+      prListFields(),
+    ],
+    { operation: `hydrate pull request #${number}` },
+  );
+  if (!pull || typeof pull !== "object") return null;
+  return pull;
+}
+
+async function hydratePullRequestForPrListFallbackAsync(number) {
+  const pull = await ghJsonWithRetryAsync(
     [
       "pr",
       "view",
@@ -1767,6 +1818,15 @@ function numberArg(name, fallback) {
   return value;
 }
 
+function boundedInteger(value, fallback, label, minimum, maximum) {
+  if (value === undefined || value === null || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(`${label} must be an integer from ${minimum} to ${maximum}`);
+  }
+  return parsed;
+}
+
 function booleanFlag(value) {
   if (value === true) return true;
   if (value === false || value == null) return false;
@@ -1816,6 +1876,19 @@ function ghRaw(ghArgs) {
   });
 }
 
+async function ghRawAsync(ghArgs) {
+  const env = { ...process.env, NO_COLOR: "1", CLICOLOR: "0" };
+  delete env.FORCE_COLOR;
+  const { stdout } = await execFileAsync(ghCommand, ghArgs, {
+    cwd: repoRoot(),
+    env,
+    encoding: "utf8",
+    maxBuffer: 128 * 1024 * 1024,
+    timeout: Number(process.env.CLOWNFISH_GITHUB_IMPORT_PAGE_TIMEOUT_MS ?? 180_000),
+  });
+  return stdout;
+}
+
 function ghJsonWithRetry(ghArgs, { operation }) {
   const attempts = numberFromEnv("CLOWNFISH_GITHUB_IMPORT_RETRIES", 4);
   let lastError = null;
@@ -1828,6 +1901,23 @@ function ghJsonWithRetry(ghArgs, { operation }) {
       const delayMs = Math.min(30_000, 1_000 * 2 ** (attempt - 1));
       console.error(`${operation} failed on attempt ${attempt}/${attempts}; retrying in ${delayMs}ms`);
       sleepMs(delayMs);
+    }
+  }
+  throw lastError;
+}
+
+async function ghJsonWithRetryAsync(ghArgs, { operation }) {
+  const attempts = numberFromEnv("CLOWNFISH_GITHUB_IMPORT_RETRIES", 4);
+  let lastError = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return JSON.parse(stripAnsi(await ghRawAsync(ghArgs)) || "null");
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts || !isRetryableGhError(error)) break;
+      const delayMs = Math.min(30_000, 1_000 * 2 ** (attempt - 1));
+      console.error(`${operation} failed on attempt ${attempt}/${attempts}; retrying in ${delayMs}ms`);
+      await sleepMsAsync(delayMs);
     }
   }
   throw lastError;
@@ -1859,6 +1949,10 @@ function nonNegativeNumberFromEnv(name, fallback) {
 
 function sleepMs(milliseconds) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function sleepMsAsync(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 function stripAnsi(text) {

--- a/test/import-github-pr-inventory.test.mjs
+++ b/test/import-github-pr-inventory.test.mjs
@@ -195,6 +195,44 @@ test("live PR inventory accepts --key=value argument form", () => {
   assert.equal(payload.candidates.some((candidate) => candidate.ref === "#101"), true);
 });
 
+test("hydration concurrency reports defaults and enforces CLI and env bounds", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.gh);
+
+  const defaults = runImport(fixture);
+  assert.equal(defaults.status, 0, defaults.stderr || defaults.stdout);
+  assert.equal(JSON.parse(defaults.stdout).options.hydration_concurrency, 4);
+
+  const fromEnv = runImportWithEnv(
+    fixture,
+    { CLOWNFISH_GITHUB_IMPORT_HYDRATION_CONCURRENCY: "8" },
+  );
+  assert.equal(fromEnv.status, 0, fromEnv.stderr || fromEnv.stdout);
+  assert.equal(JSON.parse(fromEnv.stdout).options.hydration_concurrency, 8);
+
+  const fromCli = runImportWithEnv(
+    fixture,
+    { CLOWNFISH_GITHUB_IMPORT_HYDRATION_CONCURRENCY: "8" },
+    "--hydration-concurrency",
+    "1",
+  );
+  assert.equal(fromCli.status, 0, fromCli.stderr || fromCli.stdout);
+  assert.equal(JSON.parse(fromCli.stdout).options.hydration_concurrency, 1);
+
+  for (const value of ["0", "9", "1.5"]) {
+    const invalid = runImport(fixture, "--hydration-concurrency", value);
+    assert.notEqual(invalid.status, 0);
+    assert.match(invalid.stderr, /--hydration-concurrency must be an integer from 1 to 8/);
+  }
+
+  const invalidEnv = runImportWithEnv(
+    fixture,
+    { CLOWNFISH_GITHUB_IMPORT_HYDRATION_CONCURRENCY: "9" },
+  );
+  assert.notEqual(invalidEnv.status, 0);
+  assert.match(invalidEnv.stderr, /--hydration-concurrency must be an integer from 1 to 8/);
+});
+
 test("live low-signal inventory blocks proof, merge-risk, maintainer, and focused fix candidates", () => {
   const fixture = makeFixture();
   writeFakeGh(fixture.gh, { includeLowSignal: true });
@@ -485,6 +523,14 @@ test("remediation inventory can hydrate only included refs", () => {
   assert.equal(payload.totals.include_refs, 4);
   assert.deepEqual(payload.candidates.map((candidate) => candidate.ref), ["#110"]);
   assert.equal(payload.totals.fetched_open_prs, 1);
+
+  const events = readFakeGhEvents(fixture);
+  for (const [current, next] of [[110, 111], [111, 112], [112, 113]]) {
+    assert.ok(
+      hydrationEventIndex(events, "start", next) > hydrationEventIndex(events, "finish", current),
+      `expected included ref #${next} to start after #${current} finished`,
+    );
+  }
 });
 
 test("checks-success remediation intake filters noisy preflight blockers", () => {
@@ -765,10 +811,38 @@ test("checks-success remediation skips hydrated candidates without an exact head
   assert.equal(JSON.parse(result.stdout).candidates.some((candidate) => candidate.ref === "#116"), false);
 });
 
+test("checks-success hydration consumes out-of-order completions in source order", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.gh, {
+    includeChecksSuccessPreflight: true,
+    searchNumbers: [114, 116],
+    hydrateDelays: { 114: 120, 116: 0 },
+  });
+  const result = runImport(
+    fixture,
+    "--strategy",
+    "remediation",
+    "--checks-success",
+    "--limit",
+    "1",
+    "--hydration-concurrency",
+    "2",
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.deepEqual(JSON.parse(result.stdout).candidates.map((candidate) => candidate.ref), ["#114"]);
+
+  const events = readFakeGhEvents(fixture);
+  assert.ok(
+    hydrationEventIndex(events, "finish", 116) < hydrationEventIndex(events, "finish", 114),
+    "expected #116 to finish before #114",
+  );
+});
+
 test("checks-success remediation fails closed on hydration auth errors", () => {
   const fixture = makeFixture();
   writeFakeGh(fixture.gh, {
     includeChecksSuccessPreflight: true,
+    searchNumbers: [114, 116],
     failHydrateNumber: 116,
     failHydrateAuth: true,
   });
@@ -778,7 +852,9 @@ test("checks-success remediation fails closed on hydration auth errors", () => {
     "remediation",
     "--checks-success",
     "--limit",
-    "all",
+    "1",
+    "--hydration-concurrency",
+    "2",
   );
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /HTTP 401: Bad credentials/);
@@ -897,12 +973,54 @@ test("remediation inventory pr-list source falls back to per-PR hydration on Git
   assert.equal(payload.totals.fetched_open_prs, 1);
 });
 
+test("remediation fallback starts fixed hydration windows and limits accepted results", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.gh, {
+    failPrList: true,
+    searchNumbers: [106, 105, 109, 110],
+    hydrateDelays: { 106: 100, 105: 100 },
+  });
+
+  const result = runImportWithEnv(
+    fixture,
+    { CLOWNFISH_GITHUB_IMPORT_RETRIES: "1" },
+    "--strategy",
+    "remediation",
+    "--inventory-source",
+    "pr-list",
+    "--bucket",
+    "ready_for_maintainer",
+    "--limit",
+    "1",
+    "--skip-existing",
+    "false",
+    "--hydration-concurrency",
+    "2",
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.deepEqual(JSON.parse(result.stdout).candidates.map((candidate) => candidate.ref), ["#109"]);
+
+  const events = readFakeGhEvents(fixture);
+  const secondWindowStart = Math.min(
+    hydrationEventIndex(events, "start", 109),
+    hydrationEventIndex(events, "start", 110),
+  );
+  assert.ok(secondWindowStart > hydrationEventIndex(events, "finish", 106));
+  assert.ok(secondWindowStart > hydrationEventIndex(events, "finish", 105));
+});
+
 test("remediation fallback skips one PR when hydration keeps failing", () => {
   const fixture = makeFixture();
-  writeFakeGh(fixture.gh, { failPrList: true, failHydrateNumber: 109, failHydrateIncident: true });
+  writeFakeGh(fixture.gh, {
+    failPrList: true,
+    searchNumbers: [109, 110],
+    failHydrateNumber: 109,
+    failHydrateIncident: true,
+  });
 
-  const result = runImport(
+  const result = runImportWithEnv(
     fixture,
+    { CLOWNFISH_GITHUB_IMPORT_RETRIES: "1" },
     "--strategy",
     "remediation",
     "--bucket",
@@ -920,6 +1038,10 @@ test("remediation fallback skips one PR when hydration keeps failing", () => {
 });
 
 function runImport(fixture, ...extraArgs) {
+  return runImportWithEnv(fixture, {}, ...extraArgs);
+}
+
+function runImportWithEnv(fixture, extraEnv, ...extraArgs) {
   const write = extraArgs.includes("--write");
   const defaultExistingDir = extraArgs.includes("--default-existing-dir");
   const args = extraArgs.filter((arg) => arg !== "--write" && arg !== "--default-existing-dir");
@@ -952,6 +1074,7 @@ function runImport(fixture, ...extraArgs) {
       env: {
         ...process.env,
         CLOWNFISH_CHECKS_SUCCESS_MERGEABILITY_POLL_DELAY_MS: "0",
+        ...extraEnv,
       },
     },
   );
@@ -964,10 +1087,11 @@ function makeFixture() {
   const results = path.join(root, "results");
   const gh = path.join(root, "fake-gh.mjs");
   const ghCalls = `${gh}.calls`;
+  const ghEvents = `${gh}.events`;
   fs.mkdirSync(out, { recursive: true });
   fs.mkdirSync(existing, { recursive: true });
   fs.mkdirSync(results, { recursive: true });
-  return { root, out, existing, results, gh, ghCalls };
+  return { root, out, existing, results, gh, ghCalls, ghEvents };
 }
 
 function writeFakeGh(filePath, options = {}) {
@@ -1306,17 +1430,38 @@ function writeFakeGh(filePath, options = {}) {
     ...conflictingRepairPulls,
     cleanPrListPull,
   ];
+  const filteredSearchPulls = Array.isArray(options.searchNumbers)
+    ? searchPulls.filter((pull) => options.searchNumbers.includes(pull.number))
+    : searchPulls;
   fs.writeFileSync(
     filePath,
     `#!/usr/bin/env node
 import fs from "node:fs";
 const prListPulls = ${JSON.stringify(prListPulls)};
+const hydrationDelays = ${JSON.stringify(options.hydrateDelays ?? {})};
+const hydrationNumber =
+  process.argv[2] === "pr" && process.argv[3] === "view"
+    ? String(process.argv[4])
+    : null;
+function recordHydrationEvent(event) {
+  if (!hydrationNumber) return;
+  fs.appendFileSync(
+    ${JSON.stringify(`${filePath}.events`)},
+    JSON.stringify({ event, number: Number(hydrationNumber) }) + "\\n",
+  );
+}
 fs.appendFileSync(${JSON.stringify(`${filePath}.calls`)}, JSON.stringify(process.argv.slice(2)) + "\\n");
+if (hydrationNumber) {
+  recordHydrationEvent("start");
+  const delayMs = Number(hydrationDelays[hydrationNumber] ?? 0);
+  if (delayMs > 0) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+}
 if (process.argv[2] === "pr" && process.argv[3] === "list" && ${JSON.stringify(Boolean(options.failPrList))}) {
   console.error("HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)");
   process.exit(1);
 }
 if (process.argv[2] === "pr" && process.argv[3] === "view" && String(process.argv[4]) === ${JSON.stringify(String(options.failHydrateNumber ?? ""))}) {
+  recordHydrationEvent("finish");
   console.error(${JSON.stringify(
     options.failHydrateNotFound
       ? "Could not resolve to a PullRequest with the number of 116."
@@ -1346,7 +1491,7 @@ if (process.argv[2] === "api" && process.argv.includes("repos/openclaw/openclaw/
 ) {
   payload = { data: { updatePullRequestBranch: { pullRequest: { headRefOid: ${JSON.stringify("a".repeat(40))} } } } };
 } else if (process.argv[2] === "search") {
-  payload = ${JSON.stringify(searchPulls)};
+  payload = ${JSON.stringify(filteredSearchPulls)};
 } else if (process.argv[2] === "pr" && process.argv[3] === "view") {
   payload = prListPulls.find((pull) => String(pull.number) === String(process.argv[4])) ?? null;
   if (String(process.argv[4]) === ${JSON.stringify(String(options.staleBaseNumber ?? ""))} && payload) {
@@ -1387,6 +1532,7 @@ if (process.argv[2] === "api" && process.argv.includes("repos/openclaw/openclaw/
   },
 })};
 }
+recordHydrationEvent("finish");
 console.log(JSON.stringify(payload));
 `,
     { mode: 0o755 },
@@ -1505,6 +1651,22 @@ function readFakeGhCalls(fixture) {
     .split(/\r?\n/)
     .filter(Boolean)
     .map((line) => JSON.parse(line));
+}
+
+function readFakeGhEvents(fixture) {
+  if (!fs.existsSync(fixture.ghEvents)) return [];
+  return fs
+    .readFileSync(fixture.ghEvents, "utf8")
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function hydrationEventIndex(events, event, number) {
+  const index = events.findIndex((entry) => entry.event === event && entry.number === number);
+  assert.notEqual(index, -1, `missing ${event} event for pull request #${number}`);
+  return index;
 }
 
 function writePublishedResult(filePath) {

--- a/test/import-github-pr-inventory.test.mjs
+++ b/test/import-github-pr-inventory.test.mjs
@@ -1009,6 +1009,43 @@ test("remediation fallback starts fixed hydration windows and limits accepted re
   assert.ok(secondWindowStart > hydrationEventIndex(events, "finish", 105));
 });
 
+test("remediation fallback retries an async hydration timeout", () => {
+  const fixture = makeFixture();
+  writeFakeGh(fixture.gh, {
+    failPrList: true,
+    searchNumbers: [109],
+    timeoutHydrateOnceNumber: 109,
+  });
+
+  const result = runImportWithEnv(
+    fixture,
+    {
+      CLOWNFISH_GITHUB_IMPORT_RETRIES: "2",
+      CLOWNFISH_GITHUB_IMPORT_PAGE_TIMEOUT_MS: "2000",
+    },
+    "--strategy",
+    "remediation",
+    "--inventory-source",
+    "pr-list",
+    "--bucket",
+    "ready_for_maintainer",
+    "--limit",
+    "all",
+    "--skip-existing",
+    "false",
+    "--hydration-concurrency",
+    "1",
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stderr, /hydrate pull request #109 failed on attempt 1\/2; retrying/);
+  assert.deepEqual(JSON.parse(result.stdout).candidates.map((candidate) => candidate.ref), ["#109"]);
+
+  const hydrationCalls = readFakeGhCalls(fixture).filter(
+    (call) => call[0] === "pr" && call[1] === "view" && call[2] === "109",
+  );
+  assert.equal(hydrationCalls.length, 2);
+});
+
 test("remediation fallback skips one PR when hydration keeps failing", () => {
   const fixture = makeFixture();
   writeFakeGh(fixture.gh, {
@@ -1443,6 +1480,13 @@ const hydrationNumber =
   process.argv[2] === "pr" && process.argv[3] === "view"
     ? String(process.argv[4])
     : null;
+const callsPath = ${JSON.stringify(`${filePath}.calls`)};
+const priorCalls = fs.existsSync(callsPath)
+  ? fs.readFileSync(callsPath, "utf8").trim().split(/\\r?\\n/).filter(Boolean).map((line) => JSON.parse(line))
+  : [];
+const hydrationAttempt = hydrationNumber
+  ? priorCalls.filter((call) => call[0] === "pr" && call[1] === "view" && String(call[2]) === hydrationNumber).length + 1
+  : 0;
 function recordHydrationEvent(event) {
   if (!hydrationNumber) return;
   fs.appendFileSync(
@@ -1450,10 +1494,13 @@ function recordHydrationEvent(event) {
     JSON.stringify({ event, number: Number(hydrationNumber) }) + "\\n",
   );
 }
-fs.appendFileSync(${JSON.stringify(`${filePath}.calls`)}, JSON.stringify(process.argv.slice(2)) + "\\n");
+fs.appendFileSync(callsPath, JSON.stringify(process.argv.slice(2)) + "\\n");
 if (hydrationNumber) {
   recordHydrationEvent("start");
-  const delayMs = Number(hydrationDelays[hydrationNumber] ?? 0);
+  const timeoutOnce =
+    hydrationNumber === ${JSON.stringify(String(options.timeoutHydrateOnceNumber ?? ""))} &&
+    hydrationAttempt === 1;
+  const delayMs = timeoutOnce ? 5000 : Number(hydrationDelays[hydrationNumber] ?? 0);
   if (delayMs > 0) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
 }
 if (process.argv[2] === "pr" && process.argv[3] === "list" && ${JSON.stringify(Boolean(options.failPrList))}) {


### PR DESCRIPTION
## Summary

- hydrate fallback PR views in ordered windows instead of serially
- default to concurrency 4 with a hard cap of 8
- preserve source ordering, accepted-result limits, retries, and fail-closed auth behavior
- keep explicit include-ref hydration sequential
- retry async hydration process timeouts without masking missing-PR errors

## Validation

- `node --test test/import-github-pr-inventory.test.mjs` (34/34)
- timeout regression stress run (5/5)
- `npm run validate` (6,699 jobs)
- `git diff --check`
- independent review: approved
