### PR TITLE
fix(preflight): consume exact bot comment states

### DIFF
--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -2371,9 +2371,9 @@ function isActionableCommentEvidence(
   const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
 
   if (isClawSweeperAuthor(author)) {
-    const currentReview = body.toLowerCase().split(/<details>/, 1)[0];
-    if (hasActionableClawSweeperReviewSignal(currentReview, { view })) return true;
-    if (hasClawSweeperReadyReviewSignal(currentReview)) return true;
+    const normalized = body.toLowerCase();
+    if (hasActionableClawSweeperReviewSignal(normalized, { view })) return true;
+    if (hasClawSweeperReadyReviewSignal(normalized)) return true;
   }
   if (isReviewBot({ author: { login: author }, body })) {
     return /found issues|requested changes|changes requested|needs changes?|needs human|do not merge|duplicate|superseded|security/i.test(
@@ -2472,9 +2472,8 @@ function hasActionableApprovedReviewBody(body) {
 }
 
 function isBenignAutomationComment({ author, body, pull, view }) {
-  const currentReview = String(body).split(/<details>/, 1)[0];
   if (isClawSweeperReviewStartComment({ author, body, pull })) return true;
-  if (isClawSweeperAuthor(author) && hasClawSweeperReadyReviewSignal(currentReview)) {
+  if (isClawSweeperAuthor(author) && hasClawSweeperReadyReviewSignal(body)) {
     return isClawSweeperReadyReviewComment({ author, body, pull, view });
   }
   if (isStaleAutomationReviewComment({ author, body, pull })) return true;
@@ -2493,6 +2492,7 @@ function isDependencyGuardAutomationComment({ body, pull }) {
   if (!/^<!--\s*openclaw:dependency-graph-guard\s*-->/.test(body)) return false;
   const headSha = String(pull?.head?.sha ?? "").toLowerCase();
   if (!/^[0-9a-f]{40}$/.test(headSha)) return false;
+  if (isTrustedDependencyGraphAutomationComment({ body, headSha })) return true;
   if (/### dependency graph change authorized\b/.test(body)) {
     const approvedSha = body.match(/\bapproved sha:\s*`([0-9a-f]{40})`/)?.[1];
     return approvedSha === headSha;
@@ -2501,6 +2501,38 @@ function isDependencyGuardAutomationComment({ body, pull }) {
     /^<!--\s*openclaw:dependency-graph-guard\s*-->\s*### dependency graph guard cleared\s+this pr no longer has blocked dependency graph changes\.\s+a future dependency graph change requires a fresh `\/allow-dependencies-change` comment after the guard blocks that new head sha\.\s+- current sha:\s*`([0-9a-f]{40})`\s*$/i,
   );
   return cleared?.[1]?.toLowerCase() === headSha;
+}
+
+function isTrustedDependencyGraphAutomationComment({ body, headSha }) {
+  const lines = String(body)
+    .trim()
+    .toLowerCase()
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length !== 7) return false;
+  if (lines[0] !== "<!-- openclaw:dependency-graph-guard -->") return false;
+  if (lines[1] !== "### dependency graph changes noted") return false;
+  if (
+    lines[2] !==
+    "this pr includes dependency graph changes. the dependency guard is informational because the pr author is a repository admin or a member of `@openclaw/openclaw-secops`."
+  ) {
+    return false;
+  }
+  const currentSha = lines[3].match(/^- current sha:\s*`([0-9a-f]{40})`$/)?.[1];
+  if (currentSha !== headSha) return false;
+  if (!/^- trusted actor:\s*@[a-z0-9](?:[a-z0-9-]{0,38})$/.test(lines[4])) return false;
+  if (
+    !/^- trusted role:\s*`pull request author; (?:repository admin|openclaw-secops)`$/.test(
+      lines[5],
+    )
+  ) {
+    return false;
+  }
+  return (
+    lines[6] ===
+    "security review is still recommended before merge when the dependency graph change is intentional."
+  );
 }
 
 function isStaleAutomationReviewComment({ author, body, pull }) {
@@ -2589,8 +2621,18 @@ function isClawSweeperReadyReviewComment({ author, body, pull, view = null }) {
   const hasExactMarker = hasExactHeadClawSweeperReadyMarker({ body: normalized, pull });
   if (!hasExactMarker) return false;
 
-  const currentReview = normalized.split(/<details>/, 1)[0];
-  return !hasActionableClawSweeperReviewSignal(currentReview, { view }) && hasClawSweeperReadyReviewSignal(currentReview);
+  const reviewState = parseClawSweeperReviewState({ body: normalized, pull });
+  if (reviewState.kind === "malformed") return false;
+  if (hasActionableClawSweeperReviewSignal(normalized, { view })) return false;
+  if (!hasClawSweeperReadyReviewSignal(normalized)) return false;
+  if (reviewState.kind === "legacy") return hasLegacyClawSweeperReadyReviewSignal(normalized);
+  if (reviewState.kind === "transitional") return true;
+  return (
+    reviewState.readiness === "ready" &&
+    reviewState.findings === "none" &&
+    reviewState.security === "none" &&
+    reviewState.beforeMerge === "none"
+  );
 }
 
 function isStaleClawSweeperReadyReviewComment({ author, body, pull, view = null }) {
@@ -2600,10 +2642,9 @@ function isStaleClawSweeperReadyReviewComment({ author, body, pull, view = null 
   const headSha = String(pull?.head?.sha ?? "").toLowerCase();
   if (!marker || !/^[0-9a-f]{40}$/.test(headSha) || marker.sha === headSha) return false;
 
-  const currentReview = normalized.split(/<details>/, 1)[0];
   return (
-    !hasActionableClawSweeperReviewSignal(currentReview, { view }) &&
-    hasClawSweeperReadyReviewSignal(currentReview)
+    !hasActionableClawSweeperReviewSignal(normalized, { view }) &&
+    hasClawSweeperReadyReviewSignal(normalized)
   );
 }
 
@@ -2674,10 +2715,29 @@ function hasClawSweeperReadyReviewSignal(body) {
   const firstLine = String(body).split(/\r?\n/, 1)[0].trim();
   return (
     isClawSweeperMaintainerReviewHeader(firstLine) &&
+    (hasLegacyClawSweeperReadyReviewSignal(body) ||
+      hasCurrentClawSweeperReadyReviewSignal(body))
+  );
+}
+
+function hasLegacyClawSweeperReadyReviewSignal(body) {
+  return (
     /result:\s*ready for maintainer review\./.test(body) &&
     /(review metrics:\*\*\s*none identified|review metrics:\s*none identified|no (?:clawsweeper |automated )?repair(?: job| lane)? is (?:needed|indicated)|no concrete (?:code finding|contributor-facing blocker left)|remaining action is normal maintainer review)/.test(
       body,
     )
+  );
+}
+
+function hasCurrentClawSweeperReadyReviewSignal(body) {
+  const readiness = markdownReviewSection(body, { heading: "merge readiness", level: 2 });
+  const beforeMerge = markdownReviewSection(body, { heading: "before merge", level: 2 });
+  return (
+    readiness.kind === "present" &&
+    /(?:^|\n)✅\s*\*\*ready for maintainer review\*\*(?:\n|$)/.test(readiness.body) &&
+    /\bno actionable findings\./.test(readiness.body) &&
+    beforeMerge.kind === "present" &&
+    isNoneReviewSection(beforeMerge.body)
   );
 }
 
@@ -2700,8 +2760,50 @@ function hasActionableClawSweeperReviewSignal(body, { view = null } = {}) {
       reviewSection(body, "proof guidance"),
     ) ||
     /\b(?:blocker|must|needs?|required|missing)\b/.test(reviewSection(body, "risk before merge")) ||
-    /\bremaining (?:merge )?blocker\b/.test(reviewSection(body, "next step before merge"))
+    /\bremaining (?:merge )?blocker\b/.test(reviewSection(body, "next step before merge")) ||
+    hasActionableCurrentClawSweeperReviewSignal(body)
   );
+}
+
+function hasActionableCurrentClawSweeperReviewSignal(body) {
+  for (const heading of ["before merge", "review findings"]) {
+    const section = markdownReviewSection(body, { heading, level: 2 });
+    if (
+      section.kind === "duplicate" ||
+      (section.kind === "present" && !isNoneReviewSection(section.body))
+    ) {
+      return true;
+    }
+  }
+
+  const securitySections = [
+    markdownReviewSection(body, { heading: "security", level: 2 }),
+    markdownReviewSection(body, { heading: "security", level: 3 }),
+  ];
+  if (
+    securitySections.some(
+      (section) =>
+        section.kind === "duplicate" ||
+        (section.kind === "present" && !isNoneReviewSection(section.body)),
+    )
+  ) {
+    return true;
+  }
+
+  for (const label of ["findings", "security"]) {
+    const cells = reviewTableResults(body, label);
+    if (cells.length > 1 || cells.some((cell) => !isNoneReviewSection(cell))) return true;
+  }
+
+  return String(body)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .some((line) =>
+      /\b(?:please\s+)?(?:confirm|verify|fix|address|resolve|add|remove|update|change|provide|run)\b.{0,200}\bbefore (?:merge|merging|landing|shipping)\b/.test(
+        line,
+      ),
+    );
 }
 
 function withoutAdvisoryReviewSections(body) {
@@ -2721,6 +2823,41 @@ function reviewSection(body, heading) {
       ),
     )?.[1] ?? ""
   );
+}
+
+function markdownReviewSection(body, { heading, level }) {
+  const marker = `${"#".repeat(level)} ${String(heading).toLowerCase()}`;
+  const lines = String(body).toLowerCase().split(/\r?\n/);
+  const indexes = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index].trim() === marker) indexes.push(index);
+  }
+  if (indexes.length === 0) return { kind: "missing", body: "" };
+  if (indexes.length !== 1) return { kind: "duplicate", body: "" };
+
+  const section = [];
+  for (let index = indexes[0] + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    const headingMatch = line.match(/^(#{1,6})\s+\S/);
+    if (headingMatch && headingMatch[1].length <= level) break;
+    if (level === 2 && /^<details>/i.test(line.trim())) break;
+    if (level === 3 && /^<\/details>/i.test(line.trim())) break;
+    section.push(line);
+  }
+  return { kind: "present", body: section.join("\n").trim() };
+}
+
+function isNoneReviewSection(body) {
+  return /^none[.!]?$/.test(String(body).trim());
+}
+
+function reviewTableResults(body, label) {
+  const escapedLabel = String(label).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `^\\|\\s*\\*\\*${escapedLabel}\\*\\*\\s*\\|\\s*([^|\\r\\n]+?)\\s*\\|`,
+    "gim",
+  );
+  return [...String(body).matchAll(pattern)].map((match) => match[1].trim().toLowerCase());
 }
 
 function hasExplicitMergeObjection(body, { view = null } = {}) {
@@ -2829,6 +2966,48 @@ function hasExactHeadClawSweeperReadyMarker({ body, pull }) {
   const marker = parseClawSweeperReadyMarker({ body, pull });
   const headSha = String(pull?.head?.sha ?? "").toLowerCase();
   return Boolean(marker && /^[0-9a-f]{40}$/.test(headSha) && marker.sha === headSha);
+}
+
+function parseClawSweeperReviewState({ body, pull }) {
+  const openers = String(body).match(/<!--\s*clawsweeper-review-version\b/gi) ?? [];
+  if (openers.length === 0) return { kind: "legacy" };
+  const markers = [
+    ...String(body).matchAll(/<!--\s*clawsweeper-review-version\s+([^>]*)-->/gi),
+  ];
+  if (openers.length !== 1 || markers.length !== 1) return { kind: "malformed" };
+
+  const attributes = parseMarkerAttributes(markers[0][1]);
+  const headSha = String(pull?.head?.sha ?? "").toLowerCase();
+  const pullNumber = String(pull?.number ?? "");
+  if (
+    !attributes ||
+    attributes.v !== "1" ||
+    attributes.item !== pullNumber ||
+    attributes.sha?.toLowerCase() !== headSha ||
+    !/^[0-9a-f]{40}$/.test(headSha)
+  ) {
+    return { kind: "malformed" };
+  }
+
+  // The v1 state tuple is the producer/consumer contract. Missing every state
+  // field is transitional; partial tuples and unknown values fail closed.
+  const stateKeys = ["readiness", "findings", "security", "before_merge"];
+  const presentStateKeys = stateKeys.filter((key) => Object.hasOwn(attributes, key));
+  if (presentStateKeys.length === 0) return { kind: "transitional" };
+  if (presentStateKeys.length !== stateKeys.length) return { kind: "malformed" };
+  if (!["ready", "blocked"].includes(attributes.readiness)) return { kind: "malformed" };
+  if (!["none", "actionable"].includes(attributes.findings)) return { kind: "malformed" };
+  if (!["none", "actionable"].includes(attributes.security)) return { kind: "malformed" };
+  if (!["none", "actionable"].includes(attributes.before_merge)) {
+    return { kind: "malformed" };
+  }
+  return {
+    kind: "structured",
+    readiness: attributes.readiness,
+    findings: attributes.findings,
+    security: attributes.security,
+    beforeMerge: attributes.before_merge,
+  };
 }
 
 function parseClawSweeperReadyMarker({ body, pull }) {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -2037,6 +2037,145 @@ test("external merge preflight accepts #98505 current-head ready review phrasing
   assert.equal(report.status, "passed", report.reason);
 });
 
+test("external merge preflight accepts a clean transitional ClawSweeper v1 review", () => {
+  const fixture = makeFixture({
+    issueComments: [
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: makeCurrentClawSweeperReviewComment(),
+        url: "https://github.com/openclaw/openclaw/pull/120232#issuecomment-5219047091",
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+  assert.equal(report.status, "passed", report.reason);
+});
+
+test("external merge preflight accepts an exact-head structured ClawSweeper v1 ready state", () => {
+  const fixture = makeFixture({
+    issueComments: [
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: makeCurrentClawSweeperReviewComment({
+          reviewStateAttributes:
+            "readiness=ready findings=none security=none before_merge=none",
+        }),
+        url: "https://github.com/openclaw/openclaw/pull/120232#issuecomment-5219047091",
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+  assert.equal(report.status, "passed", report.reason);
+});
+
+test("external merge preflight blocks the observed contradictory #120232 ClawSweeper review", () => {
+  const fixture = makeFixture({
+    issueComments: [
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: makeCurrentClawSweeperReviewComment({
+          details: [
+            "### Stored data model",
+            "",
+            "Persistent data-model change detected: `persistent cache schema: scripts/ci-changed-scope.mjs`, `vector/embedding metadata: scripts/ci-changed-scope.mjs`. Confirm migration or upgrade compatibility proof before merge.",
+          ],
+        }),
+        url: "https://github.com/openclaw/openclaw/pull/120232#issuecomment-5219047091",
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
+for (const [name, options] of [
+  [
+    "unknown state version",
+    {
+      reviewVersion: "2",
+      reviewStateAttributes: "readiness=ready findings=none security=none before_merge=none",
+    },
+  ],
+  ["missing version marker", { includeReviewVersion: false }],
+  ["partial state tuple", { reviewStateAttributes: "readiness=ready findings=none" }],
+  [
+    "duplicate state marker",
+    {
+      reviewStateAttributes: "readiness=ready findings=none security=none before_merge=none",
+      duplicateReviewVersion: true,
+    },
+  ],
+  [
+    "actionable finding state",
+    {
+      reviewStateAttributes:
+        "readiness=ready findings=actionable security=none before_merge=none",
+    },
+  ],
+  [
+    "security finding state",
+    {
+      reviewStateAttributes:
+        "readiness=ready findings=none security=actionable before_merge=none",
+    },
+  ],
+  [
+    "nonempty before-merge state",
+    {
+      reviewStateAttributes:
+        "readiness=ready findings=none security=none before_merge=actionable",
+    },
+  ],
+]) {
+  test(`external merge preflight blocks ClawSweeper ${name}`, () => {
+    const fixture = makeFixture({
+      issueComments: [
+        {
+          author: { login: "clawsweeper[bot]" },
+          authorAssociation: "CONTRIBUTOR",
+          body: makeCurrentClawSweeperReviewComment(options),
+          url: "https://github.com/openclaw/openclaw/pull/120232#issuecomment-5219047091",
+        },
+      ],
+    });
+    const { report } = runPreflightFixture(fixture);
+    assert.equal(report.status, "blocked", name);
+    assert.match(report.reason, /actionable top-level issue comment/, name);
+  });
+}
+
+for (const [name, options] of [
+  ["nonempty Before merge section", { beforeMerge: "- [ ] Add a regression test." }],
+  ["visible findings", { findings: "1", findingsEvidence: "A routing defect remains." }],
+  ["visible security finding", { security: "1", securityEvidence: "Token scope is unsafe." }],
+  ["detailed security finding", { detailSecurity: "- Token scope is unsafe." }],
+  ["appended objection", { extraVisible: ["Do not merge; the routing defect remains."] }],
+]) {
+  test(`external merge preflight blocks ClawSweeper ready prose with ${name}`, () => {
+    const fixture = makeFixture({
+      issueComments: [
+        {
+          author: { login: "clawsweeper[bot]" },
+          authorAssociation: "CONTRIBUTOR",
+          body: makeCurrentClawSweeperReviewComment({
+            reviewStateAttributes:
+              "readiness=ready findings=none security=none before_merge=none",
+            ...options,
+          }),
+          url: "https://github.com/openclaw/openclaw/pull/120232#issuecomment-5219047091",
+        },
+      ],
+    });
+    const { report } = runPreflightFixture(fixture);
+    assert.equal(report.status, "blocked", name);
+    assert.match(report.reason, /actionable top-level issue comment/, name);
+  });
+}
+
 test("external merge preflight blocks explicit objections appended to positive ready-review phrasing", () => {
   for (const objection of [
     "No concrete code finding, but maintainers must not merge this.",
@@ -2244,7 +2383,7 @@ test("external merge preflight does not clear a CI wait from an unrelated passin
   assert.equal(report.status, "blocked");
 });
 
-test("external merge preflight ignores #98821 stale QA and refresh comments after a newer exact-head ready review", () => {
+test("external merge preflight keeps #98821 comments blocking after a contradictory ready review", () => {
   const fixture = makeFixture({
     pullUser: { login: "harjothkhara" },
     pullLabels: [{ name: "gateway" }, { name: "size: S" }, { name: "P2" }],
@@ -2346,7 +2485,8 @@ test("external merge preflight ignores #98821 stale QA and refresh comments afte
     ],
   });
   const { report } = runPreflightFixture(fixture);
-  assert.equal(report.status, "passed", report.reason);
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
 });
 
 test("external merge preflight blocks a #98821-shaped QA failure note newer than the ready review", () => {
@@ -3509,6 +3649,118 @@ test("external merge preflight accepts exact-head dependency guard authorization
   assert.equal(result.actions[0]?.action, "merge_canonical");
 });
 
+test("external merge preflight accepts #120232 exact-head informational dependency state", () => {
+  const headSha = "a".repeat(40);
+  const fixture = makeFixture({
+    headSha,
+    issueComments: [
+      {
+        author: { login: "github-actions[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: makeInformationalDependencyGraphComment({ headSha }),
+        url: "https://github.com/openclaw/openclaw/pull/120232#issuecomment-5218410461",
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+  assert.equal(report.status, "passed", report.reason);
+});
+
+for (const [name, body] of [
+  [
+    "stale head",
+    makeInformationalDependencyGraphComment({ headSha: "c".repeat(40) }),
+  ],
+  [
+    "blocked state",
+    [
+      "<!-- openclaw:dependency-graph-guard -->",
+      "",
+      "### Dependency graph changes are blocked",
+      "",
+      "Security approval is required before merge.",
+      "",
+      `- Current SHA: \`${"a".repeat(40)}\``,
+    ].join("\n"),
+  ],
+  [
+    "unknown trusted role",
+    makeInformationalDependencyGraphComment({
+      headSha: "a".repeat(40),
+      trustedRole: "pull request author; outside collaborator",
+    }),
+  ],
+  [
+    "duplicate marker",
+    makeInformationalDependencyGraphComment({
+      headSha: "a".repeat(40),
+      duplicateMarker: true,
+    }),
+  ],
+  [
+    "appended objection",
+    makeInformationalDependencyGraphComment({
+      headSha: "a".repeat(40),
+      extraLines: ["", "Do not merge; the dependency review found an unsafe package."],
+    }),
+  ],
+]) {
+  test(`external merge preflight blocks informational dependency state with ${name}`, () => {
+    const fixture = makeFixture({
+      headSha: "a".repeat(40),
+      issueComments: [
+        {
+          author: { login: "github-actions[bot]" },
+          authorAssociation: "CONTRIBUTOR",
+          body,
+          url: "https://github.com/openclaw/openclaw/pull/120232#issuecomment-5218410461",
+        },
+      ],
+    });
+    const { report } = runPreflightFixture(fixture);
+    assert.equal(report.status, "blocked", name);
+    assert.match(
+      report.reason,
+      /security-sensitive signal|actionable top-level issue comment/,
+      name,
+    );
+  });
+}
+
+test("external merge preflight keeps human requests blocking beside informational bot states", () => {
+  const headSha = "a".repeat(40);
+  const fixture = makeFixture({
+    headSha,
+    issueComments: [
+      {
+        author: { login: "github-actions[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: makeInformationalDependencyGraphComment({ headSha }),
+        url: "https://github.com/openclaw/openclaw/pull/120232#issuecomment-5218410461",
+      },
+      {
+        author: { login: "clawsweeper[bot]" },
+        authorAssociation: "CONTRIBUTOR",
+        body: makeCurrentClawSweeperReviewComment({
+          headSha,
+          reviewStateAttributes:
+            "readiness=ready findings=none security=none before_merge=none",
+        }),
+        url: "https://github.com/openclaw/openclaw/pull/120232#issuecomment-5219047091",
+      },
+      {
+        author: { login: "reviewer" },
+        authorAssociation: "MEMBER",
+        body: "Please add a regression test before merge.",
+        url: "https://github.com/openclaw/openclaw/pull/120232#issuecomment-human",
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+});
+
 test("external merge preflight accepts GraphQL github-actions cleared dependency guard", () => {
   const headSha = "a".repeat(40);
   const fixture = makeFixture({
@@ -4040,6 +4292,106 @@ function runExternalMergeRunner(fixture, extraArgs, env) {
       timeout: 60_000,
     },
   );
+}
+
+function makeInformationalDependencyGraphComment({
+  headSha = "a".repeat(40),
+  trustedRole = "pull request author; openclaw-secops",
+  duplicateMarker = false,
+  extraLines = [],
+} = {}) {
+  return [
+    "<!-- openclaw:dependency-graph-guard -->",
+    ...(duplicateMarker ? ["<!-- openclaw:dependency-graph-guard -->"] : []),
+    "",
+    "### Dependency graph changes noted",
+    "",
+    "This PR includes dependency graph changes. The dependency guard is informational because the PR author is a repository admin or a member of `@openclaw/openclaw-secops`.",
+    "",
+    `- Current SHA: \`${headSha}\``,
+    "- Trusted actor: @vincentkoc",
+    `- Trusted role: \`${trustedRole}\``,
+    "",
+    "Security review is still recommended before merge when the dependency graph change is intentional.",
+    ...extraLines,
+  ].join("\n");
+}
+
+function makeCurrentClawSweeperReviewComment({
+  headSha = "a".repeat(40),
+  includeReviewVersion = true,
+  reviewVersion = "1",
+  reviewStateAttributes = "",
+  duplicateReviewVersion = false,
+  beforeMerge = "None.",
+  findings = "None",
+  findingsEvidence = "None.",
+  security = "None",
+  securityEvidence = "None.",
+  detailSecurity = "None.",
+  extraVisible = [],
+  details = [],
+} = {}) {
+  const reviewVersionMarker = [
+    "<!-- clawsweeper-review-version",
+    "item=123",
+    "reviewed_at=2026-08-07T15:37:22.579Z",
+    `sha=${headSha}`,
+    `source_revision=${"1".repeat(64)}`,
+    `v=${reviewVersion}`,
+    reviewStateAttributes,
+    "-->",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return [
+    "Codex review: needs maintainer review before merge. _Reviewed August 7, 2026, 11:37 AM ET / 15:37 UTC._",
+    "",
+    "# ClawSweeper review",
+    "",
+    "## What this changes",
+    "",
+    "This PR routes changes to the Knip cleanup wrapper, runner, and owner test through Windows CI and adds coverage for that selection.",
+    "",
+    "## Merge readiness",
+    "",
+    "✅ **Ready for maintainer review**",
+    "",
+    "No actionable findings. Current main still omits the Knip wrapper, runner, and owner-test paths from Windows selection, while this narrowly owned patch covers the classifier, manifest, fast routing, and native Windows test list.",
+    "",
+    "**Priority:** P3",
+    `**Reviewed head:** \`${headSha}\``,
+    "",
+    "## Verification",
+    "",
+    "| Check | Result | Evidence |",
+    "|---|---|---|",
+    "| **Real behavior** | Not applicable | Maintainer-authored CI-routing PR. |",
+    `| **Findings** | ${findings} | ${findingsEvidence} |`,
+    `| **Security** | ${security} | ${securityEvidence} |`,
+    "",
+    "## Before merge",
+    "",
+    beforeMerge,
+    "",
+    ...extraVisible,
+    "<details>",
+    "<summary><strong>Agent review details</strong></summary>",
+    "",
+    "### Security",
+    "",
+    detailSecurity,
+    "",
+    ...details,
+    "</details>",
+    "",
+    `<!-- clawsweeper-verdict:needs-human item=123 sha=${headSha} confidence=high updated_at=2026-08-07T15:33:01Z reviewed_at=2026-08-07T15:37:22.579Z -->`,
+    ...(includeReviewVersion
+      ? ["", reviewVersionMarker, ...(duplicateReviewVersion ? ["", reviewVersionMarker] : [])]
+      : []),
+    "",
+    "<!-- clawsweeper-review item=123 -->",
+  ].join("\n");
 }
 
 function runPreflightFixture(fixture, extraEnv = {}) {


### PR DESCRIPTION
## Summary

- accept the exact-head trusted Dependency Guard informational state without treating its advisory security sentence as an unresolved finding
- consume a versioned ClawSweeper review-state tuple, with full-comment checks for transitional output and fail-closed handling for malformed, unknown, partial, or duplicate state
- preserve blocking behavior for stale or blocked dependency states, findings, security concerns, nonempty Before Merge sections, appended objections, and human requests

## Root cause

OpenClaw PR https://github.com/openclaw/openclaw/pull/120232 was blocked before checkout and validation:

- https://github.com/openclaw/clownfish/actions/runs/31193109132 classified the informational Dependency Guard comment as security-sensitive and actionable
- https://github.com/openclaw/clownfish/actions/runs/31194153747 also classified the ClawSweeper readiness comment as actionable

The dependency classifier understood authorization and clearance states, but not the producer's exact-head trusted informational state.

The ClawSweeper classifier depended on legacy prose and ignored everything after `<details>`. Current output is structured differently, and the observed comment is internally contradictory: it says there are no findings and Before Merge is empty, then asks maintainers to confirm migration or upgrade compatibility before merge inside the details section.

## State contract

Clownfish now accepts the existing `clawsweeper-review-version` marker as the versioned producer/consumer boundary. The producer-ready v1 shape is:

```text
<!-- clawsweeper-review-version item=<pr> sha=<40-hex-head> v=1 readiness=ready findings=none security=none before_merge=none ... -->
```

Rules:

- `item`, `sha`, and `v=1` must match the current pull request and exact head
- all four state fields must be present together
- `readiness` is `ready` or `blocked`
- `findings`, `security`, and `before_merge` are `none` or `actionable`
- unknown versions or values, partial tuples, and duplicate markers fail closed
- a v1 marker with none of the state fields is transitional and is accepted only when the full comment has clean readiness, Findings, Security, and Before Merge evidence
- structured state never overrides contradictory visible prose, nonempty sections, or explicit merge objections

The current https://github.com/openclaw/openclaw/pull/120232#issuecomment-5219047091 therefore remains blocking until the producer removes the contradictory pre-merge instruction and emits a consistent state tuple.

## Proof

- `node --test test/preflight-external-pr-merge.test.mjs`: 172 passed
- `npm run validate`: 6,707 jobs validated
- `node --check scripts/preflight-external-pr-merge.mjs`
- `git diff --check`
- local autoreview: clean, no accepted/actionable findings
- TruffleHog pre-review scan: clean

The focused regressions cover the two observed comments plus stale, blocked, unknown-role, duplicate-marker, appended-objection, unknown-version, missing-version, partial-state, findings, security, nonempty Before Merge, and human-request variants.

## LOC

- production: +190 / -11
- tests: +354 / -2

The production increase implements the requested versioned comment-state contract and fail-closed security boundary; it does not add a second merge path or compatibility fallback.
