### PR TITLE
build(preflight): install CommonMark runtime

### DIFF
--- a/.github/workflows/cluster-worker.yml
+++ b/.github/workflows/cluster-worker.yml
@@ -563,6 +563,9 @@ jobs:
             ${{ runner.os }}-node24-codex-${{ env.CODEX_CLI_VERSION }}-target-pnpm-
             ${{ runner.os }}-node24-codex-
 
+      - name: Install project dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
       - name: Install Codex CLI
         run: |
           set -euo pipefail

--- a/.github/workflows/external-merge-preflight.yml
+++ b/.github/workflows/external-merge-preflight.yml
@@ -68,6 +68,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node24-codex-
 
+      - name: Install project dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
       - name: Install Codex CLI
         env:
           CODEX_CLI_VERSION: ${{ vars.CLOWNFISH_CODEX_CLI_VERSION || '0.125.0' }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Install project dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
       - name: Validate job specs
         run: npm run validate
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,62 @@
+{
+  "name": "clownfish",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "clownfish",
+      "version": "0.1.0",
+      "dependencies": {
+        "commonmark": "0.31.2"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/commonmark": {
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/commonmark/-/commonmark-0.31.2.tgz",
+      "integrity": "sha512-2fRLTyb9r/2835k5cwcAwOj0DEc44FARnMp5veGsJ+mEAZdi52sNopLu07ZyElQUz058H43whzlERDIaaSw4rg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "entities": "~3.0.1",
+        "mdurl": "~1.0.1",
+        "minimist": "~1.2.8"
+      },
+      "bin": {
+        "commonmark": "bin/commonmark"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "license": "MIT"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   },
   "engines": {
     "node": ">=24"
+  },
+  "dependencies": {
+    "commonmark": "0.31.2"
   }
 }

--- a/test/commonmark-runtime.test.mjs
+++ b/test/commonmark-runtime.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { Parser } from "commonmark";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const installCommand = "npm ci --ignore-scripts --no-audit --no-fund";
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function renderedText(markdown) {
+  const ast = new Parser().parse(markdown);
+  const walker = ast.walker();
+  let event;
+  let output = "";
+  while ((event = walker.next())) {
+    if (!event.entering) continue;
+    if (event.node.type === "text" || event.node.type === "code") {
+      output += event.node.literal;
+    } else if (
+      event.node.type === "softbreak" ||
+      event.node.type === "linebreak"
+    ) {
+      output += " ";
+    }
+  }
+  return output;
+}
+
+test("CommonMark runtime is pinned and installed before dependent workflows", () => {
+  const packageJson = JSON.parse(read("package.json"));
+  assert.equal(packageJson.dependencies.commonmark, "0.31.2");
+
+  for (const [workflowPath, dependentCommand] of [
+    [".github/workflows/validate.yml", "npm run validate"],
+    [
+      ".github/workflows/external-merge-preflight.yml",
+      "npm run preflight-external-merge",
+    ],
+    [
+      ".github/workflows/cluster-worker.yml",
+      "npm run run-external-merge-preflights",
+    ],
+  ]) {
+    const workflow = read(workflowPath);
+    const setupIndex = workflow.indexOf("actions/setup-node@v5");
+    const installIndex = workflow.indexOf(installCommand, setupIndex);
+    const dependentIndex = workflow.indexOf(dependentCommand, installIndex);
+    assert.ok(setupIndex >= 0, `${workflowPath}: missing Node setup`);
+    assert.ok(installIndex > setupIndex, `${workflowPath}: missing dependency install`);
+    assert.ok(
+      dependentIndex > installIndex,
+      `${workflowPath}: dependency install must precede ${dependentCommand}`,
+    );
+  }
+});
+
+test("CommonMark runtime preserves rendered paragraph and link-title boundaries", () => {
+  assert.match(
+    renderedText(
+      [
+        "Safe context.",
+        "2. harmless",
+        '[gate]: <> "Do not merge."',
+      ].join("\n"),
+    ),
+    /Do not merge\./,
+  );
+  assert.doesNotMatch(
+    renderedText(
+      [
+        "Safe [context][gate].",
+        "",
+        '[gate]: /url "Do not merge."',
+      ].join("\n"),
+    ),
+    /Do not merge\./,
+  );
+});


### PR DESCRIPTION
## Summary

- pin the CommonMark reference parser at `0.31.2` with an npm lockfile
- install project dependencies before every workflow command that will load the parser
- add a contract test for dependency pinning, workflow ordering, and rendered link-title boundaries

## Why

Clownfish PR #311 needs authoritative CommonMark parsing in the external-merge
preflight. Repeated review found that a handwritten Markdown state machine was
reimplementing parser semantics and accumulating bypasses. This prerequisite PR
adds only the maintained parser runtime and its workflow installation boundary;
it does not change preflight authorization behavior.

## Validation

- `node --test test/commonmark-runtime.test.mjs` passes
- `npm run validate` validates 6,707 jobs
- `npm test` passes all 557 tests
- `npm audit --omit=dev` reports zero vulnerabilities
- local ClawSweeper exact-range review reports no correctness, security, or rank-up findings
- signed exact-head commit: `31f2feffac0d58ca1beded6ab883957acb7d5ae0`

## Risk

The workflows gain an npm install step. The runtime version and transitive graph
are locked, lifecycle scripts are disabled, and audit/funding network calls are
disabled during CI installation. Exact-head hosted CI must still exercise the
clean-runner installation and cache ordering before merge.

## Maintainer decision

Adopt `commonmark@0.31.2` as the locked parser runtime for external-merge
preflight review text. The reference parser owns Markdown syntax; Clownfish owns
the authorization projection over its AST. The paired parser PR must load it
only in the review-text parsing path so apply-only execution remains independent.
Any incompatible parser or contract change requires a separately reviewed
dependency update.

## Gate disposition

- exact-head hosted validate completed successfully, including clean-runner
  installation before all 557 tests
- exact-head CodeQL completed successfully
- local and hosted ClawSweeper reviews found no correctness or security defect
- the hosted Rank-up move to complete exact-head validate is satisfied
