### PR TITLE
fix(preflight): pin Codex review source

### DIFF
--- a/.github/workflows/external-merge-preflight.yml
+++ b/.github/workflows/external-merge-preflight.yml
@@ -134,6 +134,7 @@ jobs:
             .projectclownfish/external-merge-preflight/result.json
             .projectclownfish/external-merge-preflight/cluster-plan.json
             .projectclownfish/external-merge-preflight/preflight-report.json
+            .projectclownfish/external-merge-preflight/codex-review.json
           if-no-files-found: warn
           include-hidden-files: true
           overwrite: true

--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -10,6 +10,7 @@ import {
   EXACT_MERGE_CHECK_NAME,
   REQUIRED_CI_GATE_NAME,
 } from "./external-merge-checks.mjs";
+import { validateCodexReviewProvenance } from "./codex-review-dependency.mjs";
 
 const MAINTAINER_AUTHOR_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 const CLOSE_ACTIONS = new Set([
@@ -1263,6 +1264,10 @@ function validateMergePreflight({ result, action, target, expectedHeadSha }) {
   if (codexReview.findings_addressed !== true) return "Codex /review findings are not addressed";
   if (!Array.isArray(codexReview.evidence) || codexReview.evidence.length === 0) {
     return "Codex /review evidence is missing";
+  }
+  if (isExternalMergeAction(action)) {
+    const provenanceBlock = validateCodexReviewProvenance(result.repo, codexReview.evidence);
+    if (provenanceBlock) return provenanceBlock;
   }
   const unresolvedThreadBlock = validateResolvedReviewThreads(result.repo, target);
   if (unresolvedThreadBlock) return unresolvedThreadBlock;

--- a/scripts/codex-review-dependency.mjs
+++ b/scripts/codex-review-dependency.mjs
@@ -13,43 +13,55 @@ export const CODEX_REVIEW_PROVENANCE = {
   tag: CODEX_REVIEW_DEPENDENCY.tag, tag_object: CODEX_REVIEW_DEPENDENCY.tagObject,
   commit: CODEX_REVIEW_DEPENDENCY.commit,
 };
-export const codexReviewProvenanceEvidence = () => `${PROVENANCE_PREFIX}${JSON.stringify(CODEX_REVIEW_PROVENANCE)}`;
+const PROVENANCE_KEYS = [...Object.keys(CODEX_REVIEW_PROVENANCE), "source_path", "line"];
+function normalizeCodexReviewCitation(value) {
+  const sourcePath = value?.source_path;
+  if (typeof sourcePath !== "string" || sourcePath.includes("\\") || path.posix.isAbsolute(sourcePath) ||
+      path.posix.normalize(sourcePath) !== sourcePath || !sourcePath.startsWith("codex-rs/") ||
+      sourcePath.endsWith("/") || !Number.isInteger(value?.line) || value.line < 1) return null;
+  return { source_path: sourcePath, line: value.line };
+}
+export function codexReviewProvenanceEvidence(citation) {
+  const normalized = normalizeCodexReviewCitation(citation);
+  if (!normalized) throw new Error("Codex dependency provenance citation is invalid");
+  return `${PROVENANCE_PREFIX}${JSON.stringify({ ...CODEX_REVIEW_PROVENANCE, ...normalized })}`;
+}
 export function validateCodexReviewProvenance(repo, evidence) {
   if (repo !== CODEX_REVIEW_DEPENDENCY.repo) return "";
   const records = Array.isArray(evidence) ? evidence.filter((entry) => typeof entry === "string" && entry.startsWith(PROVENANCE_PREFIX)) : [];
   if (records.length !== 1) return "Codex dependency provenance evidence must contain exactly one canonical record";
   let parsed; try { parsed = JSON.parse(records[0].slice(PROVENANCE_PREFIX.length)); } catch { return "Codex dependency provenance evidence is malformed"; }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return "Codex dependency provenance evidence is malformed";
-  const expectedKeys = Object.keys(CODEX_REVIEW_PROVENANCE); if (Object.keys(parsed).length !== expectedKeys.length || expectedKeys.some((key) => !Object.hasOwn(parsed, key))) return "Codex dependency provenance evidence fields are invalid";
-  return records[0] === codexReviewProvenanceEvidence() ? "" : "Codex dependency provenance evidence does not match the pinned dependency";
+  if (Object.keys(parsed).length !== PROVENANCE_KEYS.length || PROVENANCE_KEYS.some((key) => !Object.hasOwn(parsed, key))) return "Codex dependency provenance evidence fields are invalid";
+  const citation = normalizeCodexReviewCitation(parsed);
+  if (!citation) return "Codex dependency provenance citation is invalid";
+  return records[0] === codexReviewProvenanceEvidence(citation) ? "" : "Codex dependency provenance evidence is not canonical or does not match the pinned dependency";
 }
 export function validateCodexReviewSourceEvidence(review, dependencyDir, git) {
-  const tracked = new Set(String(git(["ls-files", "-z"])).split("\0").filter(Boolean));
-  let validEntry = false;
+  const tracked = new Set(String(git(["ls-files", "-z"])).split("\0").filter(Boolean)); let firstCitation = null;
   for (const rawEntry of Array.isArray(review?.evidence) ? review.evidence : []) {
     const entry = String(rawEntry);
     const citations = [...entry.matchAll(/\.\.\/codex\/([^\s:#]+)(?::(\d+)|#L(\d+))/g)];
     const hasCommit = entry.includes(CODEX_REVIEW_DEPENDENCY.commit);
     if (!hasCommit && !entry.includes("../codex/")) continue;
     if (!hasCommit || citations.length === 0) {
-      return "Codex /review evidence must cite the pinned commit and source in the same entry";
+      return { error: "Codex /review evidence must cite the pinned commit and source in the same entry", citation: null };
     }
     for (const citation of citations) {
-      const source = citation[1];
-      const line = Number(citation[2] ?? citation[3]);
-      const normalized = path.posix.normalize(source);
-      if (source.includes("\\") || path.posix.isAbsolute(source) || normalized !== source || !source.startsWith("codex-rs/")) {
-        return `Codex /review source citation is invalid: ${source}`;
-      }
-      if (!tracked.has(source)) return `Codex /review source citation is not tracked: ${source}`;
+      const normalized = normalizeCodexReviewCitation({ source_path: citation[1], line: Number(citation[2] ?? citation[3]) });
+      const source = normalized?.source_path ?? citation[1];
+      if (!normalized) return { error: `Codex /review source citation is invalid: ${source}`, citation: null };
+      if (!tracked.has(source)) return { error: `Codex /review source citation is not tracked: ${source}`, citation: null };
       const sourcePath = path.join(dependencyDir, ...source.split("/"));
       const stats = fs.lstatSync(sourcePath, { throwIfNoEntry: false });
-      if (!stats?.isFile() || stats.isSymbolicLink()) return `Codex /review source citation is not a regular file: ${source}`;
+      if (!stats?.isFile() || stats.isSymbolicLink()) return { error: `Codex /review source citation is not a regular file: ${source}`, citation: null };
       const contents = fs.readFileSync(sourcePath, "utf8");
       const lineCount = contents ? contents.split("\n").length - Number(contents.endsWith("\n")) : 0;
-      if (!Number.isInteger(line) || line < 1 || line > lineCount) return `Codex /review source citation line is out of range: ${source}:${line}`;
+      if (normalized.line > lineCount) return { error: `Codex /review source citation line is out of range: ${source}:${normalized.line}`, citation: null };
+      firstCitation ??= normalized;
     }
-    validEntry = true;
   }
-  return validEntry ? "" : "Codex /review evidence did not cite the pinned sibling Codex source";
+  return firstCitation
+    ? { error: "", citation: firstCitation }
+    : { error: "Codex /review evidence did not cite the pinned sibling Codex source", citation: null };
 }

--- a/scripts/codex-review-dependency.mjs
+++ b/scripts/codex-review-dependency.mjs
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import path from "node:path";
+export const CODEX_REVIEW_DEPENDENCY = {
+  repo: "openclaw/openclaw", version: "codex-cli 0.125.0",
+  url: "https://github.com/openai/codex.git", tag: "rust-v0.125.0",
+  tagObject: "7d8152a5d74226ddaac12f93f7c5ed3f33a60d2a",
+  commit: "637f7dd6d737f3961e6bf32fbb3861c4953269c5",
+  files: ["AGENTS.md", "codex-rs/core/src/lib.rs", "codex-rs/protocol/src/protocol.rs", "codex-rs/exec/src/main.rs"],
+};
+const PROVENANCE_PREFIX = "Codex dependency provenance: ";
+export const CODEX_REVIEW_PROVENANCE = {
+  repository: "openai/codex", version: CODEX_REVIEW_DEPENDENCY.version,
+  tag: CODEX_REVIEW_DEPENDENCY.tag, tag_object: CODEX_REVIEW_DEPENDENCY.tagObject,
+  commit: CODEX_REVIEW_DEPENDENCY.commit,
+};
+export const codexReviewProvenanceEvidence = () => `${PROVENANCE_PREFIX}${JSON.stringify(CODEX_REVIEW_PROVENANCE)}`;
+export function validateCodexReviewProvenance(repo, evidence) {
+  if (repo !== CODEX_REVIEW_DEPENDENCY.repo) return "";
+  const records = Array.isArray(evidence) ? evidence.filter((entry) => typeof entry === "string" && entry.startsWith(PROVENANCE_PREFIX)) : [];
+  if (records.length !== 1) return "Codex dependency provenance evidence must contain exactly one canonical record";
+  let parsed; try { parsed = JSON.parse(records[0].slice(PROVENANCE_PREFIX.length)); } catch { return "Codex dependency provenance evidence is malformed"; }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return "Codex dependency provenance evidence is malformed";
+  const expectedKeys = Object.keys(CODEX_REVIEW_PROVENANCE); if (Object.keys(parsed).length !== expectedKeys.length || expectedKeys.some((key) => !Object.hasOwn(parsed, key))) return "Codex dependency provenance evidence fields are invalid";
+  return records[0] === codexReviewProvenanceEvidence() ? "" : "Codex dependency provenance evidence does not match the pinned dependency";
+}
+export function validateCodexReviewSourceEvidence(review, dependencyDir, git) {
+  const tracked = new Set(String(git(["ls-files", "-z"])).split("\0").filter(Boolean));
+  let validEntry = false;
+  for (const rawEntry of Array.isArray(review?.evidence) ? review.evidence : []) {
+    const entry = String(rawEntry);
+    const citations = [...entry.matchAll(/\.\.\/codex\/([^\s:#]+)(?::(\d+)|#L(\d+))/g)];
+    const hasCommit = entry.includes(CODEX_REVIEW_DEPENDENCY.commit);
+    if (!hasCommit && !entry.includes("../codex/")) continue;
+    if (!hasCommit || citations.length === 0) {
+      return "Codex /review evidence must cite the pinned commit and source in the same entry";
+    }
+    for (const citation of citations) {
+      const source = citation[1];
+      const line = Number(citation[2] ?? citation[3]);
+      const normalized = path.posix.normalize(source);
+      if (source.includes("\\") || path.posix.isAbsolute(source) || normalized !== source || !source.startsWith("codex-rs/")) {
+        return `Codex /review source citation is invalid: ${source}`;
+      }
+      if (!tracked.has(source)) return `Codex /review source citation is not tracked: ${source}`;
+      const sourcePath = path.join(dependencyDir, ...source.split("/"));
+      const stats = fs.lstatSync(sourcePath, { throwIfNoEntry: false });
+      if (!stats?.isFile() || stats.isSymbolicLink()) return `Codex /review source citation is not a regular file: ${source}`;
+      const contents = fs.readFileSync(sourcePath, "utf8");
+      const lineCount = contents ? contents.split("\n").length - Number(contents.endsWith("\n")) : 0;
+      if (!Number.isInteger(line) || line < 1 || line > lineCount) return `Codex /review source citation line is out of range: ${source}:${line}`;
+    }
+    validEntry = true;
+  }
+  return validEntry ? "" : "Codex /review evidence did not cite the pinned sibling Codex source";
+}

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -2113,15 +2113,17 @@ function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sour
     if (!fs.existsSync(outputPath)) throw new Error("Codex /review did not write structured output");
     if (dependency) verifyCodexReviewDependency(dependencyDir, dependency, dependencyEnv);
     const review = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    let citation = null;
     if (dependency && isCleanCodexReview(review)) {
-      const evidenceBlock = validateCodexReviewSourceEvidence(review, dependencyDir, (args) =>
+      const sourceEvidence = validateCodexReviewSourceEvidence(review, dependencyDir, (args) =>
         run("git", args, { cwd: dependencyDir, env: dependencyEnv, timeout: 180_000 }),
       );
-      if (evidenceBlock) throw new Error(evidenceBlock);
+      if (sourceEvidence.error) throw new Error(sourceEvidence.error);
+      citation = sourceEvidence.citation;
     }
     return {
       ...review,
-      ...(dependency ? { dependency_provenance: { ...CODEX_REVIEW_PROVENANCE } } : {}),
+      ...(citation ? { dependency_provenance: { ...CODEX_REVIEW_PROVENANCE, ...citation } } : {}),
     };
   } finally {
     if (ownsDependencyDir) fs.rmSync(dependencyDir, { recursive: true, force: true });
@@ -2291,7 +2293,7 @@ function buildMergeResult({
           evidence: [
             `Codex /review returned ${codexReview.status} with zero findings on exact head ${pull.head.sha} and effective diff ${reviewContext.effectiveDiffSha256} from base ${codexReviewedBaseSha}.`,
             ...(codexReview.dependency_provenance
-              ? [codexReviewProvenanceEvidence()]
+              ? [codexReviewProvenanceEvidence(codexReview.dependency_provenance)]
               : []),
             ...(validationAndReviewSharedBase
               ? []

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -31,6 +31,20 @@ const ADOPTION_POLICY = "bounded-fast-forward-v1";
 const MAX_ADOPTION_MANIFEST_BLOBS = 2048;
 const MAINTAINER_REPOSITORY_PERMISSIONS = new Set(["write", "maintain", "admin"]);
 const collaboratorPermissionCache = new Map();
+const CODEX_REVIEW_DEPENDENCY = {
+  repo: "openclaw/openclaw",
+  version: "codex-cli 0.125.0",
+  url: "https://github.com/openai/codex.git",
+  tag: "rust-v0.125.0",
+  tagObject: "7d8152a5d74226ddaac12f93f7c5ed3f33a60d2a",
+  commit: "637f7dd6d737f3961e6bf32fbb3861c4953269c5",
+  files: [
+    "AGENTS.md",
+    "codex-rs/core/src/lib.rs",
+    "codex-rs/protocol/src/protocol.rs",
+    "codex-rs/exec/src/main.rs",
+  ],
+};
 
 const args = parseArgs(process.argv.slice(2));
 const sourceJobPath = args._[0];
@@ -533,6 +547,7 @@ try {
     codex_review: {
       status: codexReview.status,
       findings: codexReview.findings.length,
+      dependency: codexReview.dependency_provenance ?? null,
     },
   };
   writeJson(path.join(runDir, "result.json"), result);
@@ -582,7 +597,11 @@ function writeBlockedArtifacts({ reason, validationCommands = [], codexReview = 
     effective_diff_sha256: reviewContext?.effectiveDiffSha256 ?? null,
     validation_commands: validationCommands,
     codex_review: codexReview
-      ? { status: codexReview.status ?? "unknown", findings: Array.isArray(codexReview.findings) ? codexReview.findings.length : null }
+      ? {
+          status: codexReview.status ?? "unknown",
+          findings: Array.isArray(codexReview.findings) ? codexReview.findings.length : null,
+          dependency: codexReview.dependency_provenance ?? null,
+        }
       : null,
   };
   writeJson(path.join(runDir, "result.json"), result);
@@ -2010,6 +2029,8 @@ function runValidation({ targetDir, reviewContext }) {
 function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sourceJob, reviewContext }) {
   const schemaPath = path.join(runDir, "codex-review.schema.json");
   const outputPath = path.join(runDir, "codex-review.json");
+  const dependency = targetReviewDependency(repo);
+  const dependencyDir = path.join(path.dirname(targetDir), "codex");
   const defaultCodexReviewSandbox = "read-only";
   const codexReviewSandbox = process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_CODEX_SANDBOX ?? defaultCodexReviewSandbox;
   const useLegacyLandlock =
@@ -2051,6 +2072,12 @@ function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sour
     "The preflight already verified that the PR has no top-level or inline review comments, no unresolved review threads, no review-bot findings, no security signal, and passing GitHub checks.",
     "Do not mutate GitHub or the checkout. Do not run validation commands.",
     "Return clean only when the diff is narrow, safe, and merge-ready. Return actionable findings otherwise.",
+    ...(dependency
+      ? [
+          `Directly inspect sibling ../codex at pinned commit ${dependency.commit} from annotated tag ${dependency.tag} before your verdict.`,
+          `A clean result must cite ${dependency.commit} and at least one ../codex/codex-rs/...:<line> or ../codex/codex-rs/...#L<line> source location in evidence.`,
+        ]
+      : []),
     "",
     `Validation commands already passed: ${validationCommands.join("; ")}`,
     `Source job: ${sourceJob.relativePath}`,
@@ -2073,19 +2100,96 @@ function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sour
     "--json",
     "-",
   ];
-  run(
-    "codex",
-    codexArgs,
-    {
+  let ownsDependencyDir = false;
+  try {
+    if (dependency) {
+      if (fs.existsSync(dependencyDir)) throw new Error("Codex dependency path already exists");
+      ownsDependencyDir = true;
+      provisionCodexReviewDependency(dependencyDir, dependency);
+    }
+    run("codex", codexArgs, {
       cwd: targetDir,
       input: prompt,
       env: codexEnv(),
       timeout: Number(process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_CODEX_TIMEOUT_MS ?? 10 * 60 * 1000),
       maxBuffer: 64 * 1024 * 1024,
-    },
+    });
+    if (!fs.existsSync(outputPath)) throw new Error("Codex /review did not write structured output");
+    if (dependency) verifyCodexReviewDependency(dependencyDir, dependency);
+    const review = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    if (dependency && !hasPinnedCodexEvidence(review, dependency)) {
+      throw new Error("Codex /review evidence did not cite the pinned sibling Codex source");
+    }
+    return {
+      ...review,
+      ...(dependency ? { dependency_provenance: codexDependencyProvenance(dependency) } : {}),
+    };
+  } finally {
+    if (ownsDependencyDir) fs.rmSync(dependencyDir, { recursive: true, force: true });
+  }
+}
+
+function targetReviewDependency(repo) {
+  return repo === CODEX_REVIEW_DEPENDENCY.repo ? CODEX_REVIEW_DEPENDENCY : null;
+}
+
+function provisionCodexReviewDependency(dependencyDir, dependency) {
+  const env = codexDependencyEnv();
+  const version = run("codex", ["--version"], { env, timeout: 180_000 }).trim();
+  if (version !== dependency.version) throw new Error(`unsupported Codex version: ${version || "empty"}`);
+  run(
+    "git",
+    ["clone", "--depth", "1", "--branch", dependency.tag, "--single-branch", dependency.url, dependencyDir],
+    { env, timeout: 180_000 },
   );
-  if (!fs.existsSync(outputPath)) throw new Error("Codex /review did not write structured output");
-  return JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  verifyCodexReviewDependency(dependencyDir, dependency);
+}
+
+function verifyCodexReviewDependency(dependencyDir, dependency) {
+  const env = codexDependencyEnv();
+  const read = (...args) => run("git", args, { cwd: dependencyDir, env, timeout: 180_000 }).trim();
+  if (read("remote", "get-url", "origin") !== dependency.url) throw new Error("Codex dependency origin mismatch");
+  if (read("cat-file", "-t", `refs/tags/${dependency.tag}`) !== "tag") throw new Error("Codex dependency tag is not annotated");
+  if (read("rev-parse", `refs/tags/${dependency.tag}`) !== dependency.tagObject) throw new Error("Codex dependency tag object mismatch");
+  if (read("rev-parse", `refs/tags/${dependency.tag}^{}`) !== dependency.commit || read("rev-parse", "HEAD") !== dependency.commit) {
+    throw new Error("Codex dependency commit mismatch");
+  }
+  if (read("status", "--porcelain")) throw new Error("Codex dependency checkout is dirty");
+  for (const file of dependency.files) {
+    if (!fs.lstatSync(path.join(dependencyDir, file), { throwIfNoEntry: false })?.isFile()) {
+      throw new Error(`Codex dependency required file is not regular: ${file}`);
+    }
+  }
+}
+
+function hasPinnedCodexEvidence(review, dependency) {
+  const evidence = Array.isArray(review?.evidence) ? review.evidence.join("\n") : "";
+  return evidence.includes(dependency.commit) && /\.\.\/codex\/codex-rs\/[^\s]+(?::\d+|#L\d+)/.test(evidence);
+}
+
+function codexDependencyProvenance(dependency) {
+  return {
+    repository: "openai/codex",
+    version: dependency.version,
+    tag: dependency.tag,
+    tag_object: dependency.tagObject,
+    commit: dependency.commit,
+  };
+}
+
+function codexDependencyEnv() {
+  const env = {
+    ...gitIntegrityEnv(),
+    GIT_ALLOW_PROTOCOL: "https",
+    GIT_ASKPASS: "/bin/false",
+    GIT_TERMINAL_PROMPT: "0",
+    GCM_INTERACTIVE: "Never",
+    SSH_ASKPASS: "/bin/false",
+  };
+  for (const key of Object.keys(env)) {
+    if (/(?:github|openai|codex|npm|token|secret|password|private[_-]?key)/i.test(key)) delete env[key];
+  }
+  return env;
 }
 
 function buildMergeResult({
@@ -2111,6 +2215,9 @@ function buildMergeResult({
   const baseAdoptionManifest = buildBaseAdoptionManifest({ targetDir, reviewContext, pull });
   const evidence = [
     `Exact PR head ${pull.head.sha} checked out from refs/pull/${pullRequest}/head.`,
+    ...(codexReview.dependency_provenance
+      ? [`Codex dependency ${codexReview.dependency_provenance.tag} was verified at ${codexReview.dependency_provenance.commit}.`]
+      : []),
     validationAndReviewSharedBase
       ? `Validation and Codex review ran on synthetic squash-result commit ${reviewContext.syntheticMergeSha} with origin/main ${reviewContext.reviewedBaseSha} as its parent and merge tree ${reviewContext.mergeTreeSha} computed from exact PR head ${pull.head.sha}.`
       : `Codex review ran on synthetic squash-result commit ${codexReviewedSyntheticMergeSha} with origin/main ${codexReviewedBaseSha} as its parent and merge tree ${codexReviewedMergeTreeSha}; validation was rerun on synthetic commit ${reviewContext.syntheticMergeSha} with refreshed origin/main ${reviewContext.reviewedBaseSha}.`,
@@ -2185,6 +2292,9 @@ function buildMergeResult({
           findings_addressed: true,
           evidence: [
             `Codex /review returned ${codexReview.status} with zero findings on exact head ${pull.head.sha} and effective diff ${reviewContext.effectiveDiffSha256} from base ${codexReviewedBaseSha}.`,
+            ...(codexReview.dependency_provenance
+              ? [`Pinned dependency openai/codex ${codexReview.dependency_provenance.tag} at ${codexReview.dependency_provenance.commit}; direct source citation was enforced.`]
+              : []),
             ...(validationAndReviewSharedBase
               ? []
               : [

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -10,6 +11,12 @@ import {
 } from "./base-drift-validation.mjs";
 import { hasSecuritySensitiveText } from "./security-sensitive.mjs";
 import { COORDINATOR_CHECK_NAMES } from "./external-merge-checks.mjs";
+import {
+  CODEX_REVIEW_DEPENDENCY,
+  CODEX_REVIEW_PROVENANCE,
+  codexReviewProvenanceEvidence,
+  validateCodexReviewSourceEvidence,
+} from "./codex-review-dependency.mjs";
 
 const PASSING_CHECK_CONCLUSIONS = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"]);
 const CLEAN_MERGE_STATES = new Set(["CLEAN"]);
@@ -31,21 +38,6 @@ const ADOPTION_POLICY = "bounded-fast-forward-v1";
 const MAX_ADOPTION_MANIFEST_BLOBS = 2048;
 const MAINTAINER_REPOSITORY_PERMISSIONS = new Set(["write", "maintain", "admin"]);
 const collaboratorPermissionCache = new Map();
-const CODEX_REVIEW_DEPENDENCY = {
-  repo: "openclaw/openclaw",
-  version: "codex-cli 0.125.0",
-  url: "https://github.com/openai/codex.git",
-  tag: "rust-v0.125.0",
-  tagObject: "7d8152a5d74226ddaac12f93f7c5ed3f33a60d2a",
-  commit: "637f7dd6d737f3961e6bf32fbb3861c4953269c5",
-  files: [
-    "AGENTS.md",
-    "codex-rs/core/src/lib.rs",
-    "codex-rs/protocol/src/protocol.rs",
-    "codex-rs/exec/src/main.rs",
-  ],
-};
-
 const args = parseArgs(process.argv.slice(2));
 const sourceJobPath = args._[0];
 const pullRequest = Number(args.pr ?? args["pull-request"]);
@@ -2029,8 +2021,10 @@ function runValidation({ targetDir, reviewContext }) {
 function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sourceJob, reviewContext }) {
   const schemaPath = path.join(runDir, "codex-review.schema.json");
   const outputPath = path.join(runDir, "codex-review.json");
-  const dependency = targetReviewDependency(repo);
+  const dependency = repo === CODEX_REVIEW_DEPENDENCY.repo ? CODEX_REVIEW_DEPENDENCY : null;
   const dependencyDir = path.join(path.dirname(targetDir), "codex");
+  let bootstrapDir = null;
+  let dependencyEnv = null;
   const defaultCodexReviewSandbox = "read-only";
   const codexReviewSandbox = process.env.CLOWNFISH_EXTERNAL_PREFLIGHT_CODEX_SANDBOX ?? defaultCodexReviewSandbox;
   const useLegacyLandlock =
@@ -2105,7 +2099,9 @@ function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sour
     if (dependency) {
       if (fs.existsSync(dependencyDir)) throw new Error("Codex dependency path already exists");
       ownsDependencyDir = true;
-      provisionCodexReviewDependency(dependencyDir, dependency);
+      bootstrapDir = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-codex-review-"));
+      dependencyEnv = codexDependencyEnv(bootstrapDir);
+      provisionCodexReviewDependency(dependencyDir, dependency, bootstrapDir, dependencyEnv);
     }
     run("codex", codexArgs, {
       cwd: targetDir,
@@ -2115,38 +2111,36 @@ function runCodexReview({ repo, pullRequest, targetDir, validationCommands, sour
       maxBuffer: 64 * 1024 * 1024,
     });
     if (!fs.existsSync(outputPath)) throw new Error("Codex /review did not write structured output");
-    if (dependency) verifyCodexReviewDependency(dependencyDir, dependency);
+    if (dependency) verifyCodexReviewDependency(dependencyDir, dependency, dependencyEnv);
     const review = JSON.parse(fs.readFileSync(outputPath, "utf8"));
-    if (dependency && !hasPinnedCodexEvidence(review, dependency)) {
-      throw new Error("Codex /review evidence did not cite the pinned sibling Codex source");
+    if (dependency && isCleanCodexReview(review)) {
+      const evidenceBlock = validateCodexReviewSourceEvidence(review, dependencyDir, (args) =>
+        run("git", args, { cwd: dependencyDir, env: dependencyEnv, timeout: 180_000 }),
+      );
+      if (evidenceBlock) throw new Error(evidenceBlock);
     }
     return {
       ...review,
-      ...(dependency ? { dependency_provenance: codexDependencyProvenance(dependency) } : {}),
+      ...(dependency ? { dependency_provenance: { ...CODEX_REVIEW_PROVENANCE } } : {}),
     };
   } finally {
     if (ownsDependencyDir) fs.rmSync(dependencyDir, { recursive: true, force: true });
+    if (bootstrapDir) fs.rmSync(bootstrapDir, { recursive: true, force: true });
   }
 }
 
-function targetReviewDependency(repo) {
-  return repo === CODEX_REVIEW_DEPENDENCY.repo ? CODEX_REVIEW_DEPENDENCY : null;
-}
-
-function provisionCodexReviewDependency(dependencyDir, dependency) {
-  const env = codexDependencyEnv();
-  const version = run("codex", ["--version"], { env, timeout: 180_000 }).trim();
+function provisionCodexReviewDependency(dependencyDir, dependency, bootstrapDir, env) {
+  const version = run("codex", ["--version"], { cwd: bootstrapDir, env, timeout: 180_000 }).trim();
   if (version !== dependency.version) throw new Error(`unsupported Codex version: ${version || "empty"}`);
   run(
     "git",
     ["clone", "--depth", "1", "--branch", dependency.tag, "--single-branch", dependency.url, dependencyDir],
-    { env, timeout: 180_000 },
+    { cwd: bootstrapDir, env, timeout: 180_000 },
   );
-  verifyCodexReviewDependency(dependencyDir, dependency);
+  verifyCodexReviewDependency(dependencyDir, dependency, env);
 }
 
-function verifyCodexReviewDependency(dependencyDir, dependency) {
-  const env = codexDependencyEnv();
+function verifyCodexReviewDependency(dependencyDir, dependency, env) {
   const read = (...args) => run("git", args, { cwd: dependencyDir, env, timeout: 180_000 }).trim();
   if (read("remote", "get-url", "origin") !== dependency.url) throw new Error("Codex dependency origin mismatch");
   if (read("cat-file", "-t", `refs/tags/${dependency.tag}`) !== "tag") throw new Error("Codex dependency tag is not annotated");
@@ -2162,33 +2156,40 @@ function verifyCodexReviewDependency(dependencyDir, dependency) {
   }
 }
 
-function hasPinnedCodexEvidence(review, dependency) {
-  const evidence = Array.isArray(review?.evidence) ? review.evidence.join("\n") : "";
-  return evidence.includes(dependency.commit) && /\.\.\/codex\/codex-rs\/[^\s]+(?::\d+|#L\d+)/.test(evidence);
-}
-
-function codexDependencyProvenance(dependency) {
-  return {
-    repository: "openai/codex",
-    version: dependency.version,
-    tag: dependency.tag,
-    tag_object: dependency.tagObject,
-    commit: dependency.commit,
-  };
-}
-
-function codexDependencyEnv() {
-  const env = {
-    ...gitIntegrityEnv(),
+function codexDependencyEnv(bootstrapDir) {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (
+      /^GIT_CONFIG(?:_|$)/.test(key) ||
+      /^(?:GIT_DIR|GIT_WORK_TREE|GIT_COMMON_DIR|GIT_OBJECT_DIRECTORY|GIT_ALTERNATE_OBJECT_DIRECTORIES|GIT_INDEX_FILE|GIT_CEILING_DIRECTORIES|GIT_DISCOVERY_ACROSS_FILESYSTEM|GIT_SSH|GIT_SSH_COMMAND)$/.test(key) ||
+      /(?:github|openai|codex|npm|token|secret|password|private[_-]?key)/i.test(key)
+    ) delete env[key];
+  }
+  Object.assign(env, {
+    HOME: path.join(bootstrapDir, "home"),
+    XDG_CONFIG_HOME: path.join(bootstrapDir, "xdg"),
     GIT_ALLOW_PROTOCOL: "https",
     GIT_ASKPASS: "/bin/false",
+    GIT_CONFIG_COUNT: "5",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_KEY_0: "core.hooksPath",
+    GIT_CONFIG_KEY_1: "protocol.ext.allow",
+    GIT_CONFIG_KEY_2: "credential.helper",
+    GIT_CONFIG_KEY_3: "http.extraHeader",
+    GIT_CONFIG_KEY_4: "http.https://github.com/.extraHeader",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_VALUE_0: "/dev/null",
+    GIT_CONFIG_VALUE_1: "never",
+    GIT_CONFIG_VALUE_2: "",
+    GIT_CONFIG_VALUE_3: "",
+    GIT_CONFIG_VALUE_4: "",
+    GIT_NO_REPLACE_OBJECTS: "1",
     GIT_TERMINAL_PROMPT: "0",
     GCM_INTERACTIVE: "Never",
     SSH_ASKPASS: "/bin/false",
-  };
-  for (const key of Object.keys(env)) {
-    if (/(?:github|openai|codex|npm|token|secret|password|private[_-]?key)/i.test(key)) delete env[key];
-  }
+  });
+  fs.mkdirSync(env.HOME, { recursive: true });
+  fs.mkdirSync(env.XDG_CONFIG_HOME, { recursive: true });
   return env;
 }
 
@@ -2215,9 +2216,6 @@ function buildMergeResult({
   const baseAdoptionManifest = buildBaseAdoptionManifest({ targetDir, reviewContext, pull });
   const evidence = [
     `Exact PR head ${pull.head.sha} checked out from refs/pull/${pullRequest}/head.`,
-    ...(codexReview.dependency_provenance
-      ? [`Codex dependency ${codexReview.dependency_provenance.tag} was verified at ${codexReview.dependency_provenance.commit}.`]
-      : []),
     validationAndReviewSharedBase
       ? `Validation and Codex review ran on synthetic squash-result commit ${reviewContext.syntheticMergeSha} with origin/main ${reviewContext.reviewedBaseSha} as its parent and merge tree ${reviewContext.mergeTreeSha} computed from exact PR head ${pull.head.sha}.`
       : `Codex review ran on synthetic squash-result commit ${codexReviewedSyntheticMergeSha} with origin/main ${codexReviewedBaseSha} as its parent and merge tree ${codexReviewedMergeTreeSha}; validation was rerun on synthetic commit ${reviewContext.syntheticMergeSha} with refreshed origin/main ${reviewContext.reviewedBaseSha}.`,
@@ -2293,7 +2291,7 @@ function buildMergeResult({
           evidence: [
             `Codex /review returned ${codexReview.status} with zero findings on exact head ${pull.head.sha} and effective diff ${reviewContext.effectiveDiffSha256} from base ${codexReviewedBaseSha}.`,
             ...(codexReview.dependency_provenance
-              ? [`Pinned dependency openai/codex ${codexReview.dependency_provenance.tag} at ${codexReview.dependency_provenance.commit}; direct source citation was enforced.`]
+              ? [codexReviewProvenanceEvidence()]
               : []),
             ...(validationAndReviewSharedBase
               ? []

--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { parseArgs, parseJob, repoRoot } from "./lib.mjs";
 import { hasSecuritySensitiveText, securityTextFromItem } from "./security-sensitive.mjs";
+import { validateCodexReviewProvenance } from "./codex-review-dependency.mjs";
 
 const CLOSE_ACTIONS = new Set([
   "close",
@@ -335,7 +336,7 @@ function reviewResult(resultPath) {
       warnings.push("worker-authored merge_preflight is ignored because the source job requires deterministic external preflight");
     }
   } else if (plannedMergeActions.length > 0) {
-    validateMergePreflight(result.merge_preflight, plannedMergeActions, failures);
+    validateMergePreflight(result.repo, result.merge_preflight, plannedMergeActions, failures);
   }
   validateCalibratedPrFinalization({
     sourceJobPolicy,
@@ -622,7 +623,7 @@ function validateFixActionPermissions(permissions, fixActions, failures) {
   failures.push(`fix actions are not permitted by job frontmatter (${blockers.join("; ")}): ${actionList}`);
 }
 
-function validateMergePreflight(mergePreflight, mergeActions, failures) {
+function validateMergePreflight(repo, mergePreflight, mergeActions, failures) {
   if (!Array.isArray(mergePreflight)) {
     failures.push("merge action requires merge_preflight");
     return;
@@ -643,7 +644,8 @@ function validateMergePreflight(mergePreflight, mergeActions, failures) {
       failures.push(`${target} merge action missing merge_preflight entry`);
       continue;
     }
-    if (String(action.idempotency_key ?? "").startsWith("external-merge-preflight:")) {
+    const external = String(action.idempotency_key ?? "").startsWith("external-merge-preflight:");
+    if (external) {
       if (!/^[0-9a-f]{40}$/i.test(String(preflight.reviewed_base_sha ?? ""))) {
         failures.push(`${target} external merge_preflight.reviewed_base_sha must be a 40-character Git SHA`);
       }
@@ -694,6 +696,10 @@ function validateMergePreflight(mergePreflight, mergeActions, failures) {
       failures.push(`${target} merge_preflight.codex_review.evidence must be a non-empty list`);
     } else if (!codexReview.evidence.some((entry) => /\/review|codex review/i.test(String(entry)))) {
       failures.push(`${target} merge_preflight.codex_review.evidence must mention /review or Codex review`);
+    }
+    if (external) {
+      const provenanceBlock = validateCodexReviewProvenance(repo, codexReview.evidence);
+      if (provenanceBlock) failures.push(`${target} ${provenanceBlock}`);
     }
   }
 }

--- a/scripts/run-external-merge-preflights.mjs
+++ b/scripts/run-external-merge-preflights.mjs
@@ -329,6 +329,7 @@ function readJsonIfExists(filePath) {
 
 function cleanupPreflightTarget(runDir) {
   fs.rmSync(path.join(runDir, "target"), { recursive: true, force: true });
+  fs.rmSync(path.join(runDir, "codex"), { recursive: true, force: true });
 }
 
 function positiveInteger(value, fallback, label) {

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -5,9 +5,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { codexReviewProvenanceEvidence } from "../scripts/codex-review-dependency.mjs";
+import {
+  CODEX_REVIEW_PROVENANCE,
+  codexReviewProvenanceEvidence,
+} from "../scripts/codex-review-dependency.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
+const codexCitation = { source_path: "codex-rs/exec/src/lib.rs", line: 583 };
 const EXPECTED_HEAD_SHA = "a".repeat(40);
 const CHANGED_HEAD_SHA = "b".repeat(40);
 const CURRENT_MAIN_SHA = "c".repeat(40);
@@ -1781,7 +1785,8 @@ test("apply-result rejects an already-merged replay with invalid review policy",
 
 for (const [name, evidence] of [
   ["missing", ["Codex /review returned clean"]],
-  ["tampered", [codexReviewProvenanceEvidence().replace("637f7d", "000000")]],
+  ["tuple-only", [`Codex dependency provenance: ${JSON.stringify(CODEX_REVIEW_PROVENANCE)}`]],
+  ["tampered", [codexReviewProvenanceEvidence(codexCitation).replace("637f7d", "000000")]],
 ]) {
   test(`apply-result rejects ${name} OpenClaw Codex provenance before mutation`, () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
@@ -2787,7 +2792,7 @@ function mergeResultJson({
           findings_addressed: true,
           evidence: [
             "Codex /review returned clean",
-            ...(externalBinding ? [codexReviewProvenanceEvidence()] : []),
+            ...(externalBinding ? [codexReviewProvenanceEvidence(codexCitation)] : []),
           ],
         },
         base_adoption_manifest: resolvedManifest,

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { codexReviewProvenanceEvidence } from "../scripts/codex-review-dependency.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const EXPECTED_HEAD_SHA = "a".repeat(40);
@@ -1778,6 +1779,37 @@ test("apply-result rejects an already-merged replay with invalid review policy",
   assert.equal(report.actions[0].reason, "Codex /review status is failed");
 });
 
+for (const [name, evidence] of [
+  ["missing", ["Codex /review returned clean"]],
+  ["tampered", [codexReviewProvenanceEvidence().replace("637f7d", "000000")]],
+]) {
+  test(`apply-result rejects ${name} OpenClaw Codex provenance before mutation`, () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+    const binDir = path.join(tmp, "bin");
+    const callLogPath = path.join(tmp, "gh-calls.jsonl");
+    const mergeStatePath = path.join(tmp, "merge-state");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(callLogPath, "");
+    writeReadyMergeGhStub(binDir, { headSha: EXPECTED_HEAD_SHA, externalBinding: true });
+    const jobPath = path.join(tmp, "job.md");
+    const resultPath = path.join(tmp, "result.json");
+    const reportPath = path.join(tmp, "apply-report.json");
+    const artifact = mergeResultJson({ externalBinding: true });
+    artifact.merge_preflight[0].codex_review.evidence = evidence;
+    fs.writeFileSync(jobPath, mergeJobMarkdown());
+    fs.writeFileSync(resultPath, `${JSON.stringify(artifact, null, 2)}\n`);
+
+    const result = apply(jobPath, resultPath, reportPath, binDir, {
+      dryRun: false, allowMerge: true, callLogPath, mergeStatePath,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    assert.match(report.actions[0].reason, /Codex dependency provenance evidence/);
+    assert.equal(readCallLog(callLogPath).some((args) => args.includes("POST") || args.slice(0, 2).join(" ") === "pr merge"), false);
+  });
+}
+
 test("apply-result re-reads an ambiguous merge failure and verifies accepted state", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");
@@ -2753,7 +2785,10 @@ function mergeResultJson({
           command: "/review",
           status: "clean",
           findings_addressed: true,
-          evidence: ["Codex /review returned clean"],
+          evidence: [
+            "Codex /review returned clean",
+            ...(externalBinding ? [codexReviewProvenanceEvidence()] : []),
+          ],
         },
         base_adoption_manifest: resolvedManifest,
       },

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -14,6 +14,18 @@ const intakeWorkflow = fs.readFileSync(path.join(repoRoot, ".github", "workflows
 const clusterWorkflow = fs.readFileSync(path.join(repoRoot, ".github", "workflows", "cluster-worker.yml"), "utf8");
 const autonomousPrompt = fs.readFileSync(path.join(repoRoot, "prompts", "autonomous.md"), "utf8");
 const githubInventoryImporter = fs.readFileSync(path.join(repoRoot, "scripts", "import-github-pr-inventory.mjs"), "utf8");
+const codexDependency = {
+  version: "codex-cli 0.125.0",
+  tag: "rust-v0.125.0",
+  tagObject: "7d8152a5d74226ddaac12f93f7c5ed3f33a60d2a",
+  commit: "637f7dd6d737f3961e6bf32fbb3861c4953269c5",
+  files: [
+    "AGENTS.md",
+    "codex-rs/core/src/lib.rs",
+    "codex-rs/protocol/src/protocol.rs",
+    "codex-rs/exec/src/main.rs",
+  ],
+};
 
 test("external merge preflight is exact-head, read-only, and refuses unresolved review evidence", () => {
   assert.match(script, /source job does not explicitly contain/);
@@ -118,6 +130,8 @@ test("cluster worker chains blocked merge candidates through external preflight"
   assert.match(runnerScript, /CLOWNFISH_EXTERNAL_PREFLIGHT_HEARTBEAT_MS/);
   assert.match(runnerScript, /still running after/);
   assert.match(runnerScript, /clearInterval\(heartbeat\)/);
+  assert.match(runnerScript, /rmSync\(path\.join\(runDir, "target"\)/);
+  assert.match(runnerScript, /rmSync\(path\.join\(runDir, "codex"\)/);
   assert.match(clusterWorkflow, /- name: Run external merge preflights/);
   assert.match(clusterWorkflow, /CLOWNFISH_APP_ID: \$\{\{ vars\.CLOWNFISH_APP_ID \}\}/);
   assert.match(
@@ -255,6 +269,23 @@ test("external merge runner defaults to all while preserving dry-run", () => {
     assert.equal(report.actions[0].status, "passed");
     assert.match(report.actions[0].reason, /dry run; guarded applicator not invoked/);
     assert.equal(fs.existsSync(fixture.mergeLogPath), false);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("external merge runner removes stale and completed dependency checkouts", () => {
+  const fixture = makeRunnerFixture();
+  try {
+    const nestedRunDir = path.join(fixture.runRoot, "external-merge-preflight-123");
+    fs.mkdirSync(path.join(nestedRunDir, "target"), { recursive: true });
+    fs.mkdirSync(path.join(nestedRunDir, "codex"), { recursive: true });
+    fs.writeFileSync(path.join(nestedRunDir, "codex", "stale"), "stale\n");
+
+    const child = runExternalMergeRunner(fixture, ["--phase", "preflight"], fixture.env);
+    assert.equal(child.status, 0, child.stderr || child.stdout);
+    assert.equal(fs.existsSync(path.join(nestedRunDir, "target")), false);
+    assert.equal(fs.existsSync(path.join(nestedRunDir, "codex")), false);
   } finally {
     fs.rmSync(fixture.root, { recursive: true, force: true });
   }
@@ -470,6 +501,153 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
   assert.equal(reviewed.status, 0, reviewed.stderr || reviewed.stdout);
 });
 
+test("external merge preflight binds OpenClaw review to pinned Codex source", () => {
+  const fixture = makeFixture();
+  const { report, result } = runPreflightFixture(fixture, {
+    GITHUB_TOKEN: "github-secret",
+    OPENAI_API_KEY: "openai-secret",
+    NPM_TOKEN: "npm-secret",
+    GENERIC_SECRET: "generic-secret",
+    PRIVATE_KEY: "private-key",
+  });
+
+  assert.equal(report.status, "passed", report.reason);
+  assert.deepEqual(report.codex_review.dependency, {
+    repository: "openai/codex",
+    version: codexDependency.version,
+    tag: codexDependency.tag,
+    tag_object: codexDependency.tagObject,
+    commit: codexDependency.commit,
+  });
+  const prompt = fs.readFileSync(fixture.codexPromptPath, "utf8");
+  assert.match(prompt, new RegExp(codexDependency.commit));
+  assert.match(prompt, /\.\.\/codex\/codex-rs\/\.\.\.:<line>/);
+  assert.equal(Number(fs.readFileSync(fixture.codexVersionCountPath, "utf8")), 1);
+  assert.equal(Number(fs.readFileSync(fixture.codexCloneCountPath, "utf8")), 1);
+  assert.match(
+    fs.readFileSync(fixture.gitCommandsPath, "utf8"),
+    /clone --depth 1 --branch rust-v0\.125\.0 --single-branch https:\/\/github\.com\/openai\/codex\.git /,
+  );
+  assert.deepEqual(JSON.parse(fs.readFileSync(fixture.codexDependencyEnvPath, "utf8")), {
+    allowProtocol: "https",
+    terminalPrompt: "0",
+    askpass: "/bin/false",
+    credentialKeys: [],
+  });
+  assert.match(
+    result.actions[0].evidence.join("\n"),
+    /Codex dependency .*rust-v0\.125\.0.*637f7dd6d737f3961e6bf32fbb3861c4953269c5/,
+  );
+  assert.match(
+    result.merge_preflight[0].codex_review.evidence.join("\n"),
+    /Pinned dependency openai\/codex rust-v0\.125\.0 at 637f7dd6d737f3961e6bf32fbb3861c4953269c5/,
+  );
+  assert.equal(fs.existsSync(path.join(fixture.runDir, "codex")), false);
+});
+
+for (const [name, options, reason] of [
+  ["malformed version", { codexVersion: "Codex 0.125.0" }, /unsupported Codex version/],
+  ["mismatched version", { codexVersion: "codex-cli 0.126.0" }, /unsupported Codex version/],
+  ["clone failure", { codexCloneFailure: "fixture clone failure" }, /fixture clone failure/],
+  ["lightweight tag", { codexTagType: "commit" }, /tag is not annotated/],
+  ["tag object mismatch", { codexTagObject: "4".repeat(40) }, /tag object mismatch/],
+  ["peeled commit mismatch", { codexCommitSha: "5".repeat(40) }, /commit mismatch/],
+  [
+    "missing required file",
+    { codexFileFault: { path: "codex-rs/core/src/lib.rs", type: "missing" } },
+    /required file is not regular/,
+  ],
+  [
+    "nonregular required file",
+    { codexFileFault: { path: "codex-rs/protocol/src/protocol.rs", type: "directory" } },
+    /required file is not regular/,
+  ],
+]) {
+  test(`external merge preflight rejects Codex dependency ${name}`, () => {
+    const fixture = makeFixture(options);
+    const { report } = runPreflightFixture(fixture);
+
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, reason);
+    assert.equal(fs.existsSync(path.join(fixture.runDir, "codex")), false);
+  });
+}
+
+test("external merge preflight requires pinned Codex source citations", () => {
+  const fixture = makeFixture({
+    codexReview: {
+      status: "clean",
+      summary: "clean without source proof",
+      findings: [],
+      findings_addressed: true,
+      evidence: ["reviewed the target checkout"],
+    },
+  });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /did not cite the pinned sibling Codex source/);
+  assert.equal(fs.existsSync(path.join(fixture.runDir, "codex")), false);
+});
+
+test("external merge preflight leaves non-OpenClaw review behavior unchanged", () => {
+  const fixture = makeFixture({
+    repo: "openclaw/example",
+    codexReview: {
+      status: "clean",
+      summary: "clean fixture review",
+      findings: [],
+      findings_addressed: true,
+      evidence: ["ordinary target review"],
+    },
+  });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "passed", report.reason);
+  assert.equal(report.codex_review.dependency, null);
+  assert.equal(fs.existsSync(fixture.codexVersionCountPath), false);
+  assert.equal(fs.existsSync(fixture.codexCloneCountPath), false);
+});
+
+test("external merge preflight refuses and preserves an unowned Codex dependency path", () => {
+  const fixture = makeFixture({ preexistingCodexCheckout: true });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /Codex dependency path already exists/);
+  assert.equal(fs.readFileSync(path.join(fixture.runDir, "codex", "unowned"), "utf8"), "preserve\n");
+  assert.equal(fs.existsSync(fixture.codexCloneCountPath), false);
+});
+
+test("external merge preflight removes the Codex dependency after review failure", () => {
+  const fixture = makeFixture({ codexFailure: "fixture Codex failure" });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /fixture Codex failure/);
+  assert.equal(fs.existsSync(path.join(fixture.runDir, "codex")), false);
+});
+
+test("external merge preflight removes mutated Codex source and blocks the review", () => {
+  const fixture = makeFixture({ codexMutatesSource: true });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /Codex dependency checkout is dirty/);
+  assert.equal(fs.existsSync(path.join(fixture.runDir, "codex")), false);
+});
+
+test("external merge preflight does not provision Codex when validation fails", () => {
+  const fixture = makeFixture({ validationFailure: { stderr: "fixture validation failure" } });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /fixture validation failure/);
+  assert.equal(fs.existsSync(fixture.codexVersionCountPath), false);
+  assert.equal(fs.existsSync(fixture.codexCloneCountPath), false);
+  assert.equal(fs.existsSync(path.join(fixture.runDir, "codex")), false);
+});
+
 test("external merge preflight selects legacy Landlock without weakening read-only review", () => {
   const fixture = makeFixture();
   runPreflightFixture(fixture, {
@@ -652,7 +830,17 @@ test("external merge preflight blocks later Git config mutation with precise dia
     `git diff --check ${fixture.baseSha}...${fixture.syntheticMergeSha}`,
     "git diff --check",
   ]);
-  assert.deepEqual(report.codex_review, { status: "clean", findings: 0 });
+  assert.deepEqual(report.codex_review, {
+    status: "clean",
+    findings: 0,
+    dependency: {
+      repository: "openai/codex",
+      version: codexDependency.version,
+      tag: codexDependency.tag,
+      tag_object: codexDependency.tagObject,
+      commit: codexDependency.commit,
+    },
+  });
 });
 
 test("external merge preflight fingerprints included Git config values", () => {
@@ -931,6 +1119,9 @@ test("external merge preflight reruns Codex review for same-area main drift", ()
   assert.equal(report.codex_reviewed_base_sha, "9".repeat(40));
   assert.equal(report.base_drift_proof.segments[0]?.codex_rereview, true);
   assert.equal(Number(fs.readFileSync(fixture.codexCountPath, "utf8")), 2);
+  assert.equal(Number(fs.readFileSync(fixture.codexVersionCountPath, "utf8")), 2);
+  assert.equal(Number(fs.readFileSync(fixture.codexCloneCountPath, "utf8")), 2);
+  assert.equal(fs.existsSync(path.join(fixture.runDir, "codex")), false);
 });
 
 test("external merge preflight rejects stale Codex output during a required rereview", () => {
@@ -953,7 +1144,9 @@ test("external merge preflight treats zero-finding clean reviews as clean", () =
       summary: "No blocking findings; best-fix verdict: best for this scope.",
       findings: [],
       findings_addressed: false,
-      evidence: ["No findings were emitted, so there is nothing to address."],
+      evidence: [
+        `No findings were emitted at ${codexDependency.commit}; ../codex/codex-rs/exec/src/lib.rs:583 was inspected.`,
+      ],
     },
   });
   const child = spawnSync(
@@ -4158,6 +4351,7 @@ function runPreflightFixture(fixture, extraEnv = {}) {
 }
 
 function makeFixture({
+  repo = "openclaw/openclaw",
   issueComments = [],
   reviewComments = [],
   reviews = [],
@@ -4190,10 +4384,19 @@ function makeFixture({
   validationFailure = null,
   syntheticMergeFailure = null,
   codexMutatesCheckout = false,
+  codexMutatesSource = false,
   codexSkipsSecondWrite = false,
+  codexVersion = codexDependency.version,
+  codexCloneFailure = null,
+  codexTagType = "tag",
+  codexTagObject = codexDependency.tagObject,
+  codexCommitSha = codexDependency.commit,
+  codexFileFault = null,
+  codexFailure = null,
   initialGitConfig = null,
   initialIncludedGitConfig = null,
   preexistingTargetCheckout = false,
+  preexistingCodexCheckout = false,
   toolchainGitConfig = null,
   codexGitConfigMutation = null,
   codexIncludedGitConfigMutation = null,
@@ -4202,7 +4405,7 @@ function makeFixture({
     summary: "clean fixture review",
     findings: [],
     findings_addressed: true,
-    evidence: ["Codex /review clean"],
+    evidence: [`${codexDependency.commit} ../codex/codex-rs/exec/src/lib.rs:583`],
   },
   collaboratorPermissions = {},
   collaboratorPermissionErrors = [],
@@ -4238,6 +4441,9 @@ function makeFixture({
   const codexPromptPath = path.join(root, "codex-prompt.txt");
   const codexArgsPath = path.join(root, "codex-args.json");
   const codexCountPath = path.join(root, "codex-count");
+  const codexVersionCountPath = path.join(root, "codex-version-count");
+  const codexCloneCountPath = path.join(root, "codex-clone-count");
+  const codexDependencyEnvPath = path.join(root, "codex-dependency-env.json");
   const codexPath = path.join(binDir, "codex");
   const mergeLogPath = path.join(root, "merge.log");
   const mergedStatePath = path.join(root, "merged");
@@ -4257,6 +4463,10 @@ function makeFixture({
   if (preexistingTargetCheckout) {
     fs.mkdirSync(path.join(runDir, "target", ".git"), { recursive: true });
   }
+  if (preexistingCodexCheckout) {
+    fs.mkdirSync(path.join(runDir, "codex"), { recursive: true });
+    fs.writeFileSync(path.join(runDir, "codex", "unowned"), "preserve\n");
+  }
   if (initialGitConfig) {
     fs.writeFileSync(
       gitConfigStatePath,
@@ -4272,7 +4482,7 @@ function makeFixture({
   fs.writeFileSync(
     jobPath,
     `---
-repo: openclaw/openclaw
+repo: ${repo}
 cluster_id: fixture-source
 mode: plan
 ${expectedHeadSha ? `expected_head_sha: ${expectedHeadSha}\n` : ""}${expectedHeadShas ? `expected_head_shas:\n${expectedHeadShas.map((value) => `  - "${value}"`).join("\n")}\n` : ""}allowed_actions:
@@ -4305,6 +4515,7 @@ require_fix_before_close: false
 const fs = require("node:fs");
 const path = require("node:path");
 const args = process.argv.slice(2);
+const repo = ${JSON.stringify(repo)};
 const head = ${JSON.stringify(headSha)};
 const base = ${JSON.stringify(baseSha)};
 const baseTree = ${JSON.stringify(baseTreeSha)};
@@ -4379,10 +4590,7 @@ if (args[0] === "api" && args[1].includes("/issues/123/comments")) {
   console.log(JSON.stringify(args.includes("--slurp") ? [comments] : comments));
   process.exit(0);
 }
-if (
-  args[0] === "api" &&
-  /^repos\\/openclaw\\/openclaw\\/collaborators\\/[^/]+\\/permission$/.test(args[1])
-) {
+if (args[0] === "api" && args[1].startsWith("repos/" + repo + "/collaborators/") && args[1].endsWith("/permission")) {
   const login = decodeURIComponent(args[1].split("/").at(-2)).toLowerCase();
   if (collaboratorPermissionErrors.has(login)) {
     process.stderr.write("fixture collaborator permission failure");
@@ -4391,11 +4599,11 @@ if (
   write({ permission: collaboratorPermissions[login] ?? "read" });
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/ref/heads/main") {
+if (args[0] === "api" && args[1] === "repos/" + repo + "/git/ref/heads/main") {
   write({ object: { sha: base } });
   process.exit(0);
 }
-if (args[0] === "api" && args[1].startsWith("repos/openclaw/openclaw/commits/" + head + "/check-runs?")) {
+if (args[0] === "api" && args[1].startsWith("repos/" + repo + "/commits/" + head + "/check-runs?")) {
   const page = {
     total_count: 1,
     check_runs: [{
@@ -4412,7 +4620,7 @@ if (args[0] === "api" && args[1].startsWith("repos/openclaw/openclaw/commits/" +
   write(args.includes("--slurp") ? [page] : page);
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/actions/jobs/7070") {
+if (args[0] === "api" && args[1] === "repos/" + repo + "/actions/jobs/7070") {
   write({
     id: 7070,
     run_id: 7071,
@@ -4425,7 +4633,7 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/actions/jobs/7070"
   });
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/actions/runs/7071") {
+if (args[0] === "api" && args[1] === "repos/" + repo + "/actions/runs/7071") {
   write({
     id: 7071,
     workflow_id: 8081,
@@ -4438,11 +4646,11 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/actions/runs/7071"
   });
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/actions/workflows/ci.yml") {
+if (args[0] === "api" && args[1] === "repos/" + repo + "/actions/workflows/ci.yml") {
   write({ id: 8081, path: ".github/workflows/ci.yml", state: "active" });
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/rules/branches/main") {
+if (args[0] === "api" && args[1] === "repos/" + repo + "/rules/branches/main") {
   write([{
     type: "required_status_checks",
     ruleset_source_type: "Repository",
@@ -4457,7 +4665,7 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/rules/branches/mai
   }]);
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/rulesets/18588237") {
+if (args[0] === "api" && args[1] === "repos/" + repo + "/rulesets/18588237") {
   write({
     id: 18588237,
     enforcement: "active",
@@ -4475,12 +4683,12 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/rulesets/18588237"
   });
   process.exit(0);
 }
-if (args[0] === "api" && args[1].startsWith("repos/openclaw/openclaw/commits/" + testMerge + "/check-runs?")) {
+if (args[0] === "api" && args[1].startsWith("repos/" + repo + "/commits/" + testMerge + "/check-runs?")) {
   const checks = exactMergeChecks();
   write({ total_count: checks.length, check_runs: checks });
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/check-runs" && args.includes("POST")) {
+if (args[0] === "api" && args[1] === "repos/" + repo + "/check-runs" && args.includes("POST")) {
   const inputIndex = args.indexOf("--input");
   const payload = JSON.parse(fs.readFileSync(args[inputIndex + 1], "utf8"));
   const check = {
@@ -4496,7 +4704,7 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/check-runs" && arg
   write(check);
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/check-runs/4242" && args.includes("PATCH")) {
+if (args[0] === "api" && args[1] === "repos/" + repo + "/check-runs/4242" && args.includes("PATCH")) {
   const inputIndex = args.indexOf("--input");
   const payload = JSON.parse(fs.readFileSync(args[inputIndex + 1], "utf8"));
   const previous = exactMergeChecks()[0];
@@ -4513,19 +4721,19 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/check-runs/4242" &
   write(check);
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/commits/" + testMerge) {
+if (args[0] === "api" && args[1] === "repos/" + repo + "/git/commits/" + testMerge) {
   write({ sha: testMerge, tree: { sha: mergeTree }, parents: [{ sha: base }, { sha: head }] });
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/commits/" + squashCommit) {
+if (args[0] === "api" && args[1] === "repos/" + repo + "/git/commits/" + squashCommit) {
   write({ sha: squashCommit, tree: { sha: squashTree }, parents: [{ sha: base }] });
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/commits/" + base) {
+if (args[0] === "api" && args[1] === "repos/" + repo + "/git/commits/" + base) {
   write({ sha: base, tree: { sha: baseTree }, parents: [] });
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/trees/" + baseTree + "?recursive=1") {
+if (args[0] === "api" && args[1] === "repos/" + repo + "/git/trees/" + baseTree + "?recursive=1") {
   write({
     truncated: false,
     tree: [{ path: "src/effective.ts", mode: "100644", type: "blob", sha: baseBlob }],
@@ -4534,7 +4742,7 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/trees/" + base
 }
 if (
   args[0] === "api" &&
-  [mergeTree, squashTree].some((tree) => args[1] === "repos/openclaw/openclaw/git/trees/" + tree + "?recursive=1")
+  [mergeTree, squashTree].some((tree) => args[1] === "repos/" + repo + "/git/trees/" + tree + "?recursive=1")
 ) {
   write({
     truncated: false,
@@ -4548,7 +4756,7 @@ if (args[0] === "api" && args[1].endsWith("/issues/123")) {
     { state: "open", updated_at: ${JSON.stringify(issueUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, assignees: ${JSON.stringify(pullAssignees)} },
     { state: ${JSON.stringify(finalState)}, updated_at: ${JSON.stringify(finalIssueUpdatedAt)}, labels: ${JSON.stringify(finalPullLabels)}, assignees: ${JSON.stringify(finalPullAssignees)} },
   );
-  console.log(JSON.stringify({ number: 123, ...issue, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/openclaw/openclaw/pull/123", pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/123" } }));
+  console.log(JSON.stringify({ number: 123, ...issue, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/" + repo + "/pull/123", pull_request: { url: "https://api.github.com/repos/" + repo + "/pulls/123" } }));
   process.exit(0);
 }
 if (args[0] === "api" && args[1].endsWith("/pulls/123")) {
@@ -4557,7 +4765,7 @@ if (args[0] === "api" && args[1].endsWith("/pulls/123")) {
     { state: "open", updated_at: ${JSON.stringify(pullUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, assignees: ${JSON.stringify(pullAssignees)}, headSha: head },
     { state: ${JSON.stringify(finalState)}, updated_at: ${JSON.stringify(finalPullUpdatedAt)}, labels: ${JSON.stringify(finalPullLabels)}, assignees: ${JSON.stringify(finalPullAssignees)}, headSha: ${JSON.stringify(finalHeadSha)} },
   );
-  write({ number: 123, ...pull, state: isMerged() ? "closed" : pull.state, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/openclaw/openclaw/pull/123", merged_at: isMerged() ? "2026-06-19T00:10:00Z" : null, merge_commit_sha: isMerged() ? squashCommit : testMerge, user: ${JSON.stringify(pullUser)}, head: { sha: pull.headSha, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: base, ref: "main" } });
+  write({ number: 123, ...pull, state: isMerged() ? "closed" : pull.state, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/" + repo + "/pull/123", merged_at: isMerged() ? "2026-06-19T00:10:00Z" : null, merge_commit_sha: isMerged() ? squashCommit : testMerge, user: ${JSON.stringify(pullUser)}, head: { sha: pull.headSha, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: base, ref: "main" } });
   process.exit(0);
 }
 process.stderr.write("unexpected gh command: " + args.join(" "));
@@ -4587,6 +4795,15 @@ const mergeBlob = ${JSON.stringify(mergeBlobSha)};
 const statePath = path.join(${JSON.stringify(root)}, "git-state");
 const mainFetchCountPath = path.join(${JSON.stringify(root)}, "main-fetch-count");
 const commandLog = ${JSON.stringify(gitCommandsPath)};
+const dependencyCloneDir = args[0] === "clone" ? path.resolve(args.at(-1)) : null;
+const dependencyDir =
+  dependencyCloneDir ??
+  (path.basename(process.cwd()) === "codex"
+    ? process.cwd()
+    : path.join(${JSON.stringify(runDir)}, "codex"));
+const dependencyFiles = ${JSON.stringify(codexDependency.files)};
+const dependencyCloneCountPath = ${JSON.stringify(codexCloneCountPath)};
+const dependencyEnvPath = ${JSON.stringify(codexDependencyEnvPath)};
 function mainFetchCount() {
   return fs.existsSync(mainFetchCountPath) ? Number(fs.readFileSync(mainFetchCountPath, "utf8")) : 0;
 }
@@ -4594,15 +4811,94 @@ function currentMainRef() {
   return mainSequence[Math.min(Math.max(mainFetchCount() - 1, 0), mainSequence.length - 1)];
 }
 fs.appendFileSync(commandLog, args.join(" ") + "\\n");
-if (
-  process.env.GIT_ALLOW_PROTOCOL !== "https:ssh" ||
+const dependencyCommand =
+  process.env.GIT_ALLOW_PROTOCOL === "https" ||
+  process.cwd() === dependencyDir ||
+  (args[0] === "clone" && path.resolve(args.at(-1)) === dependencyDir);
+const hardeningMissing =
+  process.env.GIT_CONFIG_NOSYSTEM !== "1" ||
+  process.env.GIT_CONFIG_GLOBAL !== "/dev/null" ||
   process.env.GIT_CONFIG_KEY_0 !== "core.hooksPath" ||
   process.env.GIT_CONFIG_VALUE_0 !== "/dev/null" ||
   process.env.GIT_CONFIG_KEY_1 !== "protocol.ext.allow" ||
-  process.env.GIT_CONFIG_VALUE_1 !== "never"
+  process.env.GIT_CONFIG_VALUE_1 !== "never" ||
+  process.env.GIT_NO_REPLACE_OBJECTS !== "1";
+if (
+  hardeningMissing ||
+  process.env.GIT_ALLOW_PROTOCOL !== (dependencyCommand ? "https" : "https:ssh") ||
+  (dependencyCommand &&
+    (process.env.GIT_TERMINAL_PROMPT !== "0" ||
+      process.env.GCM_INTERACTIVE !== "Never" ||
+      Object.keys(process.env).some((key) =>
+        /(?:github|openai|codex|npm|token|secret|password|private[_-]?key)/i.test(key),
+      )))
 ) {
-  process.stderr.write("missing Git hardening");
+  process.stderr.write("missing Git hardening: " + JSON.stringify({
+    dependencyCommand,
+    allowProtocol: process.env.GIT_ALLOW_PROTOCOL,
+    configNoSystem: process.env.GIT_CONFIG_NOSYSTEM,
+    configGlobal: process.env.GIT_CONFIG_GLOBAL,
+    configKey0: process.env.GIT_CONFIG_KEY_0,
+    configValue0: process.env.GIT_CONFIG_VALUE_0,
+    configKey1: process.env.GIT_CONFIG_KEY_1,
+    configValue1: process.env.GIT_CONFIG_VALUE_1,
+    noReplaceObjects: process.env.GIT_NO_REPLACE_OBJECTS,
+    terminalPrompt: process.env.GIT_TERMINAL_PROMPT,
+    interactive: process.env.GCM_INTERACTIVE,
+    credentialKeys: Object.keys(process.env).filter((key) =>
+      /(?:github|openai|codex|npm|token|secret|password|private[_-]?key)/i.test(key),
+    ),
+  }));
   process.exit(97);
+}
+if (dependencyCommand) {
+  fs.writeFileSync(
+    dependencyEnvPath,
+    JSON.stringify({
+      allowProtocol: process.env.GIT_ALLOW_PROTOCOL,
+      terminalPrompt: process.env.GIT_TERMINAL_PROMPT,
+      askpass: process.env.GIT_ASKPASS,
+      credentialKeys: Object.keys(process.env).filter((key) =>
+        /(?:github|openai|codex|npm|token|secret|password|private[_-]?key)/i.test(key),
+      ),
+    }),
+  );
+}
+if (args[0] === "clone" && dependencyCommand) {
+  const failure = ${JSON.stringify(codexCloneFailure)};
+  if (failure) {
+    process.stderr.write(failure);
+    process.exit(1);
+  }
+  const count = fs.existsSync(dependencyCloneCountPath)
+    ? Number(fs.readFileSync(dependencyCloneCountPath, "utf8"))
+    : 0;
+  fs.writeFileSync(dependencyCloneCountPath, String(count + 1));
+  fs.mkdirSync(path.join(dependencyDir, ".git"), { recursive: true });
+  for (const file of dependencyFiles) {
+    if (${JSON.stringify(codexFileFault)}?.path === file && ${JSON.stringify(codexFileFault)}?.type === "missing") continue;
+    const target = path.join(dependencyDir, file);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    if (${JSON.stringify(codexFileFault)}?.path === file && ${JSON.stringify(codexFileFault)}?.type === "directory") {
+      fs.mkdirSync(target, { recursive: true });
+    } else {
+      fs.writeFileSync(target, "fixture pinned codex source\\n");
+    }
+  }
+  process.exit(0);
+}
+if (dependencyCommand) {
+  if (args[0] === "remote" && args[1] === "get-url") console.log("https://github.com/openai/codex.git");
+  else if (args[0] === "cat-file" && args[1] === "-t") console.log(${JSON.stringify(codexTagType)});
+  else if (args[0] === "rev-parse" && args[1] === "refs/tags/rust-v0.125.0") console.log(${JSON.stringify(codexTagObject)});
+  else if (args[0] === "rev-parse") console.log(${JSON.stringify(codexCommitSha)});
+  else if (args[0] === "status" && args[1] === "--porcelain") {
+    const source = path.join(dependencyDir, "codex-rs", "exec", "src", "main.rs");
+    if (fs.existsSync(source) && fs.readFileSync(source, "utf8") !== "fixture pinned codex source\\n") {
+      console.log(" M codex-rs/exec/src/main.rs");
+    }
+  }
+  process.exit(0);
 }
 const state = fs.existsSync(statePath) ? fs.readFileSync(statePath, "utf8") : "pr";
 if (args[0] === "config" && args.includes("--local") && args.includes("--list") && args.includes("--null")) {
@@ -4701,7 +4997,26 @@ if (failure && args[0] === "check:changed") {
     codexPath,
     `#!/usr/bin/env node
 const fs = require("node:fs");
+const path = require("node:path");
 const args = process.argv.slice(2);
+if (args.length === 1 && args[0] === "--version") {
+  const versionCountPath = ${JSON.stringify(codexVersionCountPath)};
+  const versionCount = fs.existsSync(versionCountPath) ? Number(fs.readFileSync(versionCountPath, "utf8")) : 0;
+  fs.writeFileSync(versionCountPath, String(versionCount + 1));
+  const credentialKeys = Object.keys(process.env).filter((key) =>
+    /(?:github|openai|codex|npm|token|secret|password|private[_-]?key)/i.test(key),
+  );
+  if (
+    process.env.GIT_TERMINAL_PROMPT !== "0" ||
+    process.env.GCM_INTERACTIVE !== "Never" ||
+    credentialKeys.length > 0
+  ) {
+    process.stderr.write("unsafe Codex dependency environment");
+    process.exit(96);
+  }
+  process.stdout.write(${JSON.stringify(codexVersion)});
+  process.exit(0);
+}
 fs.writeFileSync(${JSON.stringify(codexArgsPath)}, JSON.stringify(args));
 const index = args.indexOf("--output-last-message");
 const countPath = ${JSON.stringify(codexCountPath)};
@@ -4710,6 +5025,9 @@ fs.writeFileSync(countPath, String(count + 1));
 fs.writeFileSync(${JSON.stringify(codexPromptPath)}, fs.readFileSync(0, "utf8"));
 if (${JSON.stringify(codexMutatesCheckout)}) {
   fs.writeFileSync("src/effective.ts", "mutated by fixture review\\n");
+}
+if (${JSON.stringify(codexMutatesSource)}) {
+  fs.writeFileSync(path.join("..", "codex", "codex-rs", "exec", "src", "main.rs"), "mutated source\\n");
 }
 const codexGitConfigMutation = ${JSON.stringify(codexGitConfigMutation)};
 if (codexGitConfigMutation) {
@@ -4733,6 +5051,10 @@ if (codexIncludedGitConfigMutation) {
 if (!${JSON.stringify(codexSkipsSecondWrite)} || count === 0) {
   fs.writeFileSync(args[index + 1], JSON.stringify(${JSON.stringify(codexReview)}));
 }
+if (${JSON.stringify(codexFailure)}) {
+  process.stderr.write(${JSON.stringify(codexFailure)});
+  process.exit(1);
+}
 `,
   );
   return {
@@ -4741,8 +5063,11 @@ if (!${JSON.stringify(codexSkipsSecondWrite)} || count === 0) {
     codexPath,
     effectiveDiffSha256,
     codexArgsPath,
+    codexCloneCountPath,
     codexCountPath,
+    codexDependencyEnvPath,
     codexPromptPath,
+    codexVersionCountPath,
     gitCommandsPath,
     headSha,
     jobPath,

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -21,6 +21,7 @@ const clusterWorkflow = fs.readFileSync(path.join(repoRoot, ".github", "workflow
 const autonomousPrompt = fs.readFileSync(path.join(repoRoot, "prompts", "autonomous.md"), "utf8");
 const githubInventoryImporter = fs.readFileSync(path.join(repoRoot, "scripts", "import-github-pr-inventory.mjs"), "utf8");
 const codexDependency = CODEX_REVIEW_DEPENDENCY;
+const codexCitation = { source_path: "codex-rs/exec/src/lib.rs", line: 583 };
 
 test("external merge preflight is exact-head, read-only, and refuses unresolved review evidence", () => {
   assert.match(script, /source job does not explicitly contain/);
@@ -83,6 +84,11 @@ test("external merge workflow validates before guarded apply", () => {
   assert.match(workflow, /inputs\.apply && vars\.CLOWNFISH_ALLOW_EXECUTE == '1' && vars\.CLOWNFISH_ALLOW_MERGE == '1'/);
   assert.match(workflow, /runs-on: \$\{\{ inputs\.runner \}\}/);
   assert.match(workflow, /external-merge-preflight\/preflight-report\.json/);
+  const preflightUpload = workflow.match(/- name: Upload preflight artifact[\s\S]*?(?=\n      - name: Fail blocked preflight)/)?.[0] ?? "";
+  const applyUpload = workflow.match(/- name: Upload apply artifact[\s\S]*$/)?.[0] ?? "";
+  assert.match(preflightUpload, /external-merge-preflight\/codex-review\.json/);
+  assert.doesNotMatch(applyUpload, /external-merge-preflight\/codex-review\.json/);
+  assert.equal((workflow.match(/external-merge-preflight\/codex-review\.json/g) ?? []).length, 1);
   assert.match(
     workflow,
     /- name: Upload preflight artifact[\s\S]*?if: always\(\)[\s\S]*?- name: Fail blocked preflight[\s\S]*?if: \$\{\{ always\(\) && steps\.outcome\.outputs\.preflight_passed != 'true' \}\}[\s\S]*?exit 1[\s\S]*?\n  apply:/,
@@ -520,6 +526,7 @@ test("external merge preflight binds OpenClaw review to pinned Codex source", ()
     tag: codexDependency.tag,
     tag_object: codexDependency.tagObject,
     commit: codexDependency.commit,
+    ...codexCitation,
   });
   const prompt = fs.readFileSync(fixture.codexPromptPath, "utf8");
   assert.match(prompt, new RegExp(codexDependency.commit));
@@ -541,7 +548,7 @@ test("external merge preflight binds OpenClaw review to pinned Codex source", ()
     xdgEntries: [],
     credentialKeys: [],
   });
-  assert.equal(result.merge_preflight[0].codex_review.evidence.includes(codexReviewProvenanceEvidence()), true);
+  assert.equal(result.merge_preflight[0].codex_review.evidence.includes(codexReviewProvenanceEvidence(codexCitation)), true);
   const versionEnv = JSON.parse(fs.readFileSync(fixture.codexVersionEnvPath, "utf8"));
   assert.equal(versionEnv.cwdHasGit, false);
   assert.deepEqual(versionEnv.homeEntries, []);
@@ -654,7 +661,10 @@ test("pinned Codex source citations reject unsafe or unverifiable locations", ()
     validateCodexReviewSourceEvidence({ evidence }, root, () => tracked);
   const commit = codexDependency.commit;
 
-  assert.equal(validate([`${commit} ../codex/${regular}:2`]), "");
+  assert.deepEqual(validate([`${commit} ../codex/${regular}:2`]), {
+    error: "",
+    citation: { source_path: regular, line: 2 },
+  });
   for (const [name, evidence, reason] of [
     ["traversal", [`${commit} ../codex/codex-rs/../AGENTS.md:1`], /invalid/],
     ["absolute", [`${commit} ../codex//etc/passwd:1`], /invalid/],
@@ -663,26 +673,36 @@ test("pinned Codex source citations reject unsafe or unverifiable locations", ()
     ["untracked", [`${commit} ../codex/${untracked}:1`], /not tracked/],
     ["nonregular", [`${commit} ../codex/${nonregular}:1`], /not a regular file/],
     ["symlink", [`${commit} ../codex/${symlink}:1`], /not a regular file/],
-    ["zero", [`${commit} ../codex/${regular}:0`], /out of range/],
+    ["zero", [`${commit} ../codex/${regular}:0`], /invalid/],
     ["out-of-range", [`${commit} ../codex/${regular}:3`], /out of range/],
     ["split entry", [commit, `../codex/${regular}:1`], /same entry/],
     ["malformed extra entry", [`${commit} ../codex/${regular}:1`, `../codex/${regular}`], /same entry/],
   ]) {
-    assert.match(validate(evidence), reason, name);
+    assert.match(validate(evidence).error, reason, name);
   }
 });
 
 test("OpenClaw Codex provenance accepts only one exact canonical record", () => {
-  const canonical = codexReviewProvenanceEvidence();
-  const payload = canonical.slice(canonical.indexOf("{"));
+  const canonical = codexReviewProvenanceEvidence(codexCitation);
+  const prefix = canonical.slice(0, canonical.indexOf("{"));
+  const parsed = JSON.parse(canonical.slice(prefix.length));
+  const tupleOnly = { ...parsed };
+  delete tupleOnly.source_path;
+  delete tupleOnly.line;
+  assert.equal(canonical, `${prefix}${JSON.stringify({ repository: "openai/codex", version: codexDependency.version, tag: codexDependency.tag, tag_object: codexDependency.tagObject, commit: codexDependency.commit, ...codexCitation })}`);
   assert.equal(validateCodexReviewProvenance("openclaw/openclaw", [canonical]), "");
   assert.equal(validateCodexReviewProvenance("openclaw/example", []), "");
   for (const [name, evidence, reason] of [
     ["missing", [], /exactly one/],
     ["duplicate", [canonical, canonical], /exactly one/],
     ["malformed", ["Codex dependency provenance: {"], /malformed/],
-    ["missing field", [`Codex dependency provenance: ${JSON.stringify({ repository: "openai/codex" })}`], /fields/],
-    ["extra field", [`Codex dependency provenance: ${payload.slice(0, -1)},"extra":true}`], /fields/],
+    ["tuple-only", [`${prefix}${JSON.stringify(tupleOnly)}`], /fields/],
+    ["missing field", [`${prefix}${JSON.stringify({ ...parsed, line: undefined })}`], /fields/],
+    ["extra field", [`${prefix}${JSON.stringify({ ...parsed, extra: true })}`], /fields/],
+    ["traversal", [`${prefix}${JSON.stringify({ ...parsed, source_path: "codex-rs/../AGENTS.md" })}`], /citation/],
+    ["zero line", [`${prefix}${JSON.stringify({ ...parsed, line: 0 })}`], /citation/],
+    ["noninteger line", [`${prefix}${JSON.stringify({ ...parsed, line: 1.5 })}`], /citation/],
+    ["noncanonical serialization", [`${prefix}${JSON.stringify(parsed, null, 2)}`], /not canonical/],
     ["tuple mismatch", [canonical.replace("0.125.0", "0.126.0")], /does not match/],
   ]) {
     assert.match(validateCodexReviewProvenance("openclaw/openclaw", evidence), reason, name);
@@ -938,6 +958,7 @@ test("external merge preflight blocks later Git config mutation with precise dia
       tag: codexDependency.tag,
       tag_object: codexDependency.tagObject,
       commit: codexDependency.commit,
+      ...codexCitation,
     },
   });
 });

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -5,6 +5,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import {
+  CODEX_REVIEW_DEPENDENCY,
+  codexReviewProvenanceEvidence,
+  validateCodexReviewProvenance,
+  validateCodexReviewSourceEvidence,
+} from "../scripts/codex-review-dependency.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const script = fs.readFileSync(path.join(repoRoot, "scripts", "preflight-external-pr-merge.mjs"), "utf8");
@@ -14,18 +20,7 @@ const intakeWorkflow = fs.readFileSync(path.join(repoRoot, ".github", "workflows
 const clusterWorkflow = fs.readFileSync(path.join(repoRoot, ".github", "workflows", "cluster-worker.yml"), "utf8");
 const autonomousPrompt = fs.readFileSync(path.join(repoRoot, "prompts", "autonomous.md"), "utf8");
 const githubInventoryImporter = fs.readFileSync(path.join(repoRoot, "scripts", "import-github-pr-inventory.mjs"), "utf8");
-const codexDependency = {
-  version: "codex-cli 0.125.0",
-  tag: "rust-v0.125.0",
-  tagObject: "7d8152a5d74226ddaac12f93f7c5ed3f33a60d2a",
-  commit: "637f7dd6d737f3961e6bf32fbb3861c4953269c5",
-  files: [
-    "AGENTS.md",
-    "codex-rs/core/src/lib.rs",
-    "codex-rs/protocol/src/protocol.rs",
-    "codex-rs/exec/src/main.rs",
-  ],
-};
+const codexDependency = CODEX_REVIEW_DEPENDENCY;
 
 test("external merge preflight is exact-head, read-only, and refuses unresolved review evidence", () => {
   assert.match(script, /source job does not explicitly contain/);
@@ -56,8 +51,9 @@ test("external merge preflight is exact-head, read-only, and refuses unresolved 
   assert.match(script, /GIT_ALLOW_PROTOCOL: "https:ssh"/);
   assert.match(script, /GIT_CONFIG_KEY_0: "core\.hooksPath"/);
   assert.match(script, /GIT_CONFIG_VALUE_0: "\/dev\/null"/);
-  assert.match(script, /GIT_CONFIG_KEY_1: "protocol\.ext\.allow"/);
-  assert.match(script, /GIT_CONFIG_VALUE_1: "never"/);
+  assert.match(script, /GIT_CONFIG_KEY_2: "credential\.helper"/);
+  assert.match(script, /GIT_CONFIG_KEY_3: "http\.extraHeader"/);
+  assert.match(script, /GIT_CONFIG_KEY_4: "http\.https:\/\/github\.com\/\.extraHeader"/);
   assert.match(script, /GIT_NO_REPLACE_OBJECTS: "1"/);
   assert.match(script, /function verifyTrackedFilesystem/);
   assert.match(script, /function gitBlobSha/);
@@ -441,6 +437,12 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
   assert.equal(result.actions[0].expected_head_sha, fixture.headSha);
   assert.equal(result.actions[0].target_updated_at, "2026-06-19T00:05:00Z");
   assert.equal(result.merge_preflight[0].codex_review.status, "clean");
+  assert.equal(
+    result.merge_preflight[0].codex_review.evidence.filter((entry) =>
+      entry.startsWith("Codex dependency provenance: "),
+    ).length,
+    1,
+  );
   assert.equal(result.merge_preflight[0].reviewed_base_sha, fixture.baseSha);
   assert.equal(result.merge_preflight[0].reviewed_head_sha, fixture.headSha);
   assert.equal(result.merge_preflight[0].effective_diff_sha256, fixture.effectiveDiffSha256);
@@ -532,17 +534,39 @@ test("external merge preflight binds OpenClaw review to pinned Codex source", ()
     allowProtocol: "https",
     terminalPrompt: "0",
     askpass: "/bin/false",
+    configCount: "5",
+    configValues: ["", "", ""],
+    cwdHasGit: false,
+    homeEntries: [],
+    xdgEntries: [],
     credentialKeys: [],
   });
-  assert.match(
-    result.actions[0].evidence.join("\n"),
-    /Codex dependency .*rust-v0\.125\.0.*637f7dd6d737f3961e6bf32fbb3861c4953269c5/,
-  );
-  assert.match(
-    result.merge_preflight[0].codex_review.evidence.join("\n"),
-    /Pinned dependency openai\/codex rust-v0\.125\.0 at 637f7dd6d737f3961e6bf32fbb3861c4953269c5/,
-  );
+  assert.equal(result.merge_preflight[0].codex_review.evidence.includes(codexReviewProvenanceEvidence()), true);
+  const versionEnv = JSON.parse(fs.readFileSync(fixture.codexVersionEnvPath, "utf8"));
+  assert.equal(versionEnv.cwdHasGit, false);
+  assert.deepEqual(versionEnv.homeEntries, []);
+  assert.equal(fs.existsSync(versionEnv.cwd), false);
   assert.equal(fs.existsSync(path.join(fixture.runDir, "codex")), false);
+});
+
+test("external merge preflight isolates dependency bootstrap from hostile Git configuration", () => {
+  const fixture = makeFixture({ initialGitConfig: { key: "credential.helper", value: "fixture-local" } });
+  fs.mkdirSync(fixture.hostileHome, { recursive: true });
+  fs.writeFileSync(
+    path.join(fixture.hostileHome, ".gitconfig"),
+    `[credential]\n\thelper = !touch ${fixture.credentialSentinelPath}\n[http]\n\textraHeader = Authorization: hostile\n`,
+  );
+  const { report } = runPreflightFixture(fixture, {
+    HOME: fixture.hostileHome,
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: "credential.helper",
+    GIT_CONFIG_VALUE_0: `!touch ${fixture.credentialSentinelPath}`,
+    GIT_CONFIG_SYSTEM: path.join(fixture.hostileHome, ".gitconfig"),
+    GIT_CONFIG_PARAMETERS: "'http.extraHeader=Authorization: inherited'",
+  });
+
+  assert.equal(report.status, "passed", report.reason);
+  assert.equal(fs.existsSync(fixture.credentialSentinelPath), false);
 });
 
 for (const [name, options, reason] of [
@@ -588,6 +612,81 @@ test("external merge preflight requires pinned Codex source citations", () => {
   assert.equal(report.status, "blocked");
   assert.match(report.reason, /did not cite the pinned sibling Codex source/);
   assert.equal(fs.existsSync(path.join(fixture.runDir, "codex")), false);
+});
+
+for (const status of ["failed", "blocked"]) {
+  test(`external merge preflight preserves ${status} reviews without source citations`, () => {
+    const finding = { severity: "high", summary: "fixture finding", evidence: "target source" };
+    const fixture = makeFixture({
+      codexReview: {
+        status,
+        summary: `${status} fixture review`,
+        findings: [finding],
+        findings_addressed: false,
+        evidence: ["review did not claim pinned source proof"],
+      },
+    });
+    const { report } = runPreflightFixture(fixture);
+    const artifact = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "codex-review.json"), "utf8"));
+
+    assert.equal(report.status, "blocked");
+    assert.equal(report.codex_review.status, status);
+    assert.equal(report.codex_review.findings, 1);
+    assert.equal(artifact.summary, `${status} fixture review`);
+    assert.deepEqual(artifact.findings, [finding]);
+  });
+}
+
+test("pinned Codex source citations reject unsafe or unverifiable locations", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-codex-evidence-"));
+  const regular = "codex-rs/exec/src/lib.rs";
+  const missing = "codex-rs/exec/src/missing.rs";
+  const nonregular = "codex-rs/exec/src/nonregular.rs";
+  const symlink = "codex-rs/exec/src/symlink.rs";
+  const untracked = "codex-rs/exec/src/untracked.rs";
+  fs.mkdirSync(path.join(root, path.dirname(regular)), { recursive: true });
+  fs.writeFileSync(path.join(root, regular), "one\ntwo\n");
+  fs.writeFileSync(path.join(root, untracked), "untracked\n");
+  fs.mkdirSync(path.join(root, nonregular));
+  fs.symlinkSync(regular, path.join(root, symlink));
+  const tracked = [regular, missing, nonregular, symlink].join("\0") + "\0";
+  const validate = (evidence) =>
+    validateCodexReviewSourceEvidence({ evidence }, root, () => tracked);
+  const commit = codexDependency.commit;
+
+  assert.equal(validate([`${commit} ../codex/${regular}:2`]), "");
+  for (const [name, evidence, reason] of [
+    ["traversal", [`${commit} ../codex/codex-rs/../AGENTS.md:1`], /invalid/],
+    ["absolute", [`${commit} ../codex//etc/passwd:1`], /invalid/],
+    ["backslash", [`${commit} ../codex/codex-rs\\exec\\src\\lib.rs:1`], /invalid/],
+    ["nonexistent", [`${commit} ../codex/${missing}:1`], /not a regular file/],
+    ["untracked", [`${commit} ../codex/${untracked}:1`], /not tracked/],
+    ["nonregular", [`${commit} ../codex/${nonregular}:1`], /not a regular file/],
+    ["symlink", [`${commit} ../codex/${symlink}:1`], /not a regular file/],
+    ["zero", [`${commit} ../codex/${regular}:0`], /out of range/],
+    ["out-of-range", [`${commit} ../codex/${regular}:3`], /out of range/],
+    ["split entry", [commit, `../codex/${regular}:1`], /same entry/],
+    ["malformed extra entry", [`${commit} ../codex/${regular}:1`, `../codex/${regular}`], /same entry/],
+  ]) {
+    assert.match(validate(evidence), reason, name);
+  }
+});
+
+test("OpenClaw Codex provenance accepts only one exact canonical record", () => {
+  const canonical = codexReviewProvenanceEvidence();
+  const payload = canonical.slice(canonical.indexOf("{"));
+  assert.equal(validateCodexReviewProvenance("openclaw/openclaw", [canonical]), "");
+  assert.equal(validateCodexReviewProvenance("openclaw/example", []), "");
+  for (const [name, evidence, reason] of [
+    ["missing", [], /exactly one/],
+    ["duplicate", [canonical, canonical], /exactly one/],
+    ["malformed", ["Codex dependency provenance: {"], /malformed/],
+    ["missing field", [`Codex dependency provenance: ${JSON.stringify({ repository: "openai/codex" })}`], /fields/],
+    ["extra field", [`Codex dependency provenance: ${payload.slice(0, -1)},"extra":true}`], /fields/],
+    ["tuple mismatch", [canonical.replace("0.125.0", "0.126.0")], /does not match/],
+  ]) {
+    assert.match(validateCodexReviewProvenance("openclaw/openclaw", evidence), reason, name);
+  }
 });
 
 test("external merge preflight leaves non-OpenClaw review behavior unchanged", () => {
@@ -4444,6 +4543,9 @@ function makeFixture({
   const codexVersionCountPath = path.join(root, "codex-version-count");
   const codexCloneCountPath = path.join(root, "codex-clone-count");
   const codexDependencyEnvPath = path.join(root, "codex-dependency-env.json");
+  const codexVersionEnvPath = path.join(root, "codex-version-env.json");
+  const hostileHome = path.join(root, "hostile-home");
+  const credentialSentinelPath = path.join(root, "credential-sentinel");
   const codexPath = path.join(binDir, "codex");
   const mergeLogPath = path.join(root, "merge.log");
   const mergedStatePath = path.join(root, "merged");
@@ -4802,6 +4904,7 @@ const dependencyDir =
     ? process.cwd()
     : path.join(${JSON.stringify(runDir)}, "codex"));
 const dependencyFiles = ${JSON.stringify(codexDependency.files)};
+const dependencyTrackedFiles = [...dependencyFiles, "codex-rs/exec/src/lib.rs"];
 const dependencyCloneCountPath = ${JSON.stringify(codexCloneCountPath)};
 const dependencyEnvPath = ${JSON.stringify(codexDependencyEnvPath)};
 function mainFetchCount() {
@@ -4818,10 +4921,21 @@ const dependencyCommand =
 const hardeningMissing =
   process.env.GIT_CONFIG_NOSYSTEM !== "1" ||
   process.env.GIT_CONFIG_GLOBAL !== "/dev/null" ||
+  (dependencyCommand &&
+    (process.env.GIT_CONFIG_SYSTEM !== undefined ||
+      process.env.GIT_CONFIG_PARAMETERS !== undefined)) ||
+  process.env.GIT_CONFIG_COUNT !== (dependencyCommand ? "5" : "2") ||
   process.env.GIT_CONFIG_KEY_0 !== "core.hooksPath" ||
   process.env.GIT_CONFIG_VALUE_0 !== "/dev/null" ||
   process.env.GIT_CONFIG_KEY_1 !== "protocol.ext.allow" ||
   process.env.GIT_CONFIG_VALUE_1 !== "never" ||
+  (dependencyCommand &&
+    (process.env.GIT_CONFIG_KEY_2 !== "credential.helper" ||
+      process.env.GIT_CONFIG_VALUE_2 !== "" ||
+      process.env.GIT_CONFIG_KEY_3 !== "http.extraHeader" ||
+      process.env.GIT_CONFIG_VALUE_3 !== "" ||
+      process.env.GIT_CONFIG_KEY_4 !== "http.https://github.com/.extraHeader" ||
+      process.env.GIT_CONFIG_VALUE_4 !== "")) ||
   process.env.GIT_NO_REPLACE_OBJECTS !== "1";
 if (
   hardeningMissing ||
@@ -4851,13 +4965,18 @@ if (
   }));
   process.exit(97);
 }
-if (dependencyCommand) {
+if (args[0] === "clone" && dependencyCommand) {
   fs.writeFileSync(
     dependencyEnvPath,
     JSON.stringify({
       allowProtocol: process.env.GIT_ALLOW_PROTOCOL,
       terminalPrompt: process.env.GIT_TERMINAL_PROMPT,
       askpass: process.env.GIT_ASKPASS,
+      configCount: process.env.GIT_CONFIG_COUNT,
+      configValues: [process.env.GIT_CONFIG_VALUE_2, process.env.GIT_CONFIG_VALUE_3, process.env.GIT_CONFIG_VALUE_4],
+      cwdHasGit: fs.existsSync(path.join(process.cwd(), ".git")),
+      homeEntries: fs.readdirSync(process.env.HOME),
+      xdgEntries: fs.readdirSync(process.env.XDG_CONFIG_HOME),
       credentialKeys: Object.keys(process.env).filter((key) =>
         /(?:github|openai|codex|npm|token|secret|password|private[_-]?key)/i.test(key),
       ),
@@ -4875,14 +4994,14 @@ if (args[0] === "clone" && dependencyCommand) {
     : 0;
   fs.writeFileSync(dependencyCloneCountPath, String(count + 1));
   fs.mkdirSync(path.join(dependencyDir, ".git"), { recursive: true });
-  for (const file of dependencyFiles) {
+  for (const file of dependencyTrackedFiles) {
     if (${JSON.stringify(codexFileFault)}?.path === file && ${JSON.stringify(codexFileFault)}?.type === "missing") continue;
     const target = path.join(dependencyDir, file);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     if (${JSON.stringify(codexFileFault)}?.path === file && ${JSON.stringify(codexFileFault)}?.type === "directory") {
       fs.mkdirSync(target, { recursive: true });
     } else {
-      fs.writeFileSync(target, "fixture pinned codex source\\n");
+      fs.writeFileSync(target, "fixture pinned codex source\\n".repeat(600));
     }
   }
   process.exit(0);
@@ -4894,10 +5013,11 @@ if (dependencyCommand) {
   else if (args[0] === "rev-parse") console.log(${JSON.stringify(codexCommitSha)});
   else if (args[0] === "status" && args[1] === "--porcelain") {
     const source = path.join(dependencyDir, "codex-rs", "exec", "src", "main.rs");
-    if (fs.existsSync(source) && fs.readFileSync(source, "utf8") !== "fixture pinned codex source\\n") {
+    if (fs.existsSync(source) && fs.readFileSync(source, "utf8") !== "fixture pinned codex source\\n".repeat(600)) {
       console.log(" M codex-rs/exec/src/main.rs");
     }
   }
+  else if (args[0] === "ls-files" && args[1] === "-z") process.stdout.write(dependencyTrackedFiles.join("\\0") + "\\0");
   process.exit(0);
 }
 const state = fs.existsSync(statePath) ? fs.readFileSync(statePath, "utf8") : "pr";
@@ -5003,6 +5123,11 @@ if (args.length === 1 && args[0] === "--version") {
   const versionCountPath = ${JSON.stringify(codexVersionCountPath)};
   const versionCount = fs.existsSync(versionCountPath) ? Number(fs.readFileSync(versionCountPath, "utf8")) : 0;
   fs.writeFileSync(versionCountPath, String(versionCount + 1));
+  fs.writeFileSync(${JSON.stringify(codexVersionEnvPath)}, JSON.stringify({
+    cwd: process.cwd(),
+    cwdHasGit: fs.existsSync(path.join(process.cwd(), ".git")),
+    homeEntries: fs.readdirSync(process.env.HOME),
+  }));
   const credentialKeys = Object.keys(process.env).filter((key) =>
     /(?:github|openai|codex|npm|token|secret|password|private[_-]?key)/i.test(key),
   );
@@ -5068,6 +5193,8 @@ if (${JSON.stringify(codexFailure)}) {
     codexDependencyEnvPath,
     codexPromptPath,
     codexVersionCountPath,
+    codexVersionEnvPath,
+    credentialSentinelPath,
     gitCommandsPath,
     headSha,
     jobPath,
@@ -5076,6 +5203,7 @@ if (${JSON.stringify(codexFailure)}) {
     pnpmCommandsPath,
     root,
     runDir,
+    hostileHome,
     syntheticMergeSha,
   };
 }

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -4,9 +4,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { codexReviewProvenanceEvidence } from "../scripts/codex-review-dependency.mjs";
+import {
+  CODEX_REVIEW_PROVENANCE,
+  codexReviewProvenanceEvidence,
+} from "../scripts/codex-review-dependency.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
+const codexCitation = { source_path: "codex-rs/exec/src/lib.rs", line: 583 };
 
 test("codex result schema requires every object property for strict response formatting", () => {
   const schema = JSON.parse(fs.readFileSync(path.join(repoRoot, "schemas/codex-result.schema.json"), "utf8"));
@@ -526,7 +530,8 @@ test("review-results accepts a blocked external preflight request for calibrated
 
 for (const [name, evidence] of [
   ["missing", ["Codex /review returned clean."]],
-  ["tampered", [codexReviewProvenanceEvidence().replace("0.125.0", "0.126.0")]],
+  ["tuple-only", [`Codex dependency provenance: ${JSON.stringify(CODEX_REVIEW_PROVENANCE)}`]],
+  ["tampered", [codexReviewProvenanceEvidence(codexCitation).replace("0.125.0", "0.126.0")]],
 ]) {
   test(`review-results rejects ${name} OpenClaw Codex provenance`, () => {
     const head = "7".repeat(40);
@@ -2439,7 +2444,7 @@ security_sensitive: false
 `;
 }
 
-function validMergePreflight(target, { external = false, evidence = ["Codex /review returned clean."] } = {}) {
+function validMergePreflight(target, { external = false, evidence = ["Codex /review returned clean.", codexReviewProvenanceEvidence(codexCitation)] } = {}) {
   return {
     target,
     ...(external

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { codexReviewProvenanceEvidence } from "../scripts/codex-review-dependency.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
@@ -522,6 +523,33 @@ test("review-results accepts a blocked external preflight request for calibrated
 
   assert.equal(result.status, 0, result.stdout || result.stderr);
 });
+
+for (const [name, evidence] of [
+  ["missing", ["Codex /review returned clean."]],
+  ["tampered", [codexReviewProvenanceEvidence().replace("0.125.0", "0.126.0")]],
+]) {
+  test(`review-results rejects ${name} OpenClaw Codex provenance`, () => {
+    const head = "7".repeat(40);
+    const dir = makeResultDir(
+      {
+        mode: "autonomous",
+        actions: [{
+          target: "#1", action: "merge_canonical", status: "planned",
+          idempotency_key: `external-merge-preflight:openclaw/openclaw#1:${head}`,
+          expected_head_sha: head, classification: "canonical", target_kind: "pull_request",
+          target_updated_at: "2026-06-15T14:15:01Z", evidence: ["Fresh merge preflight completed."],
+          reason: "Canonical PR is ready to merge.",
+        }],
+        merge_preflight: [validMergePreflight("#1", { external: true, evidence })],
+      },
+      { job: mergeJob(), plan: { items: [openPrItem("#1", "2026-06-15T14:15:01Z")] } },
+    );
+
+    const result = review(dir);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /Codex dependency provenance evidence/);
+  });
+}
 
 test("review-results ignores empty security boundary item collections in mutating evidence", () => {
   const dir = makeResultDir(
@@ -2411,9 +2439,17 @@ security_sensitive: false
 `;
 }
 
-function validMergePreflight(target) {
+function validMergePreflight(target, { external = false, evidence = ["Codex /review returned clean."] } = {}) {
   return {
     target,
+    ...(external
+      ? {
+          reviewed_base_sha: "6".repeat(40),
+          reviewed_head_sha: "7".repeat(40),
+          effective_diff_sha256: "8".repeat(64),
+          effective_diff_files: 1,
+        }
+      : {}),
     security_status: "cleared",
     security_evidence: ["No security-sensitive labels or comments."],
     comments_status: "resolved",
@@ -2425,7 +2461,7 @@ function validMergePreflight(target) {
       command: "/review",
       status: "clean",
       findings_addressed: true,
-      evidence: ["Codex /review returned clean."],
+      evidence,
     },
   };
 }


### PR DESCRIPTION
## Summary

- pin OpenClaw external merge review to Codex CLI `0.125.0`, annotated tag object `7d8152a5d74226ddaac12f93f7c5ed3f33a60d2a`, and peeled commit `637f7dd6d737f3961e6bf32fbb3861c4953269c5`
- isolate version and clone operations in an owned non-repository bootstrap with empty HOME/XDG state and credential/header-stripped Git configuration
- validate tracked regular-file source citations and carry the first deterministic `{source_path,line}` citation into the canonical provenance record
- require exact provenance keys, canonical JSON serialization, a normalized `codex-rs` path, and a positive integer line; legacy tuple-only and tampered artifacts fail closed
- validate provenance in review-results and apply-result before external OpenClaw mutation or replay
- preserve failed and blocked structured review findings, upload `codex-review.json` only with the preflight artifact, and leave non-OpenClaw behavior unchanged

## Dependency proof

- `codex-rs/exec/src/lib.rs:583-587` routes `ExecCommand::Review` through `build_review_request`
- `codex-rs/exec/src/lib.rs:1775-1803` maps a custom review prompt to `ReviewTarget::Custom`
- `codex-rs/core/src/review_prompts.rs:88-94` uses the supplied custom instructions as the review prompt

## Validation

- focused upload, citation, provenance, findings, and pre-mutation checks: `13/13`
- `npm test`: `585/585`
- `npm run validate`: `6,719` jobs
- workflow YAML parse and upload-block contract
- `git diff --check`

Production and workflow: `+202/-12` (net `+190`). Tests: `+589/-34` (net `+555`).

No report embedding and no schema, package, job, or inventory changes. The only workflow change is the preflight artifact upload entry.
