### PR TITLE
fix(preflight): hydrate authoritative merge evidence

### DIFF
--- a/schemas/codex-result.schema.json
+++ b/schemas/codex-result.schema.json
@@ -201,6 +201,7 @@
           "comments_evidence",
           "bot_comments_status",
           "bot_comments_evidence",
+          "decision_authority",
           "codex_review",
           "validation_commands",
           "base_adoption_manifest"
@@ -255,6 +256,19 @@
             "type": "array",
             "items": {
               "type": "string"
+            }
+          },
+          "decision_authority": {
+            "type": ["object", "null"],
+            "required": ["schema_version", "comment_id", "author_login", "head_sha", "body_sha256", "comment_updated_at"],
+            "additionalProperties": false,
+            "properties": {
+              "schema_version": { "type": "integer", "const": 1 },
+              "comment_id": { "type": "string", "pattern": "^[1-9][0-9]*$" },
+              "author_login": { "type": "string", "pattern": "^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$" },
+              "head_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+              "body_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+              "comment_updated_at": { "type": "string", "minLength": 1 }
             }
           },
           "codex_review": {

--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -970,6 +970,23 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
         ...externalMergeHeadReport(action, expectedHeadSha, effectiveDiffBinding),
       };
     }
+    const finalAuthorityBlock = verifyDecisionAuthority({
+      repo: result.repo,
+      expectedHeadSha,
+      authority: preflight.decision_authority,
+    });
+    if (finalAuthorityBlock) {
+      return withExactMergeRevocation({
+        repo: result.repo,
+        exactMergeCheck,
+        result: {
+          ...base,
+          status: "blocked",
+          reason: finalAuthorityBlock,
+          exact_merge_check: exactMergeCheck,
+        },
+      });
+    }
   }
 
   try {

--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -8,7 +8,9 @@ import { defaultCloseComment, externalMessageProvenance } from "./external-messa
 import {
   COORDINATOR_CHECK_NAMES,
   EXACT_MERGE_CHECK_NAME,
+  matchesDecisionAuthority,
   REQUIRED_CI_GATE_NAME,
+  validateDecisionAuthority,
 } from "./external-merge-checks.mjs";
 import { validateCodexReviewProvenance } from "./codex-review-dependency.mjs";
 import { fetchSettledPullRequestSnapshot as fetchAuthoritativePullRequestSnapshot } from "./pull-request-snapshot.mjs";
@@ -450,6 +452,13 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
   if (action.target_kind !== "pull_request") {
     return { ...base, status: "blocked", reason: "merge action requires pull_request target_kind" };
   }
+  const expectedHeadSha = String(action.expected_head_sha ?? "");
+  if (!/^[0-9a-f]{40}$/i.test(expectedHeadSha)) {
+    return { ...base, status: "blocked", reason: "merge action requires expected_head_sha as a 40-character Git SHA" };
+  }
+  const preflight = findMergePreflight(result, target);
+  const authorityBlock = validateDecisionAuthority(preflight, { expectedHeadSha, allowNonNull: externalMergeAction });
+  if (authorityBlock) return { ...base, status: "blocked", reason: authorityBlock };
 
   let live = fetchIssue(result.repo, target);
   if (!live.pull_request) {
@@ -494,16 +503,6 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
   let pullRequest = initialSnapshot.pull;
   let view = initialSnapshot.view;
   const mergedAt = pullRequest.merged_at ?? view.mergedAt ?? null;
-  const expectedHeadSha = String(action.expected_head_sha ?? "");
-  if (!/^[0-9a-f]{40}$/i.test(expectedHeadSha)) {
-    return {
-      ...base,
-      status: "blocked",
-      reason: "merge action requires expected_head_sha as a 40-character Git SHA",
-      live_state: live.state,
-      live_updated_at: live.updated_at,
-    };
-  }
   const liveHeadSha = String(pullRequest.head?.sha ?? "");
   if (!mergedAt && liveHeadSha !== expectedHeadSha) {
     return {
@@ -873,6 +872,32 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
         ...externalMergeHeadReport(action, expectedHeadSha, effectiveDiffBinding),
       };
     }
+    const mergeState = verifyExactMergeAuthorizationState({
+      result,
+      action,
+      target,
+      expectedHeadSha,
+      mergeHeadSha,
+      effectiveDiffBinding,
+      beforeIssue: checkedIssue,
+      beforePull: checkedPull,
+    });
+    if (mergeState.reason) {
+      return {
+        ...base,
+        status: "blocked",
+        reason: mergeState.reason,
+        retry_recommended: true,
+        live_state: live.state,
+        live_updated_at: live.updated_at,
+        expected_head_sha: expectedHeadSha,
+        effective_diff_sha256: effectiveDiffBinding.live_effective_diff_sha256,
+        verified_main_sha: effectiveDiffBinding.verified_main_sha,
+        current_main_sha: mergeState.current_main_sha ?? null,
+        ci_gate: mergeState.ci_gate ?? ciGate,
+        ...externalMergeHeadReport(action, expectedHeadSha, effectiveDiffBinding),
+      };
+    }
     if (effectiveDiffBinding.base_adoption) {
       persistBaseAdoptionCheckpoint({
         base,
@@ -903,34 +928,20 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
         ...externalMergeHeadReport(action, expectedHeadSha, effectiveDiffBinding),
       };
     }
-    const mergeState = verifyExactMergeAuthorizationState({
-      result,
-      action,
-      target,
+    const authorityBlock = verifyDecisionAuthority({
+      repo: result.repo,
       expectedHeadSha,
-      mergeHeadSha,
-      effectiveDiffBinding,
-      beforeIssue: checkedIssue,
-      beforePull: checkedPull,
+      authority: preflight.decision_authority,
     });
-    if (mergeState.reason) {
+    if (authorityBlock) {
       return withExactMergeRevocation({
         repo: result.repo,
         exactMergeCheck,
         result: {
           ...base,
           status: "blocked",
-          reason: mergeState.reason,
-          retry_recommended: true,
-          live_state: live.state,
-          live_updated_at: live.updated_at,
-          expected_head_sha: expectedHeadSha,
-          effective_diff_sha256: effectiveDiffBinding.live_effective_diff_sha256,
-          verified_main_sha: effectiveDiffBinding.verified_main_sha,
-          current_main_sha: mergeState.current_main_sha ?? null,
-          ci_gate: mergeState.ci_gate ?? ciGate,
+          reason: authorityBlock,
           exact_merge_check: exactMergeCheck,
-          ...externalMergeHeadReport(action, expectedHeadSha, effectiveDiffBinding),
         },
       });
     }
@@ -1275,6 +1286,22 @@ function validateMergePreflight({ result, action, target, expectedHeadSha }) {
   const unresolvedThreadBlock = validateResolvedReviewThreads(result.repo, target);
   if (unresolvedThreadBlock) return unresolvedThreadBlock;
   return "";
+}
+
+function verifyDecisionAuthority({ repo, expectedHeadSha, authority }) {
+  if (authority === null) return "";
+  try {
+    const comment = ghJson(["api", `repos/${repo}/issues/comments/${authority.comment_id}`]);
+    if (!matchesDecisionAuthority(authority, comment, expectedHeadSha)) {
+      return "bound exact-head maintainer decision changed or is invalid";
+    }
+    const permission = ghJson(["api", `repos/${repo}/collaborators/${encodeURIComponent(authority.author_login)}/permission`])?.permission;
+    return ["write", "maintain", "admin"].includes(String(permission ?? "").toLowerCase())
+      ? ""
+      : "bound exact-head decision author lacks current repository permission";
+  } catch (error) {
+    return `could not revalidate exact-head decision authority: ${compactErrorText(commandErrorText(error), 500)}`;
+  }
 }
 
 function validateExternalMergeBindingFields({ action, preflight, expectedHeadSha }) {

--- a/scripts/apply-result.mjs
+++ b/scripts/apply-result.mjs
@@ -11,6 +11,7 @@ import {
   REQUIRED_CI_GATE_NAME,
 } from "./external-merge-checks.mjs";
 import { validateCodexReviewProvenance } from "./codex-review-dependency.mjs";
+import { fetchSettledPullRequestSnapshot as fetchAuthoritativePullRequestSnapshot } from "./pull-request-snapshot.mjs";
 
 const MAINTAINER_AUTHOR_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 const CLOSE_ACTIONS = new Set([
@@ -485,12 +486,13 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
   }
   const metadataDrifted = Boolean(expectedUpdatedAt && expectedUpdatedAt !== live.updated_at);
 
-  let pullRequest = fetchPullRequest(result.repo, target);
-  let view = fetchSettledPullRequestView(
+  const initialSnapshot = fetchSettledPullRequestSnapshot(
     result.repo,
     target,
     externalMergeAction ? { allowedPendingCheckNames: ignoredCheckNames } : {},
   );
+  let pullRequest = initialSnapshot.pull;
+  let view = initialSnapshot.view;
   const mergedAt = pullRequest.merged_at ?? view.mergedAt ?? null;
   const expectedHeadSha = String(action.expected_head_sha ?? "");
   if (!/^[0-9a-f]{40}$/i.test(expectedHeadSha)) {
@@ -529,7 +531,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
         live_state: "merged",
         live_updated_at: live.updated_at,
         merged_at: mergedAt,
-        merge_commit_sha: pullRequest.merge_commit_sha ?? view.mergeCommit?.oid ?? null,
+        merge_commit_sha: pullRequest.merge_commit_sha ?? null,
       };
     }
     const replayBinding = restoreBaseAdoptionBinding({
@@ -551,7 +553,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
         live_state: "merged",
         live_updated_at: live.updated_at,
         merged_at: mergedAt,
-        merge_commit_sha: pullRequest.merge_commit_sha ?? view.mergeCommit?.oid ?? null,
+        merge_commit_sha: pullRequest.merge_commit_sha ?? null,
       };
     }
     const mergedProof = verifyActualMergedCommit({
@@ -571,7 +573,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
         live_state: "merged",
         live_updated_at: live.updated_at,
         merged_at: mergedAt,
-        merge_commit_sha: pullRequest.merge_commit_sha ?? view.mergeCommit?.oid ?? null,
+        merge_commit_sha: pullRequest.merge_commit_sha ?? null,
         reviewed_effective_diff_sha256: mergedProof.reviewed_effective_diff_sha256 ?? null,
         merged_effective_diff_sha256: mergedProof.merged_effective_diff_sha256 ?? null,
       };
@@ -583,7 +585,7 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
       live_state: "merged",
       live_updated_at: live.updated_at,
       merged_at: mergedAt,
-      merge_commit_sha: pullRequest.merge_commit_sha ?? view.mergeCommit?.oid ?? null,
+      merge_commit_sha: pullRequest.merge_commit_sha ?? null,
       effective_diff_sha256: mergedProof?.merged_effective_diff_sha256 ?? null,
       verified_main_sha: mergedProof?.verified_parent_sha ?? null,
       ...externalMergeHeadReport(action, expectedHeadSha, replayBinding),
@@ -802,10 +804,11 @@ function applyMergeAction({ job, result, action, dryRun, allowMissingUpdatedAt, 
     let checkedMainSha;
     try {
       checkedIssue = fetchIssue(result.repo, target);
-      checkedPull = fetchPullRequest(result.repo, target);
-      checkedView = fetchSettledPullRequestView(result.repo, target, {
+      const checkedSnapshot = fetchSettledPullRequestSnapshot(result.repo, target, {
         allowedPendingCheckNames: ignoredCheckNames,
       });
+      checkedPull = checkedSnapshot.pull;
+      checkedView = checkedSnapshot.view;
       checkedMainSha = fetchBranchHeadSha(result.repo, "main");
     } catch (error) {
       return {
@@ -1793,10 +1796,11 @@ function verifyExactMergeAuthorizationState({
       }
     }
     const currentMainSha = fetchBranchHeadSha(result.repo, "main");
-    const currentPull = fetchPullRequest(result.repo, target);
-    const currentView = fetchSettledPullRequestView(result.repo, target, {
+    const currentSnapshot = fetchSettledPullRequestSnapshot(result.repo, target, {
       allowedPendingCheckNames: COORDINATOR_CHECK_NAMES,
     });
+    const currentPull = currentSnapshot.pull;
+    const currentView = currentSnapshot.view;
     const currentIssue = fetchIssue(result.repo, target);
     const metadataBlock = externalMergeMetadataBlock({
       beforeIssue,
@@ -2624,6 +2628,7 @@ function validateMergeablePullRequest({
   allowedPendingCheckNames = [],
   ignoredCheckNames = [],
 }) {
+  if (view?.snapshotBlockReason) return view.snapshotBlockReason;
   if (pullRequest.state !== "open") return `pull request is ${pullRequest.state}`;
   if (pullRequest.draft || view.isDraft) return "pull request is draft";
   if (String(view.baseRefName ?? pullRequest.base?.ref ?? "") !== "main") return "pull request base is not main";
@@ -2890,54 +2895,49 @@ function fetchBranchHeadSha(repo, branch) {
   return String(ref?.object?.sha ?? "");
 }
 
-function fetchPullRequestView(repo, number) {
-  return ghJson([
-    "pr",
-    "view",
-    String(number),
-    "--repo",
-    repo,
-    "--json",
-    [
-      "baseRefName",
-      "isDraft",
-      "mergeable",
-      "mergeCommit",
-      "mergeStateStatus",
-      "mergedAt",
-      "reviewDecision",
-      "state",
-      "statusCheckRollup",
-      "title",
-      "updatedAt",
-      "url",
-    ].join(","),
-  ]);
-}
-
-function fetchSettledPullRequestView(
+function fetchSettledPullRequestSnapshot(
   repo,
   number,
   { allowedPendingCheckNames = [] } = {},
 ) {
   const attempts = positiveInteger(process.env.CLOWNFISH_APPLY_MERGEABLE_POLL_ATTEMPTS, 6);
   const delayMs = nonNegativeInteger(process.env.CLOWNFISH_APPLY_MERGEABLE_POLL_DELAY_MS, 5000);
-  let latest = null;
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    latest = fetchPullRequestView(repo, number);
-    if (
-      !hasUnknownMergeability(latest) &&
-      !hasPendingStatusChecks(latest.statusCheckRollup ?? [], {
+  return fetchAuthoritativePullRequestSnapshot({
+    attempts,
+    delayMs,
+    fetchPullRequest: () => fetchPullRequest(repo, number),
+    fetchPullRequestView: () =>
+      ghJson([
+        "pr",
+        "view",
+        String(number),
+        "--repo",
+        repo,
+        "--json",
+        [
+          "baseRefName",
+          "baseRefOid",
+          "headRefOid",
+          "isDraft",
+          "mergeable",
+          "mergeStateStatus",
+          "mergedAt",
+          "potentialMergeCommit",
+          "reviewDecision",
+          "state",
+          "statusCheckRollup",
+          "title",
+          "updatedAt",
+          "url",
+        ].join(","),
+      ]),
+    hasPendingView: (view) =>
+      hasPendingStatusChecks(view.statusCheckRollup ?? [], {
         allowedPendingCheckNames,
-      })
-    ) {
-      return latest;
-    }
-    if (attempt < attempts && delayMs > 0) {
-      execFileSync("sleep", [String(delayMs / 1000)], { stdio: "ignore" });
-    }
-  }
-  return latest;
+      }),
+    sleep: (ms) =>
+      execFileSync("sleep", [String(ms / 1000)], { stdio: "ignore" }),
+  });
 }
 
 function hasPendingStatusChecks(checks, { allowedPendingCheckNames = [] } = {}) {
@@ -2949,10 +2949,6 @@ function hasPendingStatusChecks(checks, { allowedPendingCheckNames = [] } = {}) 
     const status = String(check.status ?? check.state ?? "").toUpperCase();
     return !["COMPLETED", "SUCCESS", "FAILURE", "ERROR"].includes(status);
   });
-}
-
-function hasUnknownMergeability(view) {
-  return ["", "UNKNOWN"].includes(String(view?.mergeable ?? "").toUpperCase()) || ["", "UNKNOWN"].includes(String(view?.mergeStateStatus ?? "").toUpperCase());
 }
 
 function findExistingComment(repo, number, marker, body) {

--- a/scripts/execute-fix-artifact.mjs
+++ b/scripts/execute-fix-artifact.mjs
@@ -2283,6 +2283,7 @@ function buildMergePreflight({ fixArtifact, codexReview, headSha, baseSha }) {
     target: null,
     head_sha: headSha,
     base_sha: baseSha,
+    decision_authority: null,
     security_status: "cleared",
     security_evidence: ["ProjectClownfish scoped security scan found no security-sensitive fix target, source PR, or fix artifact scope."],
     comments_status: "resolved",

--- a/scripts/external-merge-checks.mjs
+++ b/scripts/external-merge-checks.mjs
@@ -1,9 +1,76 @@
+import { createHash } from "node:crypto";
+import { hasSecuritySensitiveText } from "./security-sensitive.mjs";
+
 export const EXACT_MERGE_CHECK_NAME = "clownfish/exact-merge";
 const DEFAULT_REQUIRED_CI_GATE_NAME = "openclaw/ci-gate";
-export const REQUIRED_CI_GATE_NAME =
-  String(process.env.CLOWNFISH_REQUIRED_CI_GATE_NAME ?? DEFAULT_REQUIRED_CI_GATE_NAME).trim() ||
-  DEFAULT_REQUIRED_CI_GATE_NAME;
-export const COORDINATOR_CHECK_NAMES = Object.freeze([
-  EXACT_MERGE_CHECK_NAME,
-  REQUIRED_CI_GATE_NAME,
-]);
+export const REQUIRED_CI_GATE_NAME = String(process.env.CLOWNFISH_REQUIRED_CI_GATE_NAME ?? DEFAULT_REQUIRED_CI_GATE_NAME).trim() || DEFAULT_REQUIRED_CI_GATE_NAME;
+export const COORDINATOR_CHECK_NAMES = Object.freeze([EXACT_MERGE_CHECK_NAME, REQUIRED_CI_GATE_NAME]);
+
+const DECISION_AUTHORITY_KEYS = "author_login,body_sha256,comment_id,comment_updated_at,head_sha,schema_version";
+const EXACT_DECISION_OBJECTION =
+  /\b(?:not[- ]ready|(?:pause|wait|hold)(?:\s+off)?\b|(?:changes requested|requested changes|needs? changes?)|(?:must|should|needs? to|please)\s+(?:fix|address|resolve)\b|(?:fix|address|resolve)\b.{0,80}\b(?:before|prior to)\s+(?:merge|landing|shipping)|(?:fix|changes?)\s+(?:is|are)?\s*(?:required|needed)|needs?\s+(?:a\s+)?fix|(?:tests?|checks?|ci)\b.{0,40}\b(?:failing|failed|red|broken)|(?:bug|defect|regression|failure|risk|concern|issue)\b.{0,80}\b(?:remains?|persists?|unresolved|unfixed|open|present)|(?:unresolved|unfixed|remaining|open)\b.{0,50}\b(?:bug|defect|regression|failure|risk|concern|issue)|still\s+(?:fails?|broken)|(?:is|are|remains?)\s+(?:still\s+)?broken|(?:withdrawn|withdrew|withdraw|abandon(?:ed|ing)?|cancel(?:ed|led|ing)?)\b|(?:close|stop)\b.{0,30}\b(?:pr|pull request|merge|landing|shipping|work))\b/i;
+const EXPLICIT_MERGE_OBJECTION_PATTERNS = [
+  /\b(?:maintainers?\s+|please\s+)?(?:do not|don't|must not|mustn't|should not|shouldn't|cannot|can't)\s+(?:proceed with (?:the )?)?(?:merge|merging|land|landing|ship|shipping)\b/,
+  /\b(?:(?:(?:this|the)\s+)?(?:pr|pull request|patch|change)|this|it)\s+(?:must not|mustn't|should not|shouldn't|cannot|can't)\s+be\s+(?:merged|landed|shipped)\b/,
+  /\b(?:this|it|(?:this|the) (?:pr|pull request|patch|change))\s+is\s+(?:not safe|unsafe)\s+to\s+(?:merge|land|ship)\b/,
+  /\bnot ready to\s+(?:merge|land|ship)\b/,
+  /\bhold (?:the )?(?:merge|landing|shipping)\s+until\b/,
+  /\b(?:the )?(?:pr|pull request|patch|change)\s+remains\s+blocked\b/,
+  /\b(?:merge|merging|landing|shipping)\s+(?:is\s+)?(?:still\s+)?(?:blocked|forbidden|not allowed)\b/,
+  /\b(?:merge|merging|landing|shipping)\s+remains\s+blocked\b/,
+  /\b(?:merge|merging|landing|shipping)\s+(?:cannot|can't|must not|mustn't|should not|shouldn't)\s+(?:proceed|continue)\b/,
+  /\b(?:merge|merging|landing|shipping)\s+(?:must|should)\s+(?:wait|be delayed|remain blocked)\b/,
+  /\b(?:pending|awaiting)\s+(?:(?:maintainer|policy|risk)\s+){1,2}(?:decision|approval|acceptance)\b/,
+  /\b(?:maintainer|policy|risk)(?:\s+(?:policy|risk))?\s+(?:decision|approval|acceptance)\s+(?:is\s+)?(?:still\s+)?(?:pending|unresolved)\b/,
+  /\b(?:maintainer|policy|risk)(?:\s+(?:policy|risk))?\s+(?:decision|approval|acceptance)\s+(?:is\s+)?required before (?:merge|merging|landing|shipping)\b/,
+];
+
+export function hasExplicitMergeObjection(body, { ignoreLine = null } = {}) {
+  return String(body).split(/\r?\n/).map((line) => line.trim().replace(/^[-*]\s+/, "").replace(/^#{1,6}\s*/, ""))
+    .filter(Boolean).some((line) => !ignoreLine?.(line) && EXPLICIT_MERGE_OBJECTION_PATTERNS.some((pattern) => pattern.test(line)));
+}
+
+function isExactDecisionBody(body, headSha) {
+  const normalized = body.trim().toLowerCase();
+  return !hasSecuritySensitiveText(body) && !hasExplicitMergeObjection(normalized) && !EXACT_DECISION_OBJECTION.test(normalized) &&
+    normalized.match(/^maintainer decision for `([0-9a-f]{40})`:\s*(?:accept(?:ed|ing)?|approv(?:ed|ing)?)\b/)?.[1] === String(headSha ?? "").toLowerCase() &&
+    /\bno (?:branch )?repair,\s*(?:no )?rebase,\s*(?:or|and)\s*(?:no )?replacement (?:pr|pull request)(?: is)? requested\b/.test(normalized);
+}
+
+export function exactDecisionAuthority(comment, headSha) {
+  const body = String(comment?.body ?? "");
+  if (!isExactDecisionBody(body, headSha)) return null;
+  return {
+    schema_version: 1,
+    comment_id: String(comment?.databaseId ?? comment?.id ?? ""),
+    author_login: String(comment?.author?.login ?? comment?.user?.login ?? "").toLowerCase(),
+    head_sha: String(headSha ?? "").toLowerCase(),
+    body_sha256: createHash("sha256").update(body).digest("hex"),
+    comment_updated_at: String(comment?.updatedAt ?? comment?.updated_at ?? ""),
+  };
+}
+
+export function validateDecisionAuthority(preflight, { expectedHeadSha, allowNonNull }) {
+  if (!Object.hasOwn(preflight ?? {}, "decision_authority")) return "merge_preflight.decision_authority is required";
+  const authority = preflight.decision_authority;
+  if (authority === null) return "";
+  if (!allowNonNull) return "worker-authored merge_preflight.decision_authority must be null";
+  if (!authority || typeof authority !== "object" || Array.isArray(authority) ||
+      Object.keys(authority).sort().join() !== DECISION_AUTHORITY_KEYS) {
+    return "merge_preflight.decision_authority has invalid fields";
+  }
+  if (authority.schema_version !== 1 ||
+    !/^[1-9][0-9]*$/.test(authority.comment_id) ||
+    !/^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/.test(authority.author_login) ||
+    !/^[0-9a-f]{40}$/.test(authority.head_sha) ||
+    !/^[0-9a-f]{64}$/.test(authority.body_sha256) ||
+    !Number.isFinite(Date.parse(authority.comment_updated_at))) return "merge_preflight.decision_authority is malformed";
+  return authority.head_sha === String(expectedHeadSha ?? "").toLowerCase()
+    ? ""
+    : "merge_preflight.decision_authority head_sha does not match expected head";
+}
+
+export function matchesDecisionAuthority(authority, comment, expectedHeadSha) {
+  const live = exactDecisionAuthority(comment, expectedHeadSha);
+  return live !== null && Object.entries(live).every(([key, value]) => authority[key] === value);
+}

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -769,6 +769,7 @@ function readOnlyBlockers({
   if (view?.snapshotBlockReason) blockers.push(view.snapshotBlockReason);
   const trustedAuthorEvidenceApprovalAt = trustedAuthorEvidenceApprovalTimestamp(issueComments, { pull });
   const trustedAuthorProgressApprovalAt = trustedAuthorProgressApprovalTimestamp(issueComments, { pull });
+  const trustedExactHeadDecision = trustedExactHeadDecisionState(issueComments, { pull, view });
   const hasExactHeadClawSweeperReviewStart = issueComments.some((comment) => {
     const author = String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase();
     return isClawSweeperReviewStartComment({ author, body: comment.body, pull });
@@ -801,6 +802,7 @@ function readOnlyBlockers({
             view,
             trustedAuthorEvidenceApprovalAt,
             trustedAuthorProgressApprovalAt,
+            trustedExactHeadDecision,
           }),
       )
       .map((comment) => comment.body),
@@ -841,6 +843,7 @@ function readOnlyBlockers({
         view,
         trustedAuthorEvidenceApprovalAt,
         trustedAuthorProgressApprovalAt,
+        trustedExactHeadDecision,
       }),
   );
   if (actionableIssueComments.length > 0) {
@@ -2469,7 +2472,7 @@ function isReviewBot(review) {
 
 function isActionableCommentEvidence(
   comment,
-  { pull, view = null, trustedAuthorEvidenceApprovalAt = null, trustedAuthorProgressApprovalAt = null },
+  { pull, view = null, trustedAuthorEvidenceApprovalAt = null, trustedAuthorProgressApprovalAt = null, trustedExactHeadDecision = null },
 ) {
   if (
     isNonBlockingCommentEvidence(comment, {
@@ -2477,6 +2480,7 @@ function isActionableCommentEvidence(
       view,
       trustedAuthorEvidenceApprovalAt,
       trustedAuthorProgressApprovalAt,
+      trustedExactHeadDecision,
     })
   ) {
     return false;
@@ -2506,7 +2510,7 @@ function isActionableCommentEvidence(
 
 function isNonBlockingCommentEvidence(
   comment,
-  { pull, view = null, trustedAuthorEvidenceApprovalAt = null, trustedAuthorProgressApprovalAt = null },
+  { pull, view = null, trustedAuthorEvidenceApprovalAt = null, trustedAuthorProgressApprovalAt = null, trustedExactHeadDecision = null },
 ) {
   if (comment.isMinimized === true || comment.is_minimized === true) return true;
   const body = String(comment.body ?? "").trim();
@@ -2515,6 +2519,7 @@ function isNonBlockingCommentEvidence(
   const association = String(comment.author_association ?? comment.authorAssociation ?? "").toUpperCase();
   const normalized = body.toLowerCase();
 
+  if (isSupersededRepairOutcome(comment, { pull, trustedExactHeadDecision })) return true;
   if (isBenignAutomationComment({ author, body: normalized, pull, view })) return true;
   if (
     String(comment.state ?? "").toUpperCase() === "APPROVED" &&
@@ -2525,11 +2530,11 @@ function isNonBlockingCommentEvidence(
   if (isMaintainerCommandComment({ association, body: normalized })) return true;
   if (isMaintainerApprovalComment({ association, body: normalized })) return true;
   if (
-    isMaintainerDecisionApprovalComment({
-      association,
-      body: normalized,
+    isMaintainerDecisionApprovalComment(comment, {
+      pull,
       view,
       trustedAuthorProgressApprovalAt,
+      trustedExactHeadDecision,
     })
   ) {
     return true;
@@ -2668,16 +2673,31 @@ function isMaintainerApprovalComment({ association, body }) {
   );
 }
 
-function isMaintainerDecisionApprovalComment({
-  association,
-  body,
-  view = null,
-  trustedAuthorProgressApprovalAt = null,
-}) {
+function isMaintainerDecisionApprovalComment(
+  comment,
+  { pull, view = null, trustedAuthorProgressApprovalAt = null, trustedExactHeadDecision = null },
+) {
+  const association = String(comment.author_association ?? comment.authorAssociation ?? "").toUpperCase();
+  const body = String(comment.body ?? "").trim().toLowerCase();
   if (!["MEMBER", "OWNER", "COLLABORATOR"].includes(association)) return false;
-  if (!Number.isFinite(trustedAuthorProgressApprovalAt)) return false;
-  if (!/^maintainer decision:\s*(?:accept(?:ed|ing)?|approv(?:ed|ing)?)\b/.test(body)) return false;
-  return !isAuthorObjectionComment(body) && !hasExplicitMergeObjection(body, { view });
+  if (isExactHeadMaintainerDecision(comment, { pull, view }))
+    return commentTimestamp(comment) > (trustedExactHeadDecision?.reviewAt ?? Number.POSITIVE_INFINITY);
+  return (
+    Number.isFinite(trustedAuthorProgressApprovalAt) &&
+    /^maintainer decision:\s*(?:accept(?:ed|ing)?|approv(?:ed|ing)?)\b/.test(body) &&
+    !isAuthorObjectionComment(body) &&
+    !hasExplicitMergeObjection(body, { view })
+  );
+}
+
+function isExactHeadMaintainerDecision(comment, { pull, view = null }) {
+  const body = String(comment.body ?? "").trim().toLowerCase();
+  return (
+    ["MEMBER", "OWNER", "COLLABORATOR"].includes(String(comment.author_association ?? comment.authorAssociation ?? "").toUpperCase()) &&
+    body.match(/^maintainer decision for `([0-9a-f]{40})`:\s*(?:accept(?:ed|ing)?|approv(?:ed|ing)?)\b/)?.[1] === String(pull?.head?.sha ?? "").toLowerCase() &&
+    /\bno (?:branch )?repair,\s*(?:no )?rebase,\s*(?:or|and)\s*(?:no )?replacement (?:pr|pull request)(?: is)? requested\b/.test(body) &&
+    !isAuthorObjectionComment(body) && !hasExplicitMergeObjection(body, { view })
+  );
 }
 
 function isMaintainerProofOrStatusComment({ association, author, body }) {
@@ -2942,6 +2962,21 @@ function trustedAuthorProgressApprovalTimestamp(comments, { pull }) {
     .map(commentTimestamp)
     .filter(Number.isFinite);
   return timestamps.length > 0 ? Math.max(...timestamps) : null;
+}
+
+function trustedExactHeadDecisionState(comments, { pull, view }) {
+  const reviewAt = Math.max(
+    ...comments.filter((comment) => {
+      const body = String(comment.body ?? "").toLowerCase();
+      return isTrustedExactHeadReadyReviewComment(comment, { pull }) &&
+        /\|\s*\*\*findings\*\*\s*\|\s*none\s*\|/.test(body) &&
+        /\|\s*\*\*security\*\*\s*\|\s*none\s*\|/.test(body);
+    }).map(commentTimestamp).filter(Number.isFinite),
+  );
+  if (!Number.isFinite(reviewAt)) return null;
+  const decisionAt = Math.max(...comments.filter((comment) => isExactHeadMaintainerDecision(comment, { pull, view }))
+    .map(commentTimestamp).filter((timestamp) => Number.isFinite(timestamp) && timestamp > reviewAt));
+  return { reviewAt, decisionAt: Number.isFinite(decisionAt) ? decisionAt : null };
 }
 
 function isCommentCoveredByTrustedApproval(comment, trustedAuthorEvidenceApprovalAt) {
@@ -3359,6 +3394,25 @@ function hasInvertedProofEvidence(body) {
     });
 }
 
+function isSupersededRepairOutcome(comment, { pull, trustedExactHeadDecision }) {
+  const timestamp = commentTimestamp(comment);
+  if (!Number.isFinite(timestamp) || !Number.isFinite(trustedExactHeadDecision?.decisionAt) || timestamp >= trustedExactHeadDecision.decisionAt) return false;
+  const association = String(comment.author_association ?? comment.authorAssociation ?? "").toUpperCase();
+  const body = String(comment.body ?? "").trim();
+  const lines = body.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const marker = lines[0]?.match(/^<!-- clownfish-repair-outcome:([^:\s>]+):([^:\s>]+):#(\d+) -->$/), pullNumber = String(pull?.number ?? "");
+  if (!["MEMBER", "OWNER", "COLLABORATOR"].includes(association) || (body.match(/<!--\s*clownfish-repair-outcome:/g) ?? []).length !== 1 ||
+      marker?.[3] !== pullNumber || !marker[1].endsWith(`-${pullNumber}`) || !marker[2].startsWith(`${marker[1]}-autonomous-`)) return false;
+  const actions = lines.map((line) => line.match(/^- `([^`]+)` on `([^`]+)`: ([a-z_]+)(?: - .+)?$/)).filter(Boolean);
+  const fixActions = actions.filter((action) => action[1] === "fix_needed" && action[2] === `#${pullNumber}` && action[3] === "planned");
+  const artifactActions = actions.filter((action) => action[1] === "build_fix_artifact" && action[2] === `cluster:${marker[1]}` && action[3] === "planned");
+  const terminal = lines.some((line) => /^(?:clownfish left the pr as-is:\s*)?no push,\s*(?:no\s+)?rebase,\s*(?:no\s+)?replacement pr,\s*(?:no\s+)?merge,\s*(?:and|or)\s*(?:no\s+)?(?:fresh\s+)?clawsweeper (?:re-review|pass)\b/i.test(line));
+  return lines.filter((line) => line === `Target: #${pullNumber}`).length === 1 &&
+    actions.length === 2 && fixActions.length === 1 && artifactActions.length === 1 && terminal &&
+    !hasOpenIssueStatement(body) && !hasExplicitMergeObjection(body.toLowerCase()) && !hasBlockingRepairOutcomeRisk(body);
+}
+
+function hasBlockingRepairOutcomeRisk(body) { return /\[(?:P|S)[0-3]\]\s|\b(?:requested changes|changes requested|not safe to (?:merge|land|ship)|(?:checks?|ci)\b.{0,40}\b(?:failing|failed|red|broken)|security\b.{0,60}\b(?:concern|issue|risk|exposure|vulnerability)|dependency\b.{0,80}\b(?:concern|issue|risk|unresolved)|withdraw|withdrew|withdrawn|abandon|abandoned|cancel|cancelled|(?:stop|close)\s+(?:this|the)\s+(?:pr|pull request)|(?:unresolved|unfixed|remaining|known|open)\s+(?:\w+\s+){0,3}(?:defect|bug|regression|failure)|(?:defect|bug|regression|failure)\b.{0,80}\b(?:remains?|persists?|unresolved|unfixed|open|present)|(?:is|are|remains?|stays?)\s+(?:an?\s+)?(?:defect|bug|regression|failure|broken)|still\s+fails?|continues?\s+to\s+fail|(?:is|are)\s+still\s+broken)\b/i.test(body); }
 function commentTimestamp(comment) {
   const value = Date.parse(
     String(comment.updated_at ?? comment.updatedAt ?? comment.created_at ?? comment.createdAt ?? ""),

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -10,7 +10,7 @@ import {
   isValidationDriftControlFile,
 } from "./base-drift-validation.mjs";
 import { hasSecuritySensitiveText } from "./security-sensitive.mjs";
-import { COORDINATOR_CHECK_NAMES } from "./external-merge-checks.mjs";
+import { COORDINATOR_CHECK_NAMES, exactDecisionAuthority, hasExplicitMergeObjection as hasClosedExplicitMergeObjection } from "./external-merge-checks.mjs";
 import {
   CODEX_REVIEW_DEPENDENCY,
   CODEX_REVIEW_PROVENANCE,
@@ -39,6 +39,7 @@ const ADOPTION_POLICY = "bounded-fast-forward-v1";
 const MAX_ADOPTION_MANIFEST_BLOBS = 2048;
 const MAINTAINER_REPOSITORY_PERMISSIONS = new Set(["write", "maintain", "admin"]);
 const collaboratorPermissionCache = new Map();
+let decisionAuthorityBinding = null;
 const args = parseArgs(process.argv.slice(2));
 const sourceJobPath = args._[0];
 const pullRequest = Number(args.pr ?? args["pull-request"]);
@@ -766,6 +767,7 @@ function readOnlyBlockers({
   threads: hydratedThreads = null,
 }) {
   collaboratorPermissionCache.clear();
+  decisionAuthorityBinding = null;
   const blockers = view?.snapshotBlockReason ? [view.snapshotBlockReason] : [];
   const trustedAuthorEvidenceApprovalAt = trustedAuthorEvidenceApprovalTimestamp(issueComments, { pull });
   const trustedAuthorProgressApprovalAt = trustedAuthorProgressApprovalTimestamp(issueComments, { pull });
@@ -2281,6 +2283,7 @@ function buildMergeResult({
         synthetic_merge_tree_sha: reviewContext.mergeTreeSha,
         effective_diff_sha256: reviewContext.effectiveDiffSha256,
         effective_diff_files: reviewContext.effectiveDiffFiles,
+        decision_authority: decisionAuthorityBinding,
         security_status: "cleared",
         security_evidence: [
           "Final deterministic security scan after validation and Codex review found no matching signal in the PR title, body, labels, issue comments, reviews, or inline review comments.",
@@ -2353,6 +2356,7 @@ function fetchIssueComments({ repo, pullRequest }) {
         pullRequest(number: $number) {
           comments(first: 100) {
             nodes {
+              databaseId
               author { login }
               authorAssociation
               body
@@ -2690,14 +2694,9 @@ function isMaintainerDecisionApprovalComment(
   );
 }
 
-function isExactHeadMaintainerDecision(comment, { pull, view = null }) {
-  const body = String(comment.body ?? "").trim().toLowerCase();
-  return (
-    body.match(/^maintainer decision for `([0-9a-f]{40})`:\s*(?:accept(?:ed|ing)?|approv(?:ed|ing)?)\b/)?.[1] === String(pull?.head?.sha ?? "").toLowerCase() &&
-    /\bno (?:branch )?repair,\s*(?:no )?rebase,\s*(?:or|and)\s*(?:no )?replacement (?:pr|pull request)(?: is)? requested\b/.test(body) &&
-    !isAuthorObjectionComment(body) && !hasExplicitMergeObjection(body, { view }) &&
-    MAINTAINER_REPOSITORY_PERMISSIONS.has(fetchCollaboratorPermission(String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase()))
-  );
+function isExactHeadMaintainerDecision(comment, { pull }) {
+  return exactDecisionAuthority(comment, pull?.head?.sha) !== null &&
+    MAINTAINER_REPOSITORY_PERMISSIONS.has(fetchCollaboratorPermission(String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase()));
 }
 
 function isMaintainerProofOrStatusComment({ association, author, body }) {
@@ -2875,30 +2874,9 @@ function reviewSection(body, heading) {
 }
 
 function hasExplicitMergeObjection(body, { view = null } = {}) {
-  return String(body)
-    .split(/\r?\n/)
-    .map((line) => line.trim().replace(/^[-*]\s+/, "").replace(/^#{1,6}\s*/, ""))
-    .filter(Boolean)
-    .some((line) => {
-      if (isNegatedOrResolvedMergeObjection(line, { view })) return false;
-      return [
-        /\b(?:maintainers?\s+)?(?:do not|don't|must not|mustn't|should not|shouldn't|cannot|can't)\s+(?:merge|land|ship)\b/,
-        /\b(?:this|the)?\s*(?:pr|patch|change)\s+(?:must not|mustn't|should not|shouldn't|cannot|can't)\s+be\s+(?:merged|landed|shipped)\b/,
-        /\b(?:do not|don't|must not|mustn't)\s+proceed with (?:the )?(?:merge|landing|shipping)\b/,
-        /\b(?:this|it|the (?:pr|patch|change))\s+is\s+not safe to\s+(?:merge|land|ship)\b/,
-        /\b(?:this|it|the (?:pr|patch|change))\s+is\s+unsafe to\s+(?:merge|land|ship)\b/,
-        /\bnot ready to\s+(?:merge|land|ship)\b/,
-        /\bhold (?:the )?(?:merge|landing|shipping)\s+until\b/,
-        /\b(?:the )?(?:pr|patch|change)\s+remains\s+blocked\b/,
-        /\b(?:merge|merging|landing|shipping)\s+(?:is\s+)?(?:still\s+)?(?:blocked|not allowed)\b/,
-        /\b(?:merge|merging|landing|shipping)\s+remains\s+blocked\b/,
-        /\b(?:merge|merging|landing|shipping)\s+(?:cannot|can't|must not|mustn't|should not|shouldn't)\s+(?:proceed|continue)\b/,
-        /\b(?:merge|merging|landing|shipping)\s+(?:must|should)\s+(?:wait|be delayed|remain blocked)\b/,
-        /\b(?:pending|awaiting)\s+(?:(?:maintainer|policy|risk)\s+){1,2}(?:decision|approval|acceptance)\b/,
-        /\b(?:maintainer|policy|risk)(?:\s+(?:policy|risk))?\s+(?:decision|approval|acceptance)\s+(?:is\s+)?(?:still\s+)?(?:pending|unresolved)\b/,
-        /\b(?:maintainer|policy|risk)(?:\s+(?:policy|risk))?\s+(?:decision|approval|acceptance)\s+(?:is\s+)?required before (?:merge|merging|landing|shipping)\b/,
-      ].some((pattern) => pattern.test(line));
-    });
+  return hasClosedExplicitMergeObjection(body, {
+    ignoreLine: (line) => isNegatedOrResolvedMergeObjection(line, { view }),
+  });
 }
 
 function isNegatedOrResolvedMergeObjection(line, { view = null } = {}) {
@@ -2974,9 +2952,11 @@ function trustedExactHeadDecisionState(comments, { pull, view }) {
     }).map(commentTimestamp).filter(Number.isFinite),
   );
   if (!Number.isFinite(reviewAt)) return null;
-  const decisionAt = Math.max(...comments.filter((comment) => isExactHeadMaintainerDecision(comment, { pull, view }))
-    .map(commentTimestamp).filter((timestamp) => Number.isFinite(timestamp) && timestamp > reviewAt));
-  return { reviewAt, decisionAt: Number.isFinite(decisionAt) ? decisionAt : null };
+  const decisionComment = comments
+    .filter((comment) => isExactHeadMaintainerDecision(comment, { pull, view }))
+    .filter((comment) => commentTimestamp(comment) > reviewAt)
+    .sort((left, right) => commentTimestamp(right) - commentTimestamp(left))[0];
+  return { reviewAt, decisionAt: commentTimestamp(decisionComment), decisionComment };
 }
 
 function isCommentCoveredByTrustedApproval(comment, trustedAuthorEvidenceApprovalAt) {
@@ -3407,15 +3387,17 @@ function isSupersededRepairOutcome(comment, { pull, trustedExactHeadDecision }) 
   const fixActions = actions.filter((action) => action[1] === "fix_needed" && action[2] === `#${pullNumber}` && action[3] === "planned");
   const artifactActions = actions.filter((action) => action[1] === "build_fix_artifact" && action[2] === `cluster:${marker[1]}` && action[3] === "planned");
   const terminal = lines.some((line) => /^(?:clownfish left the pr as-is:\s*)?no push,\s*(?:no\s+)?rebase,\s*(?:no\s+)?replacement pr,\s*(?:no\s+)?merge,\s*(?:and|or)\s*(?:no\s+)?(?:fresh\s+)?clawsweeper (?:re-review|pass)\b/i.test(line));
-  return lines.filter((line) => line === `Target: #${pullNumber}`).length === 1 &&
+  const superseded = lines.filter((line) => line === `Target: #${pullNumber}`).length === 1 &&
     actions.length === 2 && fixActions.length === 1 && artifactActions.length === 1 && terminal &&
     !hasOpenIssueStatement(body) && !hasExplicitMergeObjection(body.toLowerCase()) && !hasBlockingRepairOutcomeRisk(body);
+  if (superseded) decisionAuthorityBinding ??= exactDecisionAuthority(trustedExactHeadDecision.decisionComment, pull.head.sha);
+  return superseded;
 }
 
 function hasBlockingRepairOutcomeRisk(body) { return /\[(?:P|S)[0-3]\]\s|\b(?:requested changes|changes requested|not safe to (?:merge|land|ship)|(?:checks?|ci)\b.{0,40}\b(?:failing|failed|red|broken)|security\b.{0,60}\b(?:concern|issue|risk|exposure|vulnerability)|dependency\b.{0,80}\b(?:concern|issue|risk|unresolved)|withdraw|withdrew|withdrawn|abandon|abandoned|cancel|cancelled|(?:stop|close)\s+(?:this|the)\s+(?:pr|pull request)|(?:unresolved|unfixed|remaining|known|open)\s+(?:\w+\s+){0,3}(?:defect|bug|regression|failure)|(?:defect|bug|regression|failure)\b.{0,80}\b(?:remains?|persists?|unresolved|unfixed|open|present)|(?:is|are|remains?|stays?)\s+(?:an?\s+)?(?:defect|bug|regression|failure|broken)|still\s+fails?|continues?\s+to\s+fail|(?:is|are)\s+still\s+broken)\b/i.test(body); }
 function commentTimestamp(comment) {
   const value = Date.parse(
-    String(comment.updated_at ?? comment.updatedAt ?? comment.created_at ?? comment.createdAt ?? ""),
+    String(comment?.updated_at ?? comment?.updatedAt ?? comment?.created_at ?? comment?.createdAt ?? ""),
   );
   return Number.isFinite(value) ? value : Number.NaN;
 }

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -765,8 +765,8 @@ function readOnlyBlockers({
   reviewComments: hydratedReviewComments = null,
   threads: hydratedThreads = null,
 }) {
-  const blockers = [];
-  if (view?.snapshotBlockReason) blockers.push(view.snapshotBlockReason);
+  collaboratorPermissionCache.clear();
+  const blockers = view?.snapshotBlockReason ? [view.snapshotBlockReason] : [];
   const trustedAuthorEvidenceApprovalAt = trustedAuthorEvidenceApprovalTimestamp(issueComments, { pull });
   const trustedAuthorProgressApprovalAt = trustedAuthorProgressApprovalTimestamp(issueComments, { pull });
   const trustedExactHeadDecision = trustedExactHeadDecisionState(issueComments, { pull, view });
@@ -2679,9 +2679,9 @@ function isMaintainerDecisionApprovalComment(
 ) {
   const association = String(comment.author_association ?? comment.authorAssociation ?? "").toUpperCase();
   const body = String(comment.body ?? "").trim().toLowerCase();
-  if (!["MEMBER", "OWNER", "COLLABORATOR"].includes(association)) return false;
   if (isExactHeadMaintainerDecision(comment, { pull, view }))
     return commentTimestamp(comment) > (trustedExactHeadDecision?.reviewAt ?? Number.POSITIVE_INFINITY);
+  if (!["MEMBER", "OWNER", "COLLABORATOR"].includes(association)) return false;
   return (
     Number.isFinite(trustedAuthorProgressApprovalAt) &&
     /^maintainer decision:\s*(?:accept(?:ed|ing)?|approv(?:ed|ing)?)\b/.test(body) &&
@@ -2693,10 +2693,10 @@ function isMaintainerDecisionApprovalComment(
 function isExactHeadMaintainerDecision(comment, { pull, view = null }) {
   const body = String(comment.body ?? "").trim().toLowerCase();
   return (
-    ["MEMBER", "OWNER", "COLLABORATOR"].includes(String(comment.author_association ?? comment.authorAssociation ?? "").toUpperCase()) &&
     body.match(/^maintainer decision for `([0-9a-f]{40})`:\s*(?:accept(?:ed|ing)?|approv(?:ed|ing)?)\b/)?.[1] === String(pull?.head?.sha ?? "").toLowerCase() &&
     /\bno (?:branch )?repair,\s*(?:no )?rebase,\s*(?:or|and)\s*(?:no )?replacement (?:pr|pull request)(?: is)? requested\b/.test(body) &&
-    !isAuthorObjectionComment(body) && !hasExplicitMergeObjection(body, { view })
+    !isAuthorObjectionComment(body) && !hasExplicitMergeObjection(body, { view }) &&
+    MAINTAINER_REPOSITORY_PERMISSIONS.has(fetchCollaboratorPermission(String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase()))
   );
 }
 

--- a/scripts/preflight-external-pr-merge.mjs
+++ b/scripts/preflight-external-pr-merge.mjs
@@ -17,6 +17,7 @@ import {
   codexReviewProvenanceEvidence,
   validateCodexReviewSourceEvidence,
 } from "./codex-review-dependency.mjs";
+import { fetchSettledPullRequestSnapshot as fetchAuthoritativePullRequestSnapshot } from "./pull-request-snapshot.mjs";
 
 const PASSING_CHECK_CONCLUSIONS = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"]);
 const CLEAN_MERGE_STATES = new Set(["CLEAN"]);
@@ -148,12 +149,18 @@ let report = {
 };
 
 try {
-  pull = stage("hydrate GitHub state", () => ghJson(["api", `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}`]));
+  const initialSnapshot = stage("hydrate settled GitHub state", () =>
+    fetchSettledPullRequestSnapshot({
+      repo: sourceJob.frontmatter.repo,
+      pullRequest,
+    }),
+  );
+  pull = initialSnapshot.pull;
+  view = initialSnapshot.view;
   issue = stage("hydrate issue state", () => ghJson(["api", `repos/${sourceJob.frontmatter.repo}/issues/${pullRequest}`]));
   const issueComments = stage("hydrate issue comments", () =>
     fetchIssueComments({ repo: sourceJob.frontmatter.repo, pullRequest }),
   );
-  view = stage("poll mergeability", () => fetchSettledPullRequestView({ repo: sourceJob.frontmatter.repo, pullRequest }));
 
   const virtualJob = writePreflightJob({ sourceJob, pull, pullRequest, runDir });
   preflightJobPath = virtualJob.path;
@@ -264,17 +271,19 @@ try {
   let verifiedMainSha = reviewContext.reviewedBaseSha;
   let pendingApplyAdoption = null;
   for (let attempt = 0; attempt <= maxBaseRevalidations; attempt += 1) {
-    refreshedPull = stage("rehydrate GitHub state after review", () =>
-      ghJson(["api", `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}`]),
+    const refreshedSnapshot = stage("rehydrate settled GitHub state after review", () =>
+      fetchSettledPullRequestSnapshot({
+        repo: sourceJob.frontmatter.repo,
+        pullRequest,
+      }),
     );
+    refreshedPull = refreshedSnapshot.pull;
+    refreshedView = refreshedSnapshot.view;
     refreshedIssue = stage("rehydrate issue state after review", () =>
       ghJson(["api", `repos/${sourceJob.frontmatter.repo}/issues/${pullRequest}`]),
     );
     const refreshedIssueComments = stage("rehydrate issue comments after review", () =>
       fetchIssueComments({ repo: sourceJob.frontmatter.repo, pullRequest }),
-    );
-    refreshedView = stage("poll mergeability after review", () =>
-      fetchSettledPullRequestView({ repo: sourceJob.frontmatter.repo, pullRequest }),
     );
     const finalBlockers = stage("final read-only blockers", () => [
       ...(refreshedPull.head?.sha !== reviewedHeadSha
@@ -725,30 +734,26 @@ function sourceJobPermissions(job) {
   };
 }
 
-function fetchSettledPullRequestView({ repo, pullRequest }) {
+function fetchSettledPullRequestSnapshot({ repo, pullRequest }) {
   const attempts = positiveInteger(process.env.CLOWNFISH_MERGEABLE_POLL_ATTEMPTS, 6);
   const delayMs = nonNegativeInteger(process.env.CLOWNFISH_MERGEABLE_POLL_DELAY_MS, 5000);
-  let latest = null;
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    latest = ghJson([
+  return fetchAuthoritativePullRequestSnapshot({
+    attempts,
+    delayMs,
+    fetchPullRequest: () =>
+      ghJson(["api", `repos/${repo}/pulls/${pullRequest}`]),
+    fetchPullRequestView: () =>
+      ghJson([
       "pr",
       "view",
       String(pullRequest),
       "--repo",
       repo,
       "--json",
-      "comments,headRefOid,isDraft,mergeStateStatus,mergeable,reviewDecision,reviews,statusCheckRollup,updatedAt,url",
-    ]);
-    if (!hasUnknownMergeability(latest)) return latest;
-    if (attempt < attempts && delayMs > 0) {
-      run("sleep", [String(delayMs / 1000)]);
-    }
-  }
-  return latest;
-}
-
-function hasUnknownMergeability(view) {
-  return ["", "UNKNOWN"].includes(String(view?.mergeable ?? "").toUpperCase()) || ["", "UNKNOWN"].includes(String(view?.mergeStateStatus ?? "").toUpperCase());
+      "baseRefOid,comments,headRefOid,isDraft,mergeStateStatus,mergeable,potentialMergeCommit,reviewDecision,reviews,statusCheckRollup,updatedAt,url",
+      ]),
+    sleep: (ms) => run("sleep", [String(ms / 1000)]),
+  });
 }
 
 function readOnlyBlockers({
@@ -761,6 +766,7 @@ function readOnlyBlockers({
   threads: hydratedThreads = null,
 }) {
   const blockers = [];
+  if (view?.snapshotBlockReason) blockers.push(view.snapshotBlockReason);
   const trustedAuthorEvidenceApprovalAt = trustedAuthorEvidenceApprovalTimestamp(issueComments, { pull });
   const trustedAuthorProgressApprovalAt = trustedAuthorProgressApprovalTimestamp(issueComments, { pull });
   const hasExactHeadClawSweeperReviewStart = issueComments.some((comment) => {
@@ -1389,10 +1395,12 @@ function captureFreshAdoptionGithubState({
       throw new Error(`${label} SHA is missing or invalid`);
     }
   }
-  const pull = ghJson([
-    "api",
-    `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}`,
-  ]);
+  const snapshot = fetchSettledPullRequestSnapshot({
+    repo: sourceJob.frontmatter.repo,
+    pullRequest,
+  });
+  const pull = snapshot.pull;
+  const view = snapshot.view;
   const issue = ghJson([
     "api",
     `repos/${sourceJob.frontmatter.repo}/issues/${pullRequest}`,
@@ -1406,10 +1414,6 @@ function captureFreshAdoptionGithubState({
     `repos/${sourceJob.frontmatter.repo}/pulls/${pullRequest}/comments?per_page=100`,
   ]);
   const threads = fetchReviewThreads({
-    repo: sourceJob.frontmatter.repo,
-    pullRequest,
-  });
-  const view = fetchSettledPullRequestView({
     repo: sourceJob.frontmatter.repo,
     pullRequest,
   });

--- a/scripts/pull-request-snapshot.mjs
+++ b/scripts/pull-request-snapshot.mjs
@@ -27,6 +27,7 @@ function reconcile(pull, view) {
   const restMerge = optionalSha(pull?.merge_commit_sha);
   const graphMerge = optionalSha(view?.potentialMergeCommit?.oid);
   if (restMerge.invalid || graphMerge.invalid) return result(view, "REST or GraphQL test merge SHA is invalid", false, true);
+  if (Boolean(restMerge.sha) !== Boolean(graphMerge.sha)) return result(view, "REST and GraphQL test merge SHA availability differs", true);
   if (restMerge.sha && graphMerge.sha && restMerge.sha !== graphMerge.sha) return result(view, `test merge differs between REST ${restMerge.sha} and GraphQL ${graphMerge.sha}`, true);
   return result({ ...view, mergeable: graphMergeable === "UNKNOWN" ? restMergeable : graphMergeable,
     mergeStateStatus: graphState === "UNKNOWN" ? restState : graphState });

--- a/scripts/pull-request-snapshot.mjs
+++ b/scripts/pull-request-snapshot.mjs
@@ -1,0 +1,46 @@
+const REST_MERGE_STATES = new Set(["CLEAN", "UNSTABLE", "BLOCKED", "BEHIND", "DIRTY", "DRAFT", "HAS_HOOKS", "UNKNOWN"]);
+export function fetchSettledPullRequestSnapshot({ fetchPullRequest, fetchPullRequestView, attempts, delayMs, sleep, hasPendingView = () => false }) {
+  let latest = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const pull = fetchPullRequest();
+    const result = reconcile(pull, fetchPullRequestView());
+    latest = { pull, view: { ...result.view, snapshotBlockReason: result.reason || null } };
+    if (result.terminal || (!result.retry && !hasPendingView(latest.view))) return latest;
+    if (attempt < attempts && delayMs > 0) sleep(delayMs);
+  }
+  return latest;
+}
+function reconcile(pull, view) {
+  const [restHead, graphHead, restBase, graphBase] =
+    [pull?.head?.sha, view?.headRefOid, pull?.base?.sha, view?.baseRefOid].map(sha);
+  const identityReason = mismatch("head", restHead, graphHead) || mismatch("base", restBase, graphBase);
+  if (identityReason) return result(view, identityReason, true);
+  if (pull?.merged_at || view?.mergedAt || view?.state === "MERGED") return result(view);
+  const restState = String(pull?.mergeable_state ?? "").toUpperCase();
+  if (!REST_MERGE_STATES.has(restState)) return result(view, `unsupported REST merge state: ${restState || "missing"}`, false, true);
+  const restMergeable = pull?.mergeable === true ? "MERGEABLE" : pull?.mergeable === false ? "CONFLICTING" : "";
+  if (!restMergeable || restState === "UNKNOWN") return result(view, `REST mergeability did not settle: mergeable=${String(pull?.mergeable)}, state=${restState}`, true);
+  const graphMergeable = String(view?.mergeable ?? "UNKNOWN").toUpperCase();
+  const graphState = String(view?.mergeStateStatus ?? "UNKNOWN").toUpperCase();
+  if (graphMergeable !== "UNKNOWN" && graphMergeable !== restMergeable) return result(view, `REST and GraphQL mergeability disagree: REST ${restMergeable}, GraphQL ${graphMergeable}`, true);
+  if (graphState !== "UNKNOWN" && graphState !== restState) return result(view, `REST and GraphQL merge state disagree: REST ${restState}, GraphQL ${graphState}`, true);
+  const restMerge = optionalSha(pull?.merge_commit_sha);
+  const graphMerge = optionalSha(view?.potentialMergeCommit?.oid);
+  if (restMerge.invalid || graphMerge.invalid) return result(view, "REST or GraphQL test merge SHA is invalid", false, true);
+  if (restMerge.sha && graphMerge.sha && restMerge.sha !== graphMerge.sha) return result(view, `test merge differs between REST ${restMerge.sha} and GraphQL ${graphMerge.sha}`, true);
+  return result({ ...view, mergeable: graphMergeable === "UNKNOWN" ? restMergeable : graphMergeable,
+    mergeStateStatus: graphState === "UNKNOWN" ? restState : graphState });
+}
+function mismatch(label, rest, graph) {
+  if (!rest || !graph) return `pull request ${label} identity is unavailable from REST or GraphQL`;
+  return rest === graph ? "" : `pull request ${label} differs between REST ${rest} and GraphQL ${graph}`;
+}
+function sha(value) {
+  return /^[0-9a-f]{40}$/.test(String(value ?? "").toLowerCase()) ? String(value).toLowerCase() : "";
+}
+function optionalSha(value) {
+  if (value === null || value === undefined || value === "") return { sha: "", invalid: false };
+  const normalized = sha(value);
+  return { sha: normalized, invalid: !normalized };
+}
+function result(view, reason = "", retry = false, terminal = false) { return { view, reason, retry, terminal }; }

--- a/scripts/review-results.mjs
+++ b/scripts/review-results.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import { parseArgs, parseJob, repoRoot } from "./lib.mjs";
 import { hasSecuritySensitiveText, securityTextFromItem } from "./security-sensitive.mjs";
 import { validateCodexReviewProvenance } from "./codex-review-dependency.mjs";
+import { validateDecisionAuthority } from "./external-merge-checks.mjs";
 
 const CLOSE_ACTIONS = new Set([
   "close",
@@ -645,6 +646,8 @@ function validateMergePreflight(repo, mergePreflight, mergeActions, failures) {
       continue;
     }
     const external = String(action.idempotency_key ?? "").startsWith("external-merge-preflight:");
+    const authorityBlock = validateDecisionAuthority(preflight, { expectedHeadSha, allowNonNull: external });
+    if (authorityBlock) failures.push(`${target} ${authorityBlock}`);
     if (external) {
       if (!/^[0-9a-f]{40}$/i.test(String(preflight.reviewed_base_sha ?? ""))) {
         failures.push(`${target} external merge_preflight.reviewed_base_sha must be a 40-character Git SHA`);

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -1920,6 +1920,104 @@ test("apply-result polls transient unknown mergeability before merge", () => {
   assert.equal(report.actions[0].status, "executed");
 });
 
+test("apply-result refreshes REST before each GraphQL snapshot attempt and every recheck", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    restSnapshots: [
+      { mergeable: null, mergeable_state: "unknown" },
+      { mergeable: true, mergeable_state: "unstable" },
+    ],
+    mergeViews: [
+      {
+        mergeable: "UNKNOWN",
+        mergeStateStatus: "UNKNOWN",
+        potentialMergeCommit: { oid: TEST_MERGE_SHA },
+      },
+    ],
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    mergeStatePath,
+    env: {
+      CLOWNFISH_APPLY_MERGEABLE_POLL_ATTEMPTS: "2",
+      CLOWNFISH_APPLY_MERGEABLE_POLL_DELAY_MS: "0",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "executed", report.actions[0].reason);
+  const snapshotCalls = readCallLog(callLogPath).flatMap((args) => {
+    if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/pulls/60063") {
+      return ["rest"];
+    }
+    if (args[0] === "pr" && args[1] === "view" && args[2] === "60063") {
+      return ["graphql"];
+    }
+    return [];
+  });
+  assert.deepEqual(snapshotCalls.slice(0, 4), ["rest", "graphql", "rest", "graphql"]);
+  for (const [index, kind] of snapshotCalls.entries()) {
+    if (kind === "graphql") {
+      assert.equal(snapshotCalls[index - 1], "rest");
+    }
+  }
+  assert.ok(snapshotCalls.filter((kind) => kind === "graphql").length >= 4);
+});
+
+test("apply-result blocks persistent REST/GraphQL head identity mismatch", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    mergeViews: [{ headRefOid: CHANGED_HEAD_SHA }],
+  });
+
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    mergeStatePath,
+    env: {
+      CLOWNFISH_APPLY_MERGEABLE_POLL_ATTEMPTS: "2",
+      CLOWNFISH_APPLY_MERGEABLE_POLL_DELAY_MS: "0",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /head.*REST.*GraphQL|REST.*GraphQL.*head/i);
+  assert.equal(readCallLog(callLogPath).some((args) => args.slice(0, 2).join(" ") === "pr merge"), false);
+});
+
 test("apply-result allows unstable merge state when latest checks are clean", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");
@@ -2135,8 +2233,11 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
     draft: false,
     updated_at: "2026-06-11T05:07:30Z",
     labels: [],
-    base: { ref: "main", sha: "stale-base" },
-    head: { sha: ${JSON.stringify(EXPECTED_HEAD_SHA)} }
+    base: { ref: "main", sha: ${JSON.stringify("b".repeat(40))} },
+    head: { sha: ${JSON.stringify(EXPECTED_HEAD_SHA)} },
+    mergeable: true,
+    mergeable_state: "clean",
+    merge_commit_sha: null
   });
 } else if (args[0] === "api" && args[1].startsWith("repos/openclaw/openclaw/issues/60063/comments")) {
   write([[]]);
@@ -2147,6 +2248,8 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/60063") {
 } else if (args[0] === "pr" && args[1] === "view" && args[2] === "60063") {
   write({
     baseRefName: "main",
+    baseRefOid: ${JSON.stringify("b".repeat(40))},
+    headRefOid: ${JSON.stringify(EXPECTED_HEAD_SHA)},
     isDraft: false,
     mergeable: "MERGEABLE",
     mergeStateStatus: "CLEAN",
@@ -2168,6 +2271,7 @@ function writeReadyMergeGhStub(
     headSha,
     mergeStateStatus = "CLEAN",
     mergeViews = null,
+    restSnapshots = null,
     transientViewFailures = 0,
     statusCheckRollup = [{ name: "CI", status: "COMPLETED", conclusion: "SUCCESS" }],
     labels = [],
@@ -2246,7 +2350,9 @@ const path = require("node:path");
 const args = process.argv.slice(2);
 const merged = Boolean(process.env.MERGE_STATE && fs.existsSync(process.env.MERGE_STATE));
 const mergeViews = ${JSON.stringify(mergeViews)};
+const restSnapshots = ${JSON.stringify(restSnapshots)};
 const viewCountPath = ${JSON.stringify(viewCountPath)};
+const restCountPath = ${JSON.stringify(path.join(binDir, "rest-count"))};
 const adoptionStatePath = ${JSON.stringify(path.join(binDir, "adoption-started"))};
 const exactCheckStatePath = ${JSON.stringify(path.join(binDir, "exact-check-state.json"))};
 const externalBinding = ${JSON.stringify(externalBinding)};
@@ -2284,23 +2390,32 @@ if (${JSON.stringify(adoptionValidation)} && args[0] === "repo" && args[1] === "
     pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/60063" }
   });
 } else if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/pulls/60063") {
+  const restCount = fs.existsSync(restCountPath) ? Number(fs.readFileSync(restCountPath, "utf8")) : 0;
+  fs.writeFileSync(restCountPath, String(restCount + 1));
+  const restSnapshot = Array.isArray(restSnapshots)
+    ? restSnapshots[Math.min(restCount, restSnapshots.length - 1)]
+    : {};
   write({
     number: 60063,
     state: "open",
     draft: false,
     updated_at: "2026-06-11T05:07:30Z",
     labels: fs.existsSync(adoptionStatePath) && ${JSON.stringify(adoptionLabels)} ? ${JSON.stringify(adoptionLabels)} : ${JSON.stringify(labels)},
-    base: { ref: "main", sha: externalBinding ? ${JSON.stringify(CURRENT_MAIN_SHA)} : "current-main" },
+    base: { ref: "main", sha: restSnapshot.baseSha ?? ${JSON.stringify(CURRENT_MAIN_SHA)} },
     head: {
-      sha: ${JSON.stringify(headSha)},
+      sha: restSnapshot.headSha ?? ${JSON.stringify(headSha)},
       ref: "feature/exact-head",
       repo: { full_name: "openclaw/openclaw" }
     },
     maintainer_can_modify: true,
     merged_at: merged ? "2026-06-11T05:09:00Z" : null,
+    mergeable: Object.hasOwn(restSnapshot, "mergeable") ? restSnapshot.mergeable : true,
+    mergeable_state: Object.hasOwn(restSnapshot, "mergeable_state") ? restSnapshot.mergeable_state : ${JSON.stringify(mergeStateStatus.toLowerCase())},
     merge_commit_sha: merged
       ? (externalBinding ? ${JSON.stringify(SQUASH_COMMIT_SHA)} : "c".repeat(40))
-      : (externalBinding ? ${JSON.stringify(TEST_MERGE_SHA)} : null)
+      : (Object.hasOwn(restSnapshot, "merge_commit_sha")
+          ? restSnapshot.merge_commit_sha
+          : (externalBinding ? ${JSON.stringify(TEST_MERGE_SHA)} : null))
   });
 } else if (args[0] === "api" && args[1].startsWith("repos/openclaw/openclaw/issues/60063/comments")) {
   const comments = ${JSON.stringify(issueComments)};
@@ -2498,9 +2613,14 @@ if (${JSON.stringify(adoptionValidation)} && args[0] === "repo" && args[1] === "
   const mergeView = Array.isArray(mergeViews) ? mergeViews[Math.min(count, mergeViews.length - 1)] : {};
   write({
     baseRefName: "main",
+    baseRefOid: mergeView.baseRefOid ?? ${JSON.stringify(CURRENT_MAIN_SHA)},
+    headRefOid: mergeView.headRefOid ?? ${JSON.stringify(headSha)},
     isDraft: false,
     mergeable: mergeView.mergeable ?? "MERGEABLE",
     mergeStateStatus: mergeView.mergeStateStatus ?? ${JSON.stringify(mergeStateStatus)},
+    potentialMergeCommit: mergeView.potentialMergeCommit === null
+      ? null
+      : (mergeView.potentialMergeCommit ?? (externalBinding ? { oid: ${JSON.stringify(TEST_MERGE_SHA)} } : null)),
     reviewDecision: "APPROVED",
     statusCheckRollup: mergeView.statusCheckRollup ?? [
       ...${JSON.stringify(statusCheckRollup)},

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -2177,6 +2177,57 @@ test("apply-result blocks persistent REST/GraphQL head identity mismatch", () =>
   assert.equal(readCallLog(callLogPath).some((args) => args.slice(0, 2).join(" ") === "pr merge"), false);
 });
 
+for (const [name, restMerge, graphMerge] of [
+  ["REST present and GraphQL absent", TEST_MERGE_SHA, null],
+  ["REST absent and GraphQL present", null, { oid: TEST_MERGE_SHA }],
+]) {
+  test(`apply-result blocks test merge SHA availability mismatch with ${name}`, () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+    const binDir = path.join(tmp, "bin");
+    const callLogPath = path.join(tmp, "gh-calls.jsonl");
+    const mergeStatePath = path.join(tmp, "merge-state");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(callLogPath, "");
+    writeReadyMergeGhStub(binDir, {
+      headSha: EXPECTED_HEAD_SHA,
+      externalBinding: true,
+      restSnapshots: [{ merge_commit_sha: restMerge }],
+      mergeViews: [{ potentialMergeCommit: graphMerge }],
+    });
+
+    const jobPath = path.join(tmp, "job.md");
+    const resultPath = path.join(tmp, "result.json");
+    const reportPath = path.join(tmp, "apply-report.json");
+    fs.writeFileSync(jobPath, mergeJobMarkdown());
+    fs.writeFileSync(resultPath, `${JSON.stringify(mergeResultJson({ externalBinding: true }), null, 2)}\n`);
+
+    const result = apply(jobPath, resultPath, reportPath, binDir, {
+      dryRun: false,
+      allowMerge: true,
+      callLogPath,
+      mergeStatePath,
+      env: {
+        CLOWNFISH_APPLY_MERGEABLE_POLL_ATTEMPTS: "2",
+        CLOWNFISH_APPLY_MERGEABLE_POLL_DELAY_MS: "0",
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    assert.equal(report.actions[0].status, "blocked");
+    assert.equal(report.actions[0].reason, "REST and GraphQL test merge SHA availability differs");
+    const calls = readCallLog(callLogPath);
+    const snapshotCalls = calls.flatMap((args) => {
+      if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/pulls/60063") return ["rest"];
+      if (args[0] === "pr" && args[1] === "view" && args[2] === "60063") return ["graphql"];
+      return [];
+    });
+    assert.deepEqual(snapshotCalls, ["rest", "graphql", "rest", "graphql"]);
+    assert.equal(calls.some((args) => args.slice(0, 2).join(" ") === "pr merge"), false);
+    assert.equal(fs.existsSync(mergeStatePath), false);
+  });
+}
+
 test("apply-result allows unstable merge state when latest checks are clean", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
   const binDir = path.join(tmp, "bin");

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -760,18 +760,45 @@ for (const permission of ["write", "maintain", "admin"]) {
     assert.equal(report.actions[0].status, "executed", report.actions[0].reason);
     const slowIndex = calls.findLastIndex((args) => args[1]?.includes(`/commits/${EXPECTED_HEAD_SHA}/check-runs?`));
     const pendingIndex = calls.findIndex((args) => args[1] === "repos/openclaw/openclaw/check-runs");
-    const commentIndex = calls.findIndex((args) => args[1] === `repos/openclaw/openclaw/issues/comments/${DECISION_COMMENT_ID}`);
-    const permissionIndex = calls.findIndex((args) => args[1]?.endsWith("/collaborators/vincentkoc/permission"));
+    const commentIndexes = calls.map((args, index) => args[1] === `repos/openclaw/openclaw/issues/comments/${DECISION_COMMENT_ID}` ? index : -1).filter((index) => index >= 0);
+    const permissionIndexes = calls.map((args, index) => args[1]?.endsWith("/collaborators/vincentkoc/permission") ? index : -1).filter((index) => index >= 0);
     const authorizeIndex = calls.findIndex((args) => args[1] === "repos/openclaw/openclaw/check-runs/8080");
     const mergeIndex = calls.findIndex((args) => args[0] === "pr" && args[1] === "merge");
+    assert.equal(commentIndexes.length, 2);
+    assert.equal(permissionIndexes.length, 2);
     assert.ok(
       slowIndex >= 0 &&
         pendingIndex > slowIndex &&
-        commentIndex > pendingIndex &&
-        permissionIndex > commentIndex &&
-        authorizeIndex > permissionIndex &&
-        mergeIndex > authorizeIndex,
+        commentIndexes[0] > pendingIndex &&
+        permissionIndexes[0] > commentIndexes[0] &&
+        authorizeIndex > permissionIndexes[0] &&
+        commentIndexes[1] > authorizeIndex &&
+        permissionIndexes[1] > commentIndexes[1] &&
+        mergeIndex === permissionIndexes[1] + 1,
     );
+  });
+}
+
+for (const [name, options, reason] of [
+  [
+    "comment edit after authorization",
+    { decisionComment: [liveDecisionComment(), liveDecisionComment({ body: `${DECISION_BODY} changed` })] },
+    /changed or is invalid/,
+  ],
+  [
+    "permission revocation after authorization",
+    { decisionPermission: ["admin", "read"] },
+    /repository permission/,
+  ],
+]) {
+  test(`apply-result revokes exact merge after ${name}`, () => {
+    const { report, calls, mergeStatePath } = runDecisionAuthorityApply(options);
+
+    assert.equal(report.actions[0].status, "blocked");
+    assert.match(report.actions[0].reason, reason);
+    assert.equal(fs.existsSync(mergeStatePath), false);
+    assert.equal(calls.some((args) => args[0] === "pr" && args[1] === "merge"), false);
+    assert.equal(calls.filter((args) => args[1] === "repos/openclaw/openclaw/check-runs/8080").length, 2);
   });
 }
 
@@ -2533,8 +2560,17 @@ const viewCountPath = ${JSON.stringify(viewCountPath)};
 const restCountPath = ${JSON.stringify(path.join(binDir, "rest-count"))};
 const adoptionStatePath = ${JSON.stringify(path.join(binDir, "adoption-started"))};
 const exactCheckStatePath = ${JSON.stringify(path.join(binDir, "exact-check-state.json"))};
+const decisionCommentCountPath = ${JSON.stringify(path.join(binDir, "decision-comment-count"))};
+const decisionPermissionCountPath = ${JSON.stringify(path.join(binDir, "decision-permission-count"))};
+const decisionComments = ${JSON.stringify(Array.isArray(decisionComment) ? decisionComment : [decisionComment])};
+const decisionPermissions = ${JSON.stringify(Array.isArray(decisionPermission) ? decisionPermission : [decisionPermission])};
 const externalBinding = ${JSON.stringify(externalBinding)};
 const reviewedBaseSha = ${JSON.stringify(reviewedBaseSha)};
+function nextFixture(values, countPath) {
+  const count = fs.existsSync(countPath) ? Number(fs.readFileSync(countPath, "utf8")) : 0;
+  fs.writeFileSync(countPath, String(count + 1));
+  return values[Math.min(count, values.length - 1)];
+}
 if (process.env.GH_CALL_LOG) fs.appendFileSync(process.env.GH_CALL_LOG, JSON.stringify(args) + "\\n");
 if (process.env.GH_AUTH_LOG) {
   fs.appendFileSync(
@@ -2603,13 +2639,13 @@ if (${JSON.stringify(adoptionValidation)} && args[0] === "repo" && args[1] === "
     process.stderr.write("HTTP 404: decision comment not found\\n");
     process.exit(1);
   }
-  write(${JSON.stringify(decisionComment)});
+  write(nextFixture(decisionComments, decisionCommentCountPath));
 } else if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/collaborators/vincentkoc/permission") {
   if (${JSON.stringify(decisionPermissionError)}) {
     process.stderr.write("HTTP 503: permission unavailable\\n");
     process.exit(1);
   }
-  write({ permission: ${JSON.stringify(decisionPermission)} });
+  write({ permission: nextFixture(decisionPermissions, decisionPermissionCountPath) });
 } else if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/ref/heads/main") {
   write({
     object: {

--- a/test/apply-result.test.mjs
+++ b/test/apply-result.test.mjs
@@ -34,6 +34,12 @@ const ADOPTION_DOC_CONTENT = "unrelated main documentation\n";
 const ADOPTION_BASE_BLOB_SHA = gitBlobSha(ADOPTION_BASE_CONTENT);
 const ADOPTION_MERGE_BLOB_SHA = gitBlobSha(ADOPTION_MERGE_CONTENT);
 const ADOPTION_DOC_BLOB_SHA = gitBlobSha(ADOPTION_DOC_CONTENT);
+const DECISION_COMMENT_ID = "5431659670";
+const DECISION_COMMENT_UPDATED_AT = "2026-08-26T20:28:51Z";
+const DECISION_BODY = [
+  `Maintainer decision for \`${EXPECTED_HEAD_SHA}\`: accept this exact-head merge.`,
+  "No branch repair, rebase, or replacement PR is requested.",
+].join(" ");
 const EFFECTIVE_DIFF_SHA256 = createHash("sha256")
   .update(
     `${JSON.stringify([
@@ -732,6 +738,132 @@ for (const mergeStateStatus of ["BLOCKED", "BEHIND"]) {
     assert.equal(report.actions[0].exact_merge_check.head_sha, TEST_MERGE_SHA);
   });
 }
+
+test("apply-result revokes exact merge when bound decision author lacks current repository authority", () => {
+  const { report, calls, mergeStatePath } = runDecisionAuthorityApply({
+    decisionPermission: "read",
+  });
+  assert.equal(report.actions[0].status, "blocked");
+  assert.match(report.actions[0].reason, /repository permission/i);
+  assert.equal(fs.existsSync(mergeStatePath), false);
+  const pendingIndex = calls.findIndex((args) => args[1] === "repos/openclaw/openclaw/check-runs");
+  const permissionIndex = calls.findIndex((args) => args[1]?.endsWith("/collaborators/vincentkoc/permission"));
+  const revokeIndex = calls.findIndex((args) => args[1] === "repos/openclaw/openclaw/check-runs/8080");
+  assert.ok(pendingIndex >= 0 && permissionIndex > pendingIndex && revokeIndex > permissionIndex);
+  assert.equal(calls.some((args) => args[0] === "pr" && args[1] === "merge"), false);
+});
+
+for (const permission of ["write", "maintain", "admin"]) {
+  test(`apply-result authorizes a bound exact-head decision with live ${permission} permission`, () => {
+    const { report, calls } = runDecisionAuthorityApply({ decisionPermission: permission });
+
+    assert.equal(report.actions[0].status, "executed", report.actions[0].reason);
+    const slowIndex = calls.findLastIndex((args) => args[1]?.includes(`/commits/${EXPECTED_HEAD_SHA}/check-runs?`));
+    const pendingIndex = calls.findIndex((args) => args[1] === "repos/openclaw/openclaw/check-runs");
+    const commentIndex = calls.findIndex((args) => args[1] === `repos/openclaw/openclaw/issues/comments/${DECISION_COMMENT_ID}`);
+    const permissionIndex = calls.findIndex((args) => args[1]?.endsWith("/collaborators/vincentkoc/permission"));
+    const authorizeIndex = calls.findIndex((args) => args[1] === "repos/openclaw/openclaw/check-runs/8080");
+    const mergeIndex = calls.findIndex((args) => args[0] === "pr" && args[1] === "merge");
+    assert.ok(
+      slowIndex >= 0 &&
+        pendingIndex > slowIndex &&
+        commentIndex > pendingIndex &&
+        permissionIndex > commentIndex &&
+        authorizeIndex > permissionIndex &&
+        mergeIndex > authorizeIndex,
+    );
+  });
+}
+
+for (const [name, options] of [
+  ["deleted comment", { decisionCommentError: true }],
+  ["mismatched comment ID", { decisionComment: liveDecisionComment({ id: 1 }) }],
+  ["mismatched author", { decisionComment: liveDecisionComment({ user: { login: "other" } }) }],
+  ["mismatched head", { decisionComment: liveDecisionComment({ body: DECISION_BODY.replace(EXPECTED_HEAD_SHA, CHANGED_HEAD_SHA) }) }],
+  ["mismatched body", { decisionComment: liveDecisionComment({ body: `${DECISION_BODY} changed` }) }],
+  ["mismatched timestamp", { decisionComment: liveDecisionComment({ updated_at: "2026-08-26T20:29:00Z" }) }],
+  ["read permission", { decisionPermission: "read" }],
+  ["triage permission", { decisionPermission: "triage" }],
+  ["permission lookup failure", { decisionPermissionError: true }],
+]) {
+  test(`apply-result revokes pending exact merge for ${name}`, () => {
+    const { report, calls, mergeStatePath } = runDecisionAuthorityApply(options);
+
+    assert.equal(report.actions[0].status, "blocked");
+    assert.equal(fs.existsSync(mergeStatePath), false);
+    assert.equal(calls.some((args) => args[0] === "pr" && args[1] === "merge"), false);
+    assert.ok(calls.some((args) => args[1] === "repos/openclaw/openclaw/check-runs/8080"));
+  });
+}
+
+for (const [name, objection] of [
+  ["merge objection", "Do not merge this pull request."],
+  ["security objection", "Security risk remains: credential exposure is unresolved."],
+  ["changes-requested objection", "Changes requested: provenance validation is broken."],
+  ["actionable fix objection", "Fix the broken provenance validation before landing."],
+  ["readiness objection", "Pause; this is not ready."],
+  ["failing CI objection", "Exact-head CI is still failing."],
+  ["withdrawal objection", "I withdraw approval and abandon this merge."],
+  ["passive merge objection", "This should not be merged."],
+  ["forbidden merge objection", "Merge is forbidden."],
+  ["proceed-with-merging objection", "Please do not proceed with merging."],
+  ["pending approval objection", "Maintainer approval is still pending."],
+  ["blocked PR objection", "The PR remains blocked."],
+  ["merging cannot proceed objection", "Merging cannot proceed."],
+  ["bare PR passive objection", "PR must not be merged."],
+  ["bare patch passive objection", "Patch should not be landed."],
+  ["bare change passive objection", "Change cannot be shipped."],
+]) {
+  test(`apply-result revokes a bound exact-head decision with ${name}`, () => {
+    const body = `${DECISION_BODY} ${objection}`;
+    const { report, calls, mergeStatePath } = runDecisionAuthorityApply({
+      decisionAuthority: exactDecisionAuthority({
+        body_sha256: createHash("sha256").update(body).digest("hex"),
+      }),
+      decisionComment: liveDecisionComment({ body }),
+    });
+
+    assert.equal(report.actions[0].status, "blocked");
+    assert.equal(fs.existsSync(mergeStatePath), false);
+    assert.ok(calls.some((args) => args[1] === "repos/openclaw/openclaw/check-runs/8080"));
+    assert.equal(calls.some((args) => args[0] === "pr" && args[1] === "merge"), false);
+  });
+}
+
+for (const [name, mutate] of [
+  ["missing binding", (preflight) => delete preflight.decision_authority],
+  ["malformed binding", (preflight) => {
+    preflight.decision_authority = { schema_version: 1 };
+  }],
+  ["head-mismatched binding", (preflight) => {
+    preflight.decision_authority = exactDecisionAuthority({ head_sha: CHANGED_HEAD_SHA });
+  }],
+]) {
+  test(`apply-result blocks ${name} before creating a pending exact-merge check`, () => {
+    const { report, calls } = runDecisionAuthorityApply({ mutatePreflight: mutate });
+
+    assert.equal(report.actions[0].status, "blocked");
+    assert.match(report.actions[0].reason, /decision_authority/);
+    assert.equal(calls.some((args) => args[1] === "repos/openclaw/openclaw/check-runs"), false);
+  });
+}
+
+test("apply-result keeps ordinary null-authority external merges unchanged", () => {
+  const { report, calls } = runDecisionAuthorityApply({ decisionAuthority: null });
+
+  assert.equal(report.actions[0].status, "executed", report.actions[0].reason);
+  assert.equal(calls.some((args) => args[1]?.includes("/issues/comments/")), false);
+  assert.equal(calls.some((args) => args[1]?.includes("/collaborators/")), false);
+});
+
+test("apply-result already-merged replay does not revalidate live decision authority", () => {
+  const { report, calls } = runDecisionAuthorityApply({ alreadyMerged: true });
+
+  assert.equal(report.actions[0].status, "executed", report.actions[0].reason);
+  assert.equal(report.actions[0].reason, "already merged");
+  assert.equal(calls.some((args) => args[1]?.includes("/issues/comments/")), false);
+  assert.equal(calls.some((args) => args[1]?.includes("/collaborators/")), false);
+});
 
 test("apply-result replaces a stale failed exact-merge check without refreshing the branch", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
@@ -2154,6 +2286,48 @@ function apply(jobPath, resultPath, reportPath, binDir, { dryRun = true, callLog
   );
 }
 
+function runDecisionAuthorityApply({
+  decisionAuthority = exactDecisionAuthority(),
+  mutatePreflight = null,
+  alreadyMerged = false,
+  ...stubOptions
+} = {}) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clownfish-apply-"));
+  const binDir = path.join(tmp, "bin");
+  const callLogPath = path.join(tmp, "gh-calls.jsonl");
+  const mergeStatePath = path.join(tmp, "merge-state");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(callLogPath, "");
+  if (alreadyMerged) fs.writeFileSync(mergeStatePath, "merged");
+  writeReadyMergeGhStub(binDir, {
+    headSha: EXPECTED_HEAD_SHA,
+    externalBinding: true,
+    decisionComment: liveDecisionComment(),
+    ...stubOptions,
+  });
+  const artifact = mergeResultJson({ externalBinding: true, decisionAuthority });
+  mutatePreflight?.(artifact.merge_preflight[0]);
+  const jobPath = path.join(tmp, "job.md");
+  const resultPath = path.join(tmp, "result.json");
+  const reportPath = path.join(tmp, "apply-report.json");
+  fs.writeFileSync(jobPath, mergeJobMarkdown());
+  fs.writeFileSync(resultPath, `${JSON.stringify(artifact, null, 2)}\n`);
+
+  const result = apply(jobPath, resultPath, reportPath, binDir, {
+    dryRun: false,
+    allowMerge: true,
+    callLogPath,
+    mergeStatePath,
+    env: { CLOWNFISH_GH_RETRY_BASE_MS: "1" },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return {
+    report: JSON.parse(fs.readFileSync(reportPath, "utf8")),
+    calls: readCallLog(callLogPath),
+    mergeStatePath,
+  };
+}
+
 function writeGhStub(
   binDir,
   { issueState = "open", includeExistingMarker = false, authorAssociation = "NONE", ansi = false, labels = [] } = {},
@@ -2313,6 +2487,10 @@ function writeReadyMergeGhStub(
     adoptionValidationFailure = false,
     adoptionLabels = null,
     reflectCoordinatorChecksInView = false,
+    decisionComment = null,
+    decisionPermission = "admin",
+    decisionCommentError = false,
+    decisionPermissionError = false,
   },
 ) {
   const ghPath = path.join(binDir, "gh");
@@ -2420,6 +2598,18 @@ if (${JSON.stringify(adoptionValidation)} && args[0] === "repo" && args[1] === "
 } else if (args[0] === "api" && args[1].startsWith("repos/openclaw/openclaw/issues/60063/comments")) {
   const comments = ${JSON.stringify(issueComments)};
   write(args.includes("--slurp") ? [comments] : comments);
+} else if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/comments/${DECISION_COMMENT_ID}") {
+  if (${JSON.stringify(decisionCommentError)}) {
+    process.stderr.write("HTTP 404: decision comment not found\\n");
+    process.exit(1);
+  }
+  write(${JSON.stringify(decisionComment)});
+} else if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/collaborators/vincentkoc/permission") {
+  if (${JSON.stringify(decisionPermissionError)}) {
+    process.stderr.write("HTTP 503: permission unavailable\\n");
+    process.exit(1);
+  }
+  write({ permission: ${JSON.stringify(decisionPermission)} });
 } else if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/git/ref/heads/main") {
   write({
     object: {
@@ -2862,6 +3052,7 @@ function mergeResultJson({
   reviewedBaseSha = CURRENT_MAIN_SHA,
   effectiveDiffSha256 = EFFECTIVE_DIFF_SHA256,
   baseAdoptionManifest = undefined,
+  decisionAuthority = null,
 } = {}) {
   const resolvedManifest =
     externalBinding && baseAdoptionManifest === undefined
@@ -2906,6 +3097,7 @@ function mergeResultJson({
         bot_comments_status: "resolved",
         bot_comments_evidence: ["no unresolved bot review threads"],
         validation_commands: ["pnpm check:changed"],
+        decision_authority: decisionAuthority,
         codex_review: {
           command: "/review",
           status: "clean",
@@ -2918,6 +3110,28 @@ function mergeResultJson({
         base_adoption_manifest: resolvedManifest,
       },
     ],
+  };
+}
+
+function exactDecisionAuthority(overrides = {}) {
+  return {
+    schema_version: 1,
+    comment_id: DECISION_COMMENT_ID,
+    author_login: "vincentkoc",
+    head_sha: EXPECTED_HEAD_SHA,
+    body_sha256: createHash("sha256").update(DECISION_BODY).digest("hex"),
+    comment_updated_at: DECISION_COMMENT_UPDATED_AT,
+    ...overrides,
+  };
+}
+
+function liveDecisionComment(overrides = {}) {
+  return {
+    id: Number(DECISION_COMMENT_ID),
+    user: { login: "vincentkoc" },
+    body: DECISION_BODY,
+    updated_at: DECISION_COMMENT_UPDATED_AT,
+    ...overrides,
   };
 }
 

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -2380,6 +2380,354 @@ function trustedReadyReviewComment({
   };
 }
 
+function exactHeadReadyReviewComment({
+  headSha = "a".repeat(40),
+  pullRequest = 123,
+  createdAt = "2026-08-26T13:05:08Z",
+  updatedAt = "2026-08-26T18:19:18Z",
+} = {}) {
+  return {
+    author: { login: "clawsweeper[bot]" },
+    authorAssociation: "CONTRIBUTOR",
+    isMinimized: false,
+    createdAt,
+    updatedAt,
+    body: [
+      "Codex review: needs maintainer review before merge.",
+      "",
+      "## Merge readiness",
+      "",
+      "⚠️ **Ready for maintainer review - 2 items remain**",
+      "",
+      "No actionable review findings were identified.",
+      "",
+      "| Check | Result | Evidence |",
+      "|---|---|---|",
+      "| **Findings** | None | None. |",
+      "| **Security** | None | None. |",
+      "",
+      "### Rank-up moves",
+      "",
+      "- Allow the queued exact-head checks to complete before merging.",
+      "",
+      `<!-- clawsweeper-verdict:needs-human item=${pullRequest} sha=${headSha} confidence=high -->`,
+      `<!-- clawsweeper-review item=${pullRequest} -->`,
+    ].join("\n"),
+    url: `https://github.com/openclaw/openclaw/pull/${pullRequest}#issuecomment-ready-review`,
+  };
+}
+
+const LIVE_REPAIR_OUTCOME_5429512844 = `<!-- clownfish-repair-outcome:automerge-openclaw-openclaw-130108:automerge-openclaw-openclaw-130108-autonomous-2026-08-26T17-57-21-947Z:#130108 -->
+Clownfish 🐠 reef automerge status
+
+This repair lap finished without changing the PR. Clownfish checked the reef and found no safe patch to push this time.
+
+Target: #130108
+Executor outcome: base branch advanced again during validation; reuse blocked: validated_base_not_ancestor_of_head.
+Worker summary: PR #130108 is the canonical item, but it is not merge-ready for this worker lane: the hydrated artifact shows it is open, non-security, behind base, has pending checks, and \`maintainer_can_modify=false\`. Because fix PRs are allowed and merges/closes are blocked, the safe path is a narrow credited replacement PR that carries forward @vincentkoc's test-only deletion.
+
+Worker actions:
+- \`fix_needed\` on \`#130108\`: planned - The useful source PR is blocked from in-place repair by \`maintainer_can_modify=false\` and is behind base; replacement is executable and preserves contributor credit.
+- \`build_fix_artifact\` on \`cluster:automerge-openclaw-openclaw-130108\`: planned - Build one credited replacement PR because the canonical source branch cannot be safely updated by Clownfish.
+
+No push, rebase, replacement PR, merge, or ClawSweeper re-review happened this swim.
+
+fish notes: model gpt-5.5, reasoning medium.`;
+
+const LIVE_REPAIR_OUTCOME_5430046612 = `<!-- clownfish-repair-outcome:automerge-openclaw-openclaw-130108:automerge-openclaw-openclaw-130108-autonomous-2026-08-26T18-55-12-493Z:#130108 -->
+Clownfish 🐠 reef automerge status
+
+No new branch changes from this lap. Clownfish kept the current tidy instead of splashing around.
+
+Target: #130108
+Executor outcome: base branch advanced again during validation; reuse blocked: validation_control_file_drift.
+Worker summary: PR #130108 remains the canonical source item, but it is not repairable in place by this worker lane because the hydrated preflight reports \`maintainer_can_modify=false\` and \`mergeable_state=behind\`. The narrow, executable path is a credited replacement PR carrying forward @vincentkoc's one-file test-only deletion; no close or merge action is planned because the job blocks both.
+
+Worker actions:
+- \`fix_needed\` on \`#130108\`: planned - replace_uneditable_branch_needed_for_safe_automerge_repair
+- \`build_fix_artifact\` on \`cluster:automerge-openclaw-openclaw-130108\`: planned - narrow_credited_replacement_pr
+
+Clownfish left the PR as-is: no push, no rebase, no replacement PR, no merge, and no fresh ClawSweeper pass.
+
+fish notes: model gpt-5.5, reasoning medium.`;
+
+function repairOutcomeComment({
+  createdAt,
+  id,
+  marker = null,
+  action = "fix_needed",
+  detail = "replace_uneditable_branch_needed_for_safe_automerge_repair",
+  concern = "",
+} = {}) {
+  return {
+    author: { login: "vincentkoc" },
+    authorAssociation: "MEMBER",
+    isMinimized: false,
+    createdAt,
+    body: [
+      marker ??
+        `<!-- clownfish-repair-outcome:automerge-openclaw-openclaw-123:automerge-openclaw-openclaw-123-autonomous-${id}:#123 -->`,
+      "Clownfish 🐠 reef automerge status",
+      "",
+      "No new branch changes from this lap.",
+      "",
+      "Target: #123",
+      "Executor outcome: base branch advanced during validation; reuse blocked: validation_control_file_drift.",
+      "Worker summary: PR #123 remains canonical but was behind base; a credited replacement was only planned.",
+      concern,
+      "",
+      "Worker actions:",
+      `- \`${action}\` on \`#123\`: planned - ${detail}`,
+      "- `build_fix_artifact` on `cluster:automerge-openclaw-openclaw-123`: planned - narrow_credited_replacement_pr",
+      "",
+      "Clownfish left the PR as-is: no push, no rebase, no replacement PR, no merge, and no fresh ClawSweeper pass.",
+      "",
+      "fish notes: model gpt-5.5, reasoning medium.",
+    ]
+      .filter(Boolean)
+      .join("\n"),
+    url: `https://github.com/openclaw/openclaw/pull/123#issuecomment-${id}`,
+  };
+}
+
+function exactHeadMaintainerDecision({
+  headSha = "a".repeat(40),
+  pullRequest = 123,
+  createdAt = "2026-08-26T22:05:24Z",
+  prefix = `Maintainer decision for \`${headSha}\`: accept`,
+} = {}) {
+  return {
+    author: { login: "vincentkoc" },
+    authorAssociation: "MEMBER",
+    isMinimized: false,
+    createdAt,
+    body: [
+      `${prefix} this test-only cleanup; the retained identity-aware lifecycle E2E remains the canonical owner, and exact-head CI is green.`,
+      "Clownfish must validate the current-main effective diff through the exact merge gate.",
+      "No branch repair, rebase, or replacement PR is requested.",
+    ].join(" "),
+    url: `https://github.com/openclaw/openclaw/pull/${pullRequest}#issuecomment-5431659670`,
+  };
+}
+
+function liveRepairOutcomeComment({ id, createdAt, body }) {
+  return {
+    author: { login: "vincentkoc" },
+    authorAssociation: "MEMBER",
+    isMinimized: false,
+    createdAt,
+    body,
+    url: `https://github.com/openclaw/openclaw/pull/130108#issuecomment-${id}`,
+  };
+}
+
+test("external merge preflight accepts the exact #130108 repair-outcome decision sequence", () => {
+  const fixture = makeFixture({
+    pullRequest: 130108,
+    issueComments: [
+      exactHeadReadyReviewComment({ pullRequest: 130108 }),
+      liveRepairOutcomeComment({
+        id: "5429512844",
+        createdAt: "2026-08-26T18:35:12Z",
+        body: LIVE_REPAIR_OUTCOME_5429512844,
+      }),
+      liveRepairOutcomeComment({
+        id: "5430046612",
+        createdAt: "2026-08-26T19:24:15Z",
+        body: LIVE_REPAIR_OUTCOME_5430046612,
+      }),
+      exactHeadMaintainerDecision({ pullRequest: 130108 }),
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "passed", report.reason);
+});
+
+test("external merge preflight keeps repeated valid exact-head decisions benign and uses the latest boundary", () => {
+  const fixture = makeFixture({
+    pullRequest: 130108,
+    issueComments: [
+      exactHeadReadyReviewComment({ pullRequest: 130108 }),
+      liveRepairOutcomeComment({
+        id: "5429512844",
+        createdAt: "2026-08-26T18:35:12Z",
+        body: LIVE_REPAIR_OUTCOME_5429512844,
+      }),
+      exactHeadMaintainerDecision({ pullRequest: 130108, createdAt: "2026-08-26T19:00:00Z" }),
+      liveRepairOutcomeComment({
+        id: "5430046612",
+        createdAt: "2026-08-26T19:24:15Z",
+        body: LIVE_REPAIR_OUTCOME_5430046612,
+      }),
+      exactHeadMaintainerDecision({ pullRequest: 130108 }),
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "passed", report.reason);
+});
+
+for (const [name, body] of [
+  ["wrong fix target", LIVE_REPAIR_OUTCOME_5430046612.replace("`#130108`: planned", "`#130109`: planned")],
+  ["wrong artifact target", LIVE_REPAIR_OUTCOME_5430046612.replace("`cluster:automerge-openclaw-openclaw-130108`: planned", "`cluster:wrong`: planned")],
+  ["missing companion action", LIVE_REPAIR_OUTCOME_5430046612.replace(/\n- `build_fix_artifact`[^\n]+/, "")],
+  ["duplicate action", LIVE_REPAIR_OUTCOME_5430046612.replace(/(- `fix_needed`[^\n]+)/, "$1\n$1")],
+  ["marker pull mismatch", LIVE_REPAIR_OUTCOME_5430046612.replace(":#130108 -->", ":#130109 -->")],
+  ["marker run mismatch", LIVE_REPAIR_OUTCOME_5430046612.replace("automerge-openclaw-openclaw-130108-autonomous-", "automerge-openclaw-openclaw-130109-autonomous-")],
+]) {
+  test(`external merge preflight keeps repair outcome with ${name} blocking`, () => {
+    const fixture = makeFixture({
+      pullRequest: 130108,
+      issueComments: [
+        exactHeadReadyReviewComment({ pullRequest: 130108 }),
+        liveRepairOutcomeComment({
+          id: "5430046612",
+          createdAt: "2026-08-26T19:24:15Z",
+          body,
+        }),
+        exactHeadMaintainerDecision({ pullRequest: 130108 }),
+      ],
+    });
+    const { report } = runPreflightFixture(fixture);
+
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, /actionable top-level issue comment/);
+  });
+}
+
+for (const [name, objection] of [
+  ["do-not-merge objection", "Do not merge this PR."],
+  ["unsafe-to-merge objection", "This PR is not safe to merge."],
+  ["hold-merge objection", "Hold the merge until validation is repaired."],
+  ["blocked objection", "The PR remains blocked."],
+  ["changes-requested objection", "Changes requested: address the defect."],
+  ["requested-changes objection", "Requested changes remain unresolved."],
+  ["severity-tagged finding", "[P1] Package provenance binding is broken."],
+  ["unresolved defect", "An unresolved defect remains in package provenance binding."],
+  ["remaining bug", "A bug remains in package provenance binding."],
+  ["regression", "This is a regression in package provenance binding."],
+  ["unresolved failure", "Package provenance validation failure remains unresolved."],
+  ["still-fails finding", "Package provenance validation still fails."],
+  ["still-broken finding", "Package provenance binding is still broken."],
+  ["continued failure", "Package provenance validation continues to fail."],
+]) {
+  test(`external merge preflight keeps repair outcome with ${name} blocking`, () => {
+    const body = LIVE_REPAIR_OUTCOME_5430046612.replace(
+      "Worker summary: ",
+      `Worker summary: ${objection} `,
+    );
+    const fixture = makeFixture({
+      pullRequest: 130108,
+      issueComments: [
+        exactHeadReadyReviewComment({ pullRequest: 130108 }),
+        liveRepairOutcomeComment({
+          id: "5430046612",
+          createdAt: "2026-08-26T19:24:15Z",
+          body,
+        }),
+        exactHeadMaintainerDecision({ pullRequest: 130108 }),
+      ],
+    });
+    const { report } = runPreflightFixture(fixture);
+
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, /actionable top-level issue comment/);
+  });
+}
+
+for (const [name, comments] of [
+  [
+    "mismatched decision SHA",
+    [
+      exactHeadReadyReviewComment(),
+      repairOutcomeComment({ id: "outcome", createdAt: "2026-08-26T19:24:15Z" }),
+      exactHeadMaintainerDecision({ headSha: "9".repeat(40) }),
+    ],
+  ],
+  [
+    "generic maintainer decision",
+    [
+      exactHeadReadyReviewComment(),
+      repairOutcomeComment({ id: "outcome", createdAt: "2026-08-26T19:24:15Z" }),
+      exactHeadMaintainerDecision({ prefix: "Maintainer decision: accept" }),
+    ],
+  ],
+  [
+    "decision before ready review",
+    [
+      exactHeadMaintainerDecision({ createdAt: "2026-08-26T12:00:00Z" }),
+      exactHeadReadyReviewComment(),
+      repairOutcomeComment({ id: "outcome", createdAt: "2026-08-26T19:24:15Z" }),
+    ],
+  ],
+  [
+    "later repair outcome",
+    [
+      exactHeadReadyReviewComment(),
+      exactHeadMaintainerDecision(),
+      repairOutcomeComment({ id: "outcome", createdAt: "2026-08-26T22:06:00Z" }),
+    ],
+  ],
+  [
+    "malformed repair marker",
+    [
+      exactHeadReadyReviewComment(),
+      repairOutcomeComment({
+        id: "outcome",
+        createdAt: "2026-08-26T19:24:15Z",
+        marker: "<!-- clownfish-repair-outcome:broken -->",
+      }),
+      exactHeadMaintainerDecision(),
+    ],
+  ],
+  [
+    "unknown repair action",
+    [
+      exactHeadReadyReviewComment(),
+      repairOutcomeComment({
+        id: "outcome",
+        createdAt: "2026-08-26T19:24:15Z",
+        action: "delete_branch",
+      }),
+      exactHeadMaintainerDecision(),
+    ],
+  ],
+]) {
+  test(`external merge preflight keeps ${name} blocking`, () => {
+    const { report } = runPreflightFixture(makeFixture({ issueComments: comments }));
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, /actionable top-level issue comment/);
+  });
+}
+
+for (const [name, concern, reason] of [
+  ["code defect", "Known defect: attachment ownership is still broken.", /actionable top-level issue comment/],
+  ["failing checks", "Checks are failing on the exact head.", /actionable top-level issue comment/],
+  ["security concern", "Security concern: token exposure remains possible.", /security-sensitive signal/],
+  ["dependency concern", "Dependency risk: the pinned runtime contract is unresolved.", /actionable top-level issue comment/],
+  ["withdrawal", "The author withdrew this PR.", /actionable top-level issue comment/],
+  ["stop request", "Stop this pull request.", /actionable top-level issue comment/],
+]) {
+  test(`external merge preflight never supersedes a repair outcome with ${name}`, () => {
+    const fixture = makeFixture({
+      issueComments: [
+        exactHeadReadyReviewComment(),
+        repairOutcomeComment({
+          id: "outcome",
+          createdAt: "2026-08-26T19:24:15Z",
+          concern,
+        }),
+        exactHeadMaintainerDecision(),
+      ],
+    });
+    const { report } = runPreflightFixture(fixture);
+
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, reason);
+  });
+}
+
 test("external merge preflight accepts an explicit maintainer decision with an exact-gate handoff", () => {
   const fixture = makeFixture({
     issueComments: [
@@ -4617,7 +4965,7 @@ function runExternalMergeRunner(fixture, extraArgs, env) {
 function runPreflightFixture(fixture, extraEnv = {}) {
   const child = spawnSync(
     process.execPath,
-    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", "123", "--run-dir", fixture.runDir],
+    ["scripts/preflight-external-pr-merge.mjs", fixture.jobPath, "--pr", String(fixture.pullRequest), "--run-dir", fixture.runDir],
     {
       cwd: repoRoot,
       encoding: "utf8",
@@ -4654,6 +5002,7 @@ function snapshotCallKinds(callLogPath) {
 
 function makeFixture({
   repo = "openclaw/openclaw",
+  pullRequest = 123,
   issueComments = [],
   reviewComments = [],
   reviews = [],
@@ -4799,11 +5148,11 @@ blocked_actions:
   - "label"
   - "close"
 canonical:
-  - "#123"
+  - "#${pullRequest}"
 candidates:
-  - "#123"
+  - "#${pullRequest}"
 cluster_refs:
-  - "#123"
+  - "#${pullRequest}"
 security_policy: central_security_only
 security_sensitive: false
 allow_instant_close: false
@@ -4824,6 +5173,7 @@ const path = require("node:path");
 const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(ghCallsPath)}, JSON.stringify(args) + "\\n");
 const repo = ${JSON.stringify(repo)};
+const pullRequest = ${JSON.stringify(pullRequest)};
 const head = ${JSON.stringify(headSha)};
 const base = ${JSON.stringify(baseSha)};
 const baseTree = ${JSON.stringify(baseTreeSha)};
@@ -4867,7 +5217,7 @@ if (args[0] === "repo" && args[1] === "clone") {
   process.exit(0);
 }
 if (args[0] === "pr" && args[1] === "merge") {
-  fs.appendFileSync(mergeLogPath, "123\\n");
+  fs.appendFileSync(mergeLogPath, String(pullRequest) + "\\n");
   fs.writeFileSync(mergedStatePath, "merged");
   process.exit(0);
 }
@@ -4876,7 +5226,7 @@ if (args[0] === "pr" && args[1] === "view") {
   const count = fs.existsSync(counterPath) ? Number(fs.readFileSync(counterPath, "utf8")) : 0;
   fs.writeFileSync(counterPath, String(count + 1));
   const mergeView = Array.isArray(mergeViews) ? mergeViews[Math.min(count, mergeViews.length - 1)] : {};
-  write({ baseRefName: "main", baseRefOid: mergeView.baseRefOid ?? base, comments: mergeView.comments ?? ${JSON.stringify(issueComments)}, headRefOid: mergeView.headRefOid ?? head, isDraft: false, mergeStateStatus: mergeView.mergeStateStatus ?? ${JSON.stringify(mergeStateStatus)}, mergeable: mergeView.mergeable ?? "MERGEABLE", mergedAt: isMerged() ? "2026-06-19T00:10:00Z" : null, potentialMergeCommit: mergeView.potentialMergeCommit === null ? null : (mergeView.potentialMergeCommit ?? { oid: testMerge }), reviewDecision: mergeView.reviewDecision ?? "APPROVED", reviews: mergeView.reviews ?? ${JSON.stringify(reviews)}, state: isMerged() ? "MERGED" : "OPEN", statusCheckRollup: mergeView.statusCheckRollup ?? ${JSON.stringify(statusCheckRollup)}, updatedAt: mergeView.updatedAt ?? "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" });
+  write({ baseRefName: "main", baseRefOid: mergeView.baseRefOid ?? base, comments: mergeView.comments ?? ${JSON.stringify(issueComments)}, headRefOid: mergeView.headRefOid ?? head, isDraft: false, mergeStateStatus: mergeView.mergeStateStatus ?? ${JSON.stringify(mergeStateStatus)}, mergeable: mergeView.mergeable ?? "MERGEABLE", mergedAt: isMerged() ? "2026-06-19T00:10:00Z" : null, potentialMergeCommit: mergeView.potentialMergeCommit === null ? null : (mergeView.potentialMergeCommit ?? { oid: testMerge }), reviewDecision: mergeView.reviewDecision ?? "APPROVED", reviews: mergeView.reviews ?? ${JSON.stringify(reviews)}, state: isMerged() ? "MERGED" : "OPEN", statusCheckRollup: mergeView.statusCheckRollup ?? ${JSON.stringify(statusCheckRollup)}, updatedAt: mergeView.updatedAt ?? "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/" + pullRequest });
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {
@@ -4890,11 +5240,11 @@ if (args[0] === "api" && args[1] === "graphql") {
   console.log(JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { pageInfo: { hasNextPage: false }, nodes: threads } } } } }));
   process.exit(0);
 }
-if (args[0] === "api" && args[1].includes("/pulls/123/comments")) {
+if (args[0] === "api" && args[1].includes("/pulls/" + pullRequest + "/comments")) {
   console.log(JSON.stringify(nextValue("review-comments-count", ${JSON.stringify(reviewComments)}, ${JSON.stringify(finalReviewComments)})));
   process.exit(0);
 }
-if (args[0] === "api" && args[1].includes("/issues/123/comments")) {
+if (args[0] === "api" && args[1].includes("/issues/" + pullRequest + "/comments")) {
   const comments = ${JSON.stringify(issueComments)};
   console.log(JSON.stringify(args.includes("--slurp") ? [comments] : comments));
   process.exit(0);
@@ -4951,7 +5301,7 @@ if (args[0] === "api" && args[1] === "repos/" + repo + "/actions/runs/7071") {
     head_sha: head,
     status: "completed",
     conclusion: "success",
-    pull_requests: [{ number: 123, head: { sha: head }, base: { ref: "main" } }],
+    pull_requests: [{ number: pullRequest, head: { sha: head }, base: { ref: "main" } }],
   });
   process.exit(0);
 }
@@ -5059,16 +5409,16 @@ if (
   });
   process.exit(0);
 }
-if (args[0] === "api" && args[1].endsWith("/issues/123")) {
+if (args[0] === "api" && args[1].endsWith("/issues/" + pullRequest)) {
   const issue = nextValue(
     "issue-state-count",
     { state: "open", updated_at: ${JSON.stringify(issueUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, assignees: ${JSON.stringify(pullAssignees)} },
     { state: ${JSON.stringify(finalState)}, updated_at: ${JSON.stringify(finalIssueUpdatedAt)}, labels: ${JSON.stringify(finalPullLabels)}, assignees: ${JSON.stringify(finalPullAssignees)} },
   );
-  console.log(JSON.stringify({ number: 123, ...issue, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/" + repo + "/pull/123", pull_request: { url: "https://api.github.com/repos/" + repo + "/pulls/123" } }));
+  console.log(JSON.stringify({ number: pullRequest, ...issue, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/" + repo + "/pull/" + pullRequest, pull_request: { url: "https://api.github.com/repos/" + repo + "/pulls/" + pullRequest } }));
   process.exit(0);
 }
-if (args[0] === "api" && args[1].endsWith("/pulls/123")) {
+if (args[0] === "api" && args[1].endsWith("/pulls/" + pullRequest)) {
   const restCounterPath = path.join(${JSON.stringify(root)}, "rest-pull-count");
   const restCount = fs.existsSync(restCounterPath) ? Number(fs.readFileSync(restCounterPath, "utf8")) : 0;
   fs.writeFileSync(restCounterPath, String(restCount + 1));
@@ -5080,7 +5430,7 @@ if (args[0] === "api" && args[1].endsWith("/pulls/123")) {
     { state: "open", updated_at: ${JSON.stringify(pullUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, assignees: ${JSON.stringify(pullAssignees)}, headSha: head },
     { state: ${JSON.stringify(finalState)}, updated_at: ${JSON.stringify(finalPullUpdatedAt)}, labels: ${JSON.stringify(finalPullLabels)}, assignees: ${JSON.stringify(finalPullAssignees)}, headSha: ${JSON.stringify(finalHeadSha)} },
   );
-  write({ number: 123, ...pull, state: isMerged() ? "closed" : pull.state, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/" + repo + "/pull/123", merged_at: isMerged() ? "2026-06-19T00:10:00Z" : null, mergeable: Object.hasOwn(restSnapshot, "mergeable") ? restSnapshot.mergeable : true, mergeable_state: Object.hasOwn(restSnapshot, "mergeable_state") ? restSnapshot.mergeable_state : ${JSON.stringify(mergeStateStatus.toLowerCase())}, merge_commit_sha: isMerged() ? squashCommit : (Object.hasOwn(restSnapshot, "merge_commit_sha") ? restSnapshot.merge_commit_sha : testMerge), user: ${JSON.stringify(pullUser)}, head: { sha: restSnapshot.headSha ?? pull.headSha, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: restSnapshot.baseSha ?? base, ref: "main" } });
+  write({ number: pullRequest, ...pull, state: isMerged() ? "closed" : pull.state, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/" + repo + "/pull/" + pullRequest, merged_at: isMerged() ? "2026-06-19T00:10:00Z" : null, mergeable: Object.hasOwn(restSnapshot, "mergeable") ? restSnapshot.mergeable : true, mergeable_state: Object.hasOwn(restSnapshot, "mergeable_state") ? restSnapshot.mergeable_state : ${JSON.stringify(mergeStateStatus.toLowerCase())}, merge_commit_sha: isMerged() ? squashCommit : (Object.hasOwn(restSnapshot, "merge_commit_sha") ? restSnapshot.merge_commit_sha : testMerge), user: ${JSON.stringify(pullUser)}, head: { sha: restSnapshot.headSha ?? pull.headSha, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: restSnapshot.baseSha ?? base, ref: "main" } });
   process.exit(0);
 }
 process.stderr.write("unexpected gh command: " + args.join(" "));
@@ -5415,6 +5765,7 @@ if (${JSON.stringify(codexFailure)}) {
     mergeTreeSha,
     mergeLogPath,
     pnpmCommandsPath,
+    pullRequest,
     root,
     runDir,
     hostileHome,

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -2495,10 +2495,11 @@ function exactHeadMaintainerDecision({
   pullRequest = 123,
   createdAt = "2026-08-26T22:05:24Z",
   prefix = `Maintainer decision for \`${headSha}\`: accept`,
+  authorAssociation = "MEMBER",
 } = {}) {
   return {
     author: { login: "vincentkoc" },
-    authorAssociation: "MEMBER",
+    authorAssociation,
     isMinimized: false,
     createdAt,
     body: [
@@ -2524,6 +2525,7 @@ function liveRepairOutcomeComment({ id, createdAt, body }) {
 test("external merge preflight accepts the exact #130108 repair-outcome decision sequence", () => {
   const fixture = makeFixture({
     pullRequest: 130108,
+    collaboratorPermissions: { vincentkoc: "admin" },
     issueComments: [
       exactHeadReadyReviewComment({ pullRequest: 130108 }),
       liveRepairOutcomeComment({
@@ -2547,6 +2549,7 @@ test("external merge preflight accepts the exact #130108 repair-outcome decision
 test("external merge preflight keeps repeated valid exact-head decisions benign and uses the latest boundary", () => {
   const fixture = makeFixture({
     pullRequest: 130108,
+    collaboratorPermissions: { vincentkoc: "admin" },
     issueComments: [
       exactHeadReadyReviewComment({ pullRequest: 130108 }),
       liveRepairOutcomeComment({
@@ -2568,6 +2571,96 @@ test("external merge preflight keeps repeated valid exact-head decisions benign 
   assert.equal(report.status, "passed", report.reason);
 });
 
+test("external merge preflight decision authority accepts stale CONTRIBUTOR association with live admin permission", () => {
+  const fixture = makeFixture({
+    pullRequest: 130108,
+    collaboratorPermissions: { vincentkoc: "admin" },
+    issueComments: [
+      exactHeadReadyReviewComment({ pullRequest: 130108 }),
+      liveRepairOutcomeComment({
+        id: "5430046612",
+        createdAt: "2026-08-26T19:24:15Z",
+        body: LIVE_REPAIR_OUTCOME_5430046612,
+      }),
+      exactHeadMaintainerDecision({
+        pullRequest: 130108,
+        authorAssociation: "CONTRIBUTOR",
+      }),
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "passed", report.reason);
+});
+
+for (const [name, permissionOptions] of [
+  ["rejects MEMBER association with live read permission", { collaboratorPermissions: { vincentkoc: "read" } }],
+  ["blocks permission lookup failure", { collaboratorPermissionErrors: ["vincentkoc"] }],
+]) {
+  test(`external merge preflight decision authority ${name}`, () => {
+    const fixture = makeFixture({
+      pullRequest: 130108,
+      ...permissionOptions,
+      issueComments: [
+        exactHeadReadyReviewComment({ pullRequest: 130108 }),
+        liveRepairOutcomeComment({
+          id: "5430046612",
+          createdAt: "2026-08-26T19:24:15Z",
+          body: LIVE_REPAIR_OUTCOME_5430046612,
+        }),
+        exactHeadMaintainerDecision({ pullRequest: 130108 }),
+      ],
+    });
+    const { report } = runPreflightFixture(fixture);
+
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, /actionable top-level issue comment/);
+    const ghCalls = fs
+      .readFileSync(fixture.ghCallsPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    assert.equal(ghCalls.some((args) => args[0] === "repo" && args[1] === "clone"), false);
+    assert.equal(fs.existsSync(fixture.codexCloneCountPath), false);
+    assert.equal(fs.existsSync(fixture.codexCountPath), false);
+    assert.equal(fs.existsSync(fixture.mergeLogPath), false);
+  });
+}
+
+test("external merge preflight refreshes exact-head decision authority for final blockers", () => {
+  const fixture = makeFixture({
+    pullRequest: 130108,
+    collaboratorPermissions: { vincentkoc: ["admin", "read"] },
+    issueComments: [
+      exactHeadReadyReviewComment({ pullRequest: 130108 }),
+      liveRepairOutcomeComment({
+        id: "5430046612",
+        createdAt: "2026-08-26T19:24:15Z",
+        body: LIVE_REPAIR_OUTCOME_5430046612,
+      }),
+      exactHeadMaintainerDecision({ pullRequest: 130108 }),
+    ],
+  });
+  const { report } = runPreflightFixture(fixture);
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /actionable top-level issue comment/);
+  const permissionCalls = fs
+    .readFileSync(fixture.ghCallsPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    .filter(
+      (args) =>
+        args[0] === "api" &&
+        args[1].includes("/collaborators/vincentkoc/permission"),
+    );
+  assert.equal(permissionCalls.length, 2);
+  assert.equal(fs.existsSync(fixture.mergeLogPath), false);
+});
+
 for (const [name, body] of [
   ["wrong fix target", LIVE_REPAIR_OUTCOME_5430046612.replace("`#130108`: planned", "`#130109`: planned")],
   ["wrong artifact target", LIVE_REPAIR_OUTCOME_5430046612.replace("`cluster:automerge-openclaw-openclaw-130108`: planned", "`cluster:wrong`: planned")],
@@ -2579,6 +2672,7 @@ for (const [name, body] of [
   test(`external merge preflight keeps repair outcome with ${name} blocking`, () => {
     const fixture = makeFixture({
       pullRequest: 130108,
+      collaboratorPermissions: { vincentkoc: "admin" },
       issueComments: [
         exactHeadReadyReviewComment({ pullRequest: 130108 }),
         liveRepairOutcomeComment({
@@ -2619,6 +2713,7 @@ for (const [name, objection] of [
     );
     const fixture = makeFixture({
       pullRequest: 130108,
+      collaboratorPermissions: { vincentkoc: "admin" },
       issueComments: [
         exactHeadReadyReviewComment({ pullRequest: 130108 }),
         liveRepairOutcomeComment({
@@ -2695,7 +2790,12 @@ for (const [name, comments] of [
   ],
 ]) {
   test(`external merge preflight keeps ${name} blocking`, () => {
-    const { report } = runPreflightFixture(makeFixture({ issueComments: comments }));
+    const { report } = runPreflightFixture(
+      makeFixture({
+        collaboratorPermissions: { vincentkoc: "admin" },
+        issueComments: comments,
+      }),
+    );
     assert.equal(report.status, "blocked");
     assert.match(report.reason, /actionable top-level issue comment/);
   });
@@ -2711,6 +2811,7 @@ for (const [name, concern, reason] of [
 ]) {
   test(`external merge preflight never supersedes a repair outcome with ${name}`, () => {
     const fixture = makeFixture({
+      collaboratorPermissions: { vincentkoc: "admin" },
       issueComments: [
         exactHeadReadyReviewComment(),
         repairOutcomeComment({
@@ -5255,7 +5356,12 @@ if (args[0] === "api" && args[1].startsWith("repos/" + repo + "/collaborators/")
     process.stderr.write("fixture collaborator permission failure");
     process.exit(1);
   }
-  write({ permission: collaboratorPermissions[login] ?? "read" });
+  const permissions = collaboratorPermissions[login] ?? "read";
+  write({
+    permission: Array.isArray(permissions)
+      ? nextValue("collaborator-permission-" + login, permissions[0], permissions[1])
+      : permissions,
+  });
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "repos/" + repo + "/git/ref/heads/main") {

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -1484,6 +1484,32 @@ test("external merge preflight blocks REST/GraphQL test merge disagreement", () 
   assert.match(report.reason, /test merge.*REST.*GraphQL|REST.*GraphQL.*test merge/i);
 });
 
+for (const [name, restMerge, graphMerge] of [
+  ["REST present and GraphQL absent", "7".repeat(40), null],
+  ["REST absent and GraphQL present", null, { oid: "7".repeat(40) }],
+]) {
+  test(`external merge preflight blocks test merge SHA availability mismatch with ${name}`, () => {
+    const fixture = makeFixture({
+      restSnapshots: [{ merge_commit_sha: restMerge }],
+      mergeViews: [{ potentialMergeCommit: graphMerge }],
+    });
+    const { report, result } = runPreflightFixture(fixture, {
+      CLOWNFISH_MERGEABLE_POLL_ATTEMPTS: "2",
+      CLOWNFISH_MERGEABLE_POLL_DELAY_MS: "0",
+    });
+
+    assert.equal(report.status, "blocked");
+    assert.equal(report.reason, "REST and GraphQL test merge SHA availability differs");
+    assert.deepEqual(snapshotCallKinds(fixture.ghCallsPath), [
+      "rest",
+      "graphql",
+      "rest",
+      "graphql",
+    ]);
+    assert.deepEqual(result.actions, []);
+  });
+}
+
 for (const mergeStateStatus of ["BLOCKED", "BEHIND"]) {
   test(`external merge preflight accepts ${mergeStateStatus.toLowerCase()} state for exact review`, () => {
     const fixture = makeFixture({

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -1317,6 +1317,172 @@ test("external merge preflight polls transient unknown mergeability", () => {
   assert.equal(report.status, "passed");
 });
 
+test("external merge preflight refreshes REST before every GraphQL mergeability attempt", () => {
+  const fixture = makeFixture({
+    restSnapshots: [
+      { mergeable: null, mergeable_state: "unknown" },
+      { mergeable: true, mergeable_state: "unstable" },
+    ],
+    mergeViews: [
+      {
+        mergeable: "UNKNOWN",
+        mergeStateStatus: "UNKNOWN",
+        potentialMergeCommit: { oid: "d".repeat(40) },
+      },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture, {
+    CLOWNFISH_MERGEABLE_POLL_ATTEMPTS: "2",
+    CLOWNFISH_MERGEABLE_POLL_DELAY_MS: "0",
+  });
+
+  assert.equal(report.status, "passed", report.reason);
+  assert.deepEqual(snapshotCallKinds(fixture.ghCallsPath).slice(0, 4), [
+    "rest",
+    "graphql",
+    "rest",
+    "graphql",
+  ]);
+});
+
+for (const [name, mergeView] of [
+  ["head", { headRefOid: "9".repeat(40) }],
+  ["base", { baseRefOid: "8".repeat(40) }],
+]) {
+  test(`external merge preflight blocks persistent REST/GraphQL ${name} identity mismatch`, () => {
+    const fixture = makeFixture({ mergeViews: [mergeView] });
+    const { report } = runPreflightFixture(fixture, {
+      CLOWNFISH_MERGEABLE_POLL_ATTEMPTS: "2",
+      CLOWNFISH_MERGEABLE_POLL_DELAY_MS: "0",
+    });
+
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, new RegExp(`${name}.*REST.*GraphQL|REST.*GraphQL.*${name}`, "i"));
+  });
+}
+
+test("external merge preflight retries an identity mismatch with a fresh REST snapshot", () => {
+  const fixture = makeFixture({
+    mergeViews: [
+      { baseRefOid: "8".repeat(40) },
+      { baseRefOid: "b".repeat(40) },
+    ],
+  });
+  const { report } = runPreflightFixture(fixture, {
+    CLOWNFISH_MERGEABLE_POLL_ATTEMPTS: "2",
+    CLOWNFISH_MERGEABLE_POLL_DELAY_MS: "0",
+  });
+
+  assert.equal(report.status, "passed", report.reason);
+  assert.deepEqual(snapshotCallKinds(fixture.ghCallsPath).slice(0, 4), [
+    "rest",
+    "graphql",
+    "rest",
+    "graphql",
+  ]);
+});
+
+for (const [kind, firstView] of [
+  ["mergeability", { mergeable: "CONFLICTING", mergeStateStatus: "CLEAN" }],
+  ["merge state", { mergeable: "MERGEABLE", mergeStateStatus: "UNSTABLE" }],
+]) {
+  test(`external merge preflight retries transient REST/GraphQL ${kind} disagreement`, () => {
+    const fixture = makeFixture({
+      restSnapshots: [{ mergeable: true, mergeable_state: "clean" }],
+      mergeViews: [firstView, { mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" }],
+    });
+    const { report } = runPreflightFixture(fixture, {
+      CLOWNFISH_MERGEABLE_POLL_ATTEMPTS: "2",
+      CLOWNFISH_MERGEABLE_POLL_DELAY_MS: "0",
+    });
+
+    assert.equal(report.status, "passed", report.reason);
+    assert.deepEqual(snapshotCallKinds(fixture.ghCallsPath).slice(0, 4), [
+      "rest",
+      "graphql",
+      "rest",
+      "graphql",
+    ]);
+  });
+}
+
+for (const [kind, mergeView, reason] of [
+  ["mergeability", { mergeable: "CONFLICTING", mergeStateStatus: "CLEAN" }, /REST and GraphQL mergeability disagree/i],
+  ["merge state", { mergeable: "MERGEABLE", mergeStateStatus: "UNSTABLE" }, /REST and GraphQL merge state disagree/i],
+]) {
+  test(`external merge preflight blocks persistent REST/GraphQL ${kind} disagreement after retries`, () => {
+    const fixture = makeFixture({
+      restSnapshots: [{ mergeable: true, mergeable_state: "clean" }],
+      mergeViews: [mergeView],
+    });
+    const { report } = runPreflightFixture(fixture, {
+      CLOWNFISH_MERGEABLE_POLL_ATTEMPTS: "2",
+      CLOWNFISH_MERGEABLE_POLL_DELAY_MS: "0",
+    });
+
+    assert.equal(report.status, "blocked");
+    assert.match(report.reason, reason);
+    assert.deepEqual(snapshotCallKinds(fixture.ghCallsPath).slice(0, 4), [
+      "rest",
+      "graphql",
+      "rest",
+      "graphql",
+    ]);
+  });
+}
+
+test("external merge preflight maps authoritative REST conflicts into unknown GraphQL fields", () => {
+  const fixture = makeFixture({
+    restSnapshots: [{ mergeable: false, mergeable_state: "dirty" }],
+    mergeViews: [{ mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" }],
+  });
+  const { report } = runPreflightFixture(fixture, {
+    CLOWNFISH_MERGEABLE_POLL_ATTEMPTS: "1",
+  });
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /PR mergeability is CONFLICTING/);
+  assert.match(report.reason, /PR merge state is DIRTY/);
+});
+
+test("external merge preflight blocks unsupported REST merge states", () => {
+  const fixture = makeFixture({
+    restSnapshots: [{ mergeable: true, mergeable_state: "mystery" }],
+  });
+  const { report } = runPreflightFixture(fixture, {
+    CLOWNFISH_MERGEABLE_POLL_ATTEMPTS: "1",
+  });
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /unsupported REST merge state/i);
+});
+
+test("external merge preflight blocks exhausted REST null mergeability", () => {
+  const fixture = makeFixture({
+    restSnapshots: [{ mergeable: null, mergeable_state: "unknown" }],
+  });
+  const { report } = runPreflightFixture(fixture, {
+    CLOWNFISH_MERGEABLE_POLL_ATTEMPTS: "2",
+    CLOWNFISH_MERGEABLE_POLL_DELAY_MS: "0",
+  });
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /REST mergeability.*did not settle/i);
+});
+
+test("external merge preflight blocks REST/GraphQL test merge disagreement", () => {
+  const fixture = makeFixture({
+    restSnapshots: [{ merge_commit_sha: "7".repeat(40) }],
+    mergeViews: [{ potentialMergeCommit: { oid: "6".repeat(40) } }],
+  });
+  const { report } = runPreflightFixture(fixture, {
+    CLOWNFISH_MERGEABLE_POLL_ATTEMPTS: "1",
+  });
+
+  assert.equal(report.status, "blocked");
+  assert.match(report.reason, /test merge.*REST.*GraphQL|REST.*GraphQL.*test merge/i);
+});
+
 for (const mergeStateStatus of ["BLOCKED", "BEHIND"]) {
   test(`external merge preflight accepts ${mergeStateStatus.toLowerCase()} state for exact review`, () => {
     const fixture = makeFixture({
@@ -4470,6 +4636,22 @@ function runPreflightFixture(fixture, extraEnv = {}) {
   };
 }
 
+function snapshotCallKinds(callLogPath) {
+  return fs
+    .readFileSync(callLogPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    .flatMap((args) => {
+      if (args[0] === "api" && args[1]?.endsWith("/pulls/123")) return ["rest"];
+      if (args[0] === "pr" && args[1] === "view" && args[2] === "123") {
+        return ["graphql"];
+      }
+      return [];
+    });
+}
+
 function makeFixture({
   repo = "openclaw/openclaw",
   issueComments = [],
@@ -4482,6 +4664,7 @@ function makeFixture({
   statusCheckRollup = [],
   mergeStateStatus = "CLEAN",
   mergeViews = null,
+  restSnapshots = null,
   issueUpdatedAt = "2026-06-19T00:00:00Z",
   pullUpdatedAt = "2026-06-19T00:00:00Z",
   pullAssignees = [],
@@ -4557,6 +4740,7 @@ function makeFixture({
     )
     .digest("hex");
   const gitCommandsPath = path.join(root, "git-commands.log");
+  const ghCallsPath = path.join(root, "gh-calls.jsonl");
   const pnpmCommandsPath = path.join(root, "pnpm-commands.log");
   const codexPromptPath = path.join(root, "codex-prompt.txt");
   const codexArgsPath = path.join(root, "codex-args.json");
@@ -4638,6 +4822,7 @@ require_fix_before_close: false
 const fs = require("node:fs");
 const path = require("node:path");
 const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(ghCallsPath)}, JSON.stringify(args) + "\\n");
 const repo = ${JSON.stringify(repo)};
 const head = ${JSON.stringify(headSha)};
 const base = ${JSON.stringify(baseSha)};
@@ -4649,6 +4834,7 @@ const squashTree = ${JSON.stringify(squashTreeSha)};
 const baseBlob = ${JSON.stringify(baseBlobSha)};
 const mergeBlob = ${JSON.stringify(mergeBlobSha)};
 const mergeViews = ${JSON.stringify(mergeViews)};
+const restSnapshots = ${JSON.stringify(restSnapshots)};
 const mergedStatePath = ${JSON.stringify(mergedStatePath)};
 const mergeLogPath = ${JSON.stringify(mergeLogPath)};
 const exactMergeCheckStatePath = ${JSON.stringify(exactMergeCheckStatePath)};
@@ -4690,7 +4876,7 @@ if (args[0] === "pr" && args[1] === "view") {
   const count = fs.existsSync(counterPath) ? Number(fs.readFileSync(counterPath, "utf8")) : 0;
   fs.writeFileSync(counterPath, String(count + 1));
   const mergeView = Array.isArray(mergeViews) ? mergeViews[Math.min(count, mergeViews.length - 1)] : {};
-  write({ baseRefName: "main", comments: mergeView.comments ?? ${JSON.stringify(issueComments)}, headRefOid: mergeView.headRefOid ?? head, isDraft: false, mergeCommit: { oid: isMerged() ? squashCommit : testMerge }, mergeStateStatus: mergeView.mergeStateStatus ?? ${JSON.stringify(mergeStateStatus)}, mergeable: mergeView.mergeable ?? "MERGEABLE", mergedAt: isMerged() ? "2026-06-19T00:10:00Z" : null, reviewDecision: mergeView.reviewDecision ?? "APPROVED", reviews: mergeView.reviews ?? ${JSON.stringify(reviews)}, state: isMerged() ? "MERGED" : "OPEN", statusCheckRollup: mergeView.statusCheckRollup ?? ${JSON.stringify(statusCheckRollup)}, updatedAt: mergeView.updatedAt ?? "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" });
+  write({ baseRefName: "main", baseRefOid: mergeView.baseRefOid ?? base, comments: mergeView.comments ?? ${JSON.stringify(issueComments)}, headRefOid: mergeView.headRefOid ?? head, isDraft: false, mergeStateStatus: mergeView.mergeStateStatus ?? ${JSON.stringify(mergeStateStatus)}, mergeable: mergeView.mergeable ?? "MERGEABLE", mergedAt: isMerged() ? "2026-06-19T00:10:00Z" : null, potentialMergeCommit: mergeView.potentialMergeCommit === null ? null : (mergeView.potentialMergeCommit ?? { oid: testMerge }), reviewDecision: mergeView.reviewDecision ?? "APPROVED", reviews: mergeView.reviews ?? ${JSON.stringify(reviews)}, state: isMerged() ? "MERGED" : "OPEN", statusCheckRollup: mergeView.statusCheckRollup ?? ${JSON.stringify(statusCheckRollup)}, updatedAt: mergeView.updatedAt ?? "2026-06-19T00:00:00Z", url: "https://github.com/openclaw/openclaw/pull/123" });
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {
@@ -4883,12 +5069,18 @@ if (args[0] === "api" && args[1].endsWith("/issues/123")) {
   process.exit(0);
 }
 if (args[0] === "api" && args[1].endsWith("/pulls/123")) {
+  const restCounterPath = path.join(${JSON.stringify(root)}, "rest-pull-count");
+  const restCount = fs.existsSync(restCounterPath) ? Number(fs.readFileSync(restCounterPath, "utf8")) : 0;
+  fs.writeFileSync(restCounterPath, String(restCount + 1));
+  const restSnapshot = Array.isArray(restSnapshots)
+    ? restSnapshots[Math.min(restCount, restSnapshots.length - 1)]
+    : {};
   const pull = nextValue(
     "pull-state-count",
     { state: "open", updated_at: ${JSON.stringify(pullUpdatedAt)}, labels: ${JSON.stringify(pullLabels)}, assignees: ${JSON.stringify(pullAssignees)}, headSha: head },
     { state: ${JSON.stringify(finalState)}, updated_at: ${JSON.stringify(finalPullUpdatedAt)}, labels: ${JSON.stringify(finalPullLabels)}, assignees: ${JSON.stringify(finalPullAssignees)}, headSha: ${JSON.stringify(finalHeadSha)} },
   );
-  write({ number: 123, ...pull, state: isMerged() ? "closed" : pull.state, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/" + repo + "/pull/123", merged_at: isMerged() ? "2026-06-19T00:10:00Z" : null, merge_commit_sha: isMerged() ? squashCommit : testMerge, user: ${JSON.stringify(pullUser)}, head: { sha: pull.headSha, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: base, ref: "main" } });
+  write({ number: 123, ...pull, state: isMerged() ? "closed" : pull.state, draft: false, title: ${JSON.stringify(pullTitle)}, body: ${JSON.stringify(pullBody)}, html_url: "https://github.com/" + repo + "/pull/123", merged_at: isMerged() ? "2026-06-19T00:10:00Z" : null, mergeable: Object.hasOwn(restSnapshot, "mergeable") ? restSnapshot.mergeable : true, mergeable_state: Object.hasOwn(restSnapshot, "mergeable_state") ? restSnapshot.mergeable_state : ${JSON.stringify(mergeStateStatus.toLowerCase())}, merge_commit_sha: isMerged() ? squashCommit : (Object.hasOwn(restSnapshot, "merge_commit_sha") ? restSnapshot.merge_commit_sha : testMerge), user: ${JSON.stringify(pullUser)}, head: { sha: restSnapshot.headSha ?? pull.headSha, ref: "fixture", repo: { full_name: "contributor/openclaw" } }, base: { sha: restSnapshot.baseSha ?? base, ref: "main" } });
   process.exit(0);
 }
 process.stderr.write("unexpected gh command: " + args.join(" "));
@@ -5217,6 +5409,7 @@ if (${JSON.stringify(codexFailure)}) {
     codexVersionEnvPath,
     credentialSentinelPath,
     gitCommandsPath,
+    ghCallsPath,
     headSha,
     jobPath,
     mergeTreeSha,

--- a/test/preflight-external-pr-merge.test.mjs
+++ b/test/preflight-external-pr-merge.test.mjs
@@ -453,6 +453,7 @@ test("external merge preflight emits an applicator-valid exact-head merge artifa
   assert.equal(result.merge_preflight[0].reviewed_head_sha, fixture.headSha);
   assert.equal(result.merge_preflight[0].effective_diff_sha256, fixture.effectiveDiffSha256);
   assert.equal(result.merge_preflight[0].effective_diff_files, 1);
+  assert.equal(result.merge_preflight[0].decision_authority, null);
   assert.deepEqual(
     {
       schema_version: result.merge_preflight[0].base_adoption_manifest.schema_version,
@@ -2496,12 +2497,15 @@ function exactHeadMaintainerDecision({
   createdAt = "2026-08-26T22:05:24Z",
   prefix = `Maintainer decision for \`${headSha}\`: accept`,
   authorAssociation = "MEMBER",
+  databaseId = 5431659670,
 } = {}) {
   return {
+    databaseId,
     author: { login: "vincentkoc" },
     authorAssociation,
     isMinimized: false,
     createdAt,
+    updatedAt: createdAt,
     body: [
       `${prefix} this test-only cleanup; the retained identity-aware lifecycle E2E remains the canonical owner, and exact-head CI is green.`,
       "Clownfish must validate the current-main effective diff through the exact merge gate.",
@@ -2523,6 +2527,7 @@ function liveRepairOutcomeComment({ id, createdAt, body }) {
 }
 
 test("external merge preflight accepts the exact #130108 repair-outcome decision sequence", () => {
+  const decision = exactHeadMaintainerDecision({ pullRequest: 130108 });
   const fixture = makeFixture({
     pullRequest: 130108,
     collaboratorPermissions: { vincentkoc: "admin" },
@@ -2538,12 +2543,20 @@ test("external merge preflight accepts the exact #130108 repair-outcome decision
         createdAt: "2026-08-26T19:24:15Z",
         body: LIVE_REPAIR_OUTCOME_5430046612,
       }),
-      exactHeadMaintainerDecision({ pullRequest: 130108 }),
+      decision,
     ],
   });
-  const { report } = runPreflightFixture(fixture);
+  const { report, result } = runPreflightFixture(fixture);
 
   assert.equal(report.status, "passed", report.reason);
+  assert.deepEqual(result.merge_preflight[0].decision_authority, {
+    schema_version: 1,
+    comment_id: String(decision.databaseId),
+    author_login: "vincentkoc",
+    head_sha: fixture.headSha,
+    body_sha256: createHash("sha256").update(decision.body).digest("hex"),
+    comment_updated_at: decision.updatedAt,
+  });
 });
 
 test("external merge preflight keeps repeated valid exact-head decisions benign and uses the latest boundary", () => {

--- a/test/review-results.test.mjs
+++ b/test/review-results.test.mjs
@@ -556,6 +556,54 @@ for (const [name, evidence] of [
   });
 }
 
+for (const [name, authority] of [
+  ["null", null],
+  ["valid", validDecisionAuthority()],
+]) {
+  test(`review-results accepts ${name} external merge decision authority`, () => {
+    const dir = makeResultDir(
+      externalMergeReviewResult(authority),
+      { job: mergeJob(), plan: { items: [openPrItem("#1", "2026-06-15T14:15:01Z")] } },
+    );
+
+    const result = review(dir);
+    assert.equal(result.status, 0, result.stdout || result.stderr);
+  });
+}
+
+for (const [name, mutate] of [
+  ["missing", (preflight) => delete preflight.decision_authority],
+  ["malformed", (preflight) => {
+    preflight.decision_authority = { schema_version: 1 };
+  }],
+]) {
+  test(`review-results rejects ${name} external merge decision authority`, () => {
+    const artifact = externalMergeReviewResult(null);
+    mutate(artifact.merge_preflight[0]);
+    const dir = makeResultDir(
+      artifact,
+      { job: mergeJob(), plan: { items: [openPrItem("#1", "2026-06-15T14:15:01Z")] } },
+    );
+
+    const result = review(dir);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /decision_authority/);
+  });
+}
+
+test("review-results rejects worker-authored non-null decision authority", () => {
+  const artifact = externalMergeReviewResult(validDecisionAuthority());
+  artifact.actions[0].idempotency_key = "cluster-test:merge:1";
+  const dir = makeResultDir(
+    artifact,
+    { job: mergeJob(), plan: { items: [openPrItem("#1", "2026-06-15T14:15:01Z")] } },
+  );
+
+  const result = review(dir);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /worker-authored merge_preflight\.decision_authority must be null/);
+});
+
 test("review-results ignores empty security boundary item collections in mutating evidence", () => {
   const dir = makeResultDir(
     {
@@ -2447,6 +2495,7 @@ security_sensitive: false
 function validMergePreflight(target, { external = false, evidence = ["Codex /review returned clean.", codexReviewProvenanceEvidence(codexCitation)] } = {}) {
   return {
     target,
+    decision_authority: null,
     ...(external
       ? {
           reviewed_base_sha: "6".repeat(40),
@@ -2468,6 +2517,40 @@ function validMergePreflight(target, { external = false, evidence = ["Codex /rev
       findings_addressed: true,
       evidence,
     },
+  };
+}
+
+function validDecisionAuthority(overrides = {}) {
+  return {
+    schema_version: 1,
+    comment_id: "5431659670",
+    author_login: "vincentkoc",
+    head_sha: "7".repeat(40),
+    body_sha256: "9".repeat(64),
+    comment_updated_at: "2026-08-26T20:28:51Z",
+    ...overrides,
+  };
+}
+
+function externalMergeReviewResult(decisionAuthority) {
+  const head = "7".repeat(40);
+  const preflight = validMergePreflight("#1", { external: true });
+  preflight.decision_authority = decisionAuthority;
+  return {
+    mode: "autonomous",
+    actions: [{
+      target: "#1",
+      action: "merge_canonical",
+      status: "planned",
+      idempotency_key: `external-merge-preflight:openclaw/openclaw#1:${head}`,
+      expected_head_sha: head,
+      classification: "canonical",
+      target_kind: "pull_request",
+      target_updated_at: "2026-06-15T14:15:01Z",
+      evidence: ["Fresh merge preflight completed."],
+      reason: "Canonical PR is ready to merge.",
+    }],
+    merge_preflight: [preflight],
   };
 }
 


### PR DESCRIPTION
## Summary

- Use REST-first fresh paired pull-request snapshots at every preflight and apply-time authorization gate.
- Retry when only REST or GraphQL exposes a test-merge SHA; merge authorization requires matching identity availability before comparing values.
- Require exact REST/GraphQL head, base, and test-merge identity; retry transient disagreements and fail closed with the same reason after exhaustion.
- Bind every exact-head maintainer decision dependency to the REST comment ID, author, reviewed head, raw-body SHA-256, and exact update timestamp.
- Revalidate the bound live comment and the author's current `write`, `maintain`, or `admin` permission before authorizing the successful exact-merge check and again immediately before merging.
- Use one shared closed exact-decision predicate in preflight and apply. Contradictory merge, landing, shipping, pending-approval, not-ready, actionable-fix, failing-CI, defect, risk, withdrawal, stop, and security language fails closed.
- Allow an exact-head maintainer decision to supersede only older, structurally bound, non-risk repair outcomes, including the live OpenClaw #130108 operational fixtures.

## Root cause

GitHub's sequential REST and GraphQL reads are not atomic, so authoritative merge identity must be paired and retried at every gate. Separately, preflight could suppress an older repair outcome based on an exact-head maintainer decision without binding that live authority into the artifact consumed by apply.

That left apply unable to prove the comment was unchanged or that its author still held repository authority. Its narrower syntax reparse could also accept a correctly bound comment containing contradictory or actionable objection text. The canonical owner is now the shared exact-decision parser plus apply's last-moment live comment and permission revalidation.

## Verification

- Pre-fix direct authority probes: 0/3; contradictory bound comments incorrectly executed instead of blocking.
- Pre-fix one-sided test-merge probes: preflight 0/2, apply 0/2.
- Focused current-head final-effect authority coverage: 8/8
- Focused preflight authority, repair-outcome, and resolved-objection coverage: 7/7
- Focused one-sided test-merge coverage: preflight 2/2, apply 2/2
- Full preflight suite: 226/226
- Full apply suite: 115/115
- `npm test`: 682/682
- `npm run validate`: 6,720 jobs
- `git diff --check`
- Direct contradiction probes cover `do not merge`, security and actionable objections, passive/forbidden/proceed forms, pending approval, blocked PRs, merging that cannot proceed, and bare `PR`/`Patch`/`Change` passive subjects.

## Production LOC

- Production scripts: +172/-74, net +98
- Schema: +14/-0, net +14
- Tests: +433/-10, net +423

## Real behavior proof

Date: August 27, 2026

- Scope: production `preflight-external-merge` with live GitHub REST/GraphQL transport and deterministic GraphQL fault injection. This is not a full apply or workflow E2E.
- Exact Clownfish head: `4964854a55f9f7b6134ff369decfeefdb0c3b8b5`, rebased onto current main `60d526584aa2efeeef44f8d491b15c2956115dd5`.
- Rebase evidence: signed commits `ca770348b4f20f652f724192f8f13a49092e4b45` and `4964854a55f9f7b6134ff369decfeefdb0c3b8b5` both verified `G`; range-diff contained two `=` entries; ordered stable patch IDs remained `7669d46868a91b14bae2d0feba49ac650b9853b2` and `d670af3da2d75759c052d18845e9bf12981e69a2`; the same five-file patch and final blobs were preserved.
- Rebase validation: focused preflight/apply tests `297/297`, full tests `633/633`, and validation `6,720/6,720` jobs.
- Live OpenClaw PR: `#130108` at head `cdb652131d1d507cd2e0c727e6a2ad7a489ce420` and base `1fec7b6ccd89224a1f3a9489bbc59cab2d99226d`.
- Fault: each of 2 polling attempts first asserted the real GraphQL head, then changed exactly one hex digit to redacted head `ddb652...420`; REST responses were untouched.
- Result: exit 0 with `preflight-report.json` blocked for exactly `pull request head differs between REST cdb652131d1d507cd2e0c727e6a2ad7a489ce420 and GraphQL ddb652131d1d507cd2e0c727e6a2ad7a489ce420`.
- Blocked artifacts retained the real reviewed head, empty validation commands, and null Codex/synthetic-merge fields. `result.json` was `planned` with empty `actions`, `merge_preflight`, and `needs_human`, plus `fix_artifact: null`.
- Isolation: target checkout, apply report, Codex artifact, and unexpected-command sentinel were absent.
- Transport: exactly 2 REST PR GETs, 2 fault-injected `pr view` reads, 1 issue GET, 1 comments GraphQL query, 1 inline-comment GET, and 1 review-threads GraphQL query. Only allowlisted read classes ran; no mutation command ran.
- Postcheck: OpenClaw #130108 remained open and unmerged at the same head, base, and `updated_at`.

## Current-head final-effect authority proof

Head: `7a5aa0eacd71a7e7cff1d8441e663252f1c36324`

Production-script boundary traces, verified with deterministic local GitHub command stubs:

- `apply-result revokes exact merge after comment edit after authorization`: authorization succeeds, the second authority read detects the edited comment, the exact check is revoked, and `gh pr merge` is never called.
- `apply-result revokes exact merge after permission revocation after authorization`: permission changes from `admin` to `read`, the second authority read rejects it, the exact check is revoked, and merge is never called.
- `REST present and GraphQL absent`: two complete paired snapshot attempts retain the availability-mismatch reason, then preflight/apply block with no merge action or merge-state mutation.
- `REST absent and GraphQL present`: the inverse one-sided observation follows the same retry and fail-closed path.

```sh
node --test --test-name-pattern='authorizes a bound exact-head decision|after (comment edit|permission revocation) after authorization|ordinary null-authority|already-merged replay' test/apply-result.test.mjs
# 8/8 passed

node --test --test-name-pattern='decision authority|exact #130108|explicit objections appended to positive ready-review|negated or resolved historical objection' test/preflight-external-pr-merge.test.mjs
# 7/7 passed

node --test --test-name-pattern='test merge SHA availability mismatch' test/preflight-external-pr-merge.test.mjs
# 2/2 passed

node --test --test-name-pattern='test merge SHA availability mismatch' test/apply-result.test.mjs
# 2/2 passed

npm test
# 682/682 passed

npm run validate
# 6,720 jobs validated
```

Independent current-head review: no P0/P1/P2 findings; preflight `226/226`, apply `115/115`, and direct retry/terminal/merged/both-absent probes passed.

This is deterministic local production-script boundary evidence, not live GitHub production proof.
