### PR TITLE
chore(deps): update GitHub Actions majors

### DIFF
--- a/.github/workflows/checks-success-preflight-intake.yml
+++ b/.github/workflows/checks-success-preflight-intake.yml
@@ -75,12 +75,12 @@ jobs:
           permission-contents: write
           permission-pull-requests: read
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ steps.app_token.outputs.token || github.token }}
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/cluster-batch.yml
+++ b/.github/workflows/cluster-batch.yml
@@ -80,9 +80,9 @@ jobs:
       max_comments_per_item: ${{ steps.plan.outputs.max_comments_per_item }}
       max_review_comments_per_pr: ${{ steps.plan.outputs.max_review_comments_per_pr }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 
@@ -197,7 +197,7 @@ jobs:
       CODEX_CLI_VERSION: ${{ vars.CLOWNFISH_CODEX_CLI_VERSION || '0.125.0' }}
       OPENCLAW_LOCAL_CHECK: "0"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Create GitHub App token
         id: app_token
@@ -211,12 +211,12 @@ jobs:
           permission-issues: read
           permission-pull-requests: read
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 
       - name: Cache Codex CLI and npm downloads
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.npm

--- a/.github/workflows/cluster-worker.yml
+++ b/.github/workflows/cluster-worker.yml
@@ -100,9 +100,9 @@ jobs:
       may_merge: ${{ steps.plan.outputs.may_merge }}
       target_repo: ${{ steps.plan.outputs.target_repo }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 
@@ -287,7 +287,7 @@ jobs:
       CODEX_CLI_VERSION: ${{ vars.CLOWNFISH_CODEX_CLI_VERSION || '0.125.0' }}
       OPENCLAW_LOCAL_CHECK: "0"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Create GitHub App token
         id: app_token
@@ -310,12 +310,12 @@ jobs:
             echo "allow_merge=${CLOWNFISH_ALLOW_MERGE}"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 
       - name: Cache Codex CLI and npm downloads
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.npm
@@ -482,7 +482,7 @@ jobs:
       OPENCLAW_LOCAL_CHECK: "0"
       CLOWNFISH_READ_GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Create GitHub App token
         id: app_token
@@ -546,12 +546,12 @@ jobs:
           echo "no GitHub token could reach repos/${CLOWNFISH_ALLOWED_OWNER}/openclaw"
           exit 1
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 
       - name: Cache Codex CLI, npm, and target pnpm downloads
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.npm
@@ -652,7 +652,7 @@ jobs:
       CLOWNFISH_APP_ID: ${{ vars.CLOWNFISH_APP_ID }}
       CLOWNFISH_READ_GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Create GitHub App token
         id: app_token
@@ -726,7 +726,7 @@ jobs:
           echo "no GitHub token could reach repos/${CLOWNFISH_ALLOWED_OWNER}/openclaw"
           exit 1
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/comment-router.yml
+++ b/.github/workflows/comment-router.yml
@@ -60,7 +60,7 @@ jobs:
       merge_since: ${{ steps.route.outputs.merge_since }}
       merge_comment_ids: ${{ steps.route.outputs.merge_comment_ids }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -77,7 +77,7 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 
@@ -223,7 +223,7 @@ jobs:
       cancel-in-progress: false
       queue: max
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0
@@ -246,7 +246,7 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/commit-finding-intake.yml
+++ b/.github/workflows/commit-finding-intake.yml
@@ -69,11 +69,11 @@ jobs:
     runs-on: ${{ vars.CLOWNFISH_COMMIT_FINDING_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 75
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 
@@ -120,7 +120,7 @@ jobs:
 
       - name: Cache Codex CLI, npm, and target pnpm downloads
         if: ${{ steps.prepare.outputs.should_repair == 'true' }}
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.npm

--- a/.github/workflows/external-merge-preflight.yml
+++ b/.github/workflows/external-merge-preflight.yml
@@ -41,9 +41,9 @@ jobs:
       preflight_passed: ${{ steps.outcome.outputs.preflight_passed }}
       target_repo: ${{ steps.outcome.outputs.target_repo }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 
@@ -59,7 +59,7 @@ jobs:
           sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
 
       - name: Cache Codex CLI and npm downloads
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.npm
@@ -156,7 +156,7 @@ jobs:
       cancel-in-progress: false
       queue: max
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Download preflight artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/finalize-open-prs.yml
+++ b/.github/workflows/finalize-open-prs.yml
@@ -37,11 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -57,11 +57,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -36,11 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,9 +15,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 


### PR DESCRIPTION
Updates the GitHub Actions dependencies used by Clownfish while retaining Node 24, existing workflow inputs, and mutation safeguards.

- `actions/checkout`: v5 → v7 (latest release v7.0.1), 16 references.
- `actions/setup-node`: v5 → v7 (latest release v7.0.0), 15 references.
- `actions/cache`: v5 → v6 (latest release v6.1.0), 5 references.

The artifact actions and GitHub App token action are already current. The npm package has no runtime/development dependencies or lockfile; there are no other package ecosystems or changelog files. No Dependabot or Renovate PRs are superseded.

Held upgrade: `@openai/codex` 0.125.0 → 0.150.1. External merge preflight deliberately requires exactly `codex-cli 0.125.0` together with its upstream annotated tag, tag object, commit, and source citations. Changing only the workflow default would block merges. This needs a coordinated provenance migration and worker proof; this PR leaves the complete existing contract intact.

Proof on Node 24.20.0:

- Full `npm test` before the Actions-only edit: 682 passed, 0 failed, 0 skipped; application scripts and tests are unchanged.
- Workflow regression tests after the edit: 4 passed, 0 failed.
- `npm run validate`: all 6,720 jobs valid.
- Example prompt render, plan-mode worker dry run, and offline autonomous artifact generation: passed.
- Syntax checks for all 50 scripts and `git diff --check`: passed.
- Dependency-free npm install: passed without introducing a lockfile.
- Supplemental actionlint 1.7.12: identical diagnostics before/after; three existing unsupported `concurrency.queue` fields and one existing SC2034 warning. No new diagnostics.

Baseline `main` CI is green: [validate](https://github.com/openclaw/clownfish/actions/runs/33058471099), [CodeQL](https://github.com/openclaw/clownfish/actions/runs/33139178275), [comment router](https://github.com/openclaw/clownfish/actions/runs/33138966283), [publish cluster results](https://github.com/openclaw/clownfish/actions/runs/33138615881), and [ClawSweeper Dispatch](https://github.com/openclaw/clownfish/actions/runs/33138093566).

Hosted PR validation exercises checkout/setup-node with the new versions. Privileged operational workflows are not dispatched by this maintenance PR; their live behavior remains outside the local smoke checks.

Codex autoreview completed with no actionable blockers at its default P0 threshold.
